### PR TITLE
Fix DB Connection Issues

### DIFF
--- a/examples/location-weather/src/index.ts
+++ b/examples/location-weather/src/index.ts
@@ -7,10 +7,7 @@ async function main() {
 
   const server = new ApolloServer({
     schema,
-    context: () => {
-      const context = contextBuilder();
-      return context;
-    }
+    context: contextBuilder,
   });
 
   server.listen().then(({ url }) => {

--- a/examples/postgres-geodb/.meshrc.yaml
+++ b/examples/postgres-geodb/.meshrc.yaml
@@ -18,8 +18,8 @@ sources:
           includeRootOperations: true
 transforms:
   - extend: |
-      extend type Geo_City {
-        developers(limit: Int = 10): Github_SearchResultItemConnection!
+      extend type GeoCity {
+        developers(limit: Int = 10): GithubSearchResultItemConnection!
       }
 additionalResolvers:
   - ./src/mesh/additional-resolvers.ts

--- a/examples/postgres-geodb/src/mesh/additional-resolvers.ts
+++ b/examples/postgres-geodb/src/mesh/additional-resolvers.ts
@@ -1,10 +1,10 @@
-import { Resolvers, Github_SearchType } from './__generated__/types';
+import { Resolvers, GithubSearchType } from './__generated__/types';
 
 export const resolvers: Resolvers = {
-  Geo_City: {
-    developers: async (cityData, { limit }, context, info) => context.Github.api.Github_search(
+  GeoCity: {
+    developers: async (cityData, { limit }, context, info) => context.Github.api.Githubsearch(
       {
-        type: Github_SearchType.User,
+        type: GithubSearchType.User,
         query: `location:${cityData.name}`,
         first: limit
       },

--- a/examples/postgres-geodb/src/test.query.graphql
+++ b/examples/postgres-geodb/src/test.query.graphql
@@ -6,7 +6,7 @@ query citiesAndDevelopers($city: String!) {
       district
       developers {
         nodes {
-          ... on Github_User {
+          ... on GithubUser {
             login
             avatarUrl
           }

--- a/examples/postgres-geodb/src/test.ts
+++ b/examples/postgres-geodb/src/test.ts
@@ -5,12 +5,14 @@ async function testSdk(city: string) {
   console.log(`Loading Mesh config...`)
   const meshConfig = await parseConfig();
   console.log(`Loading Mesh schema...`)
-  const { sdkRequester } = await getMesh(meshConfig);
+  const { sdkRequester, destroy } = await getMesh(meshConfig);
   const sdk = getSdk(sdkRequester);
   console.log(`Running query, looking for GitHub developers from ${city}...`)
   const result = await sdk.citiesAndDevelopers({ city });
   
   console.table(result.allCities?.nodes[0]?.developers.nodes, ['login', 'avatarUrl'])
+
+  destroy();
 } 
 
 testSdk(process.argv[2]);

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -34,7 +34,6 @@
     "definition": "dist/index.d.ts"
   },
   "dependencies": {
-    "@graphql-codegen/add": "1.13.1",
     "@graphql-codegen/core": "1.13.1",
     "@graphql-codegen/typescript": "1.13.1",
     "@graphql-codegen/typescript-generic-sdk": "1.13.1",
@@ -42,6 +41,7 @@
     "@graphql-codegen/typescript-resolvers": "1.13.1",
     "@graphql-mesh/runtime": "0.0.14",
     "@graphql-toolkit/code-file-loader": "0.9.9",
+    "@graphql-toolkit/common": "0.9.9",
     "@graphql-toolkit/core": "0.9.9",
     "@graphql-toolkit/graphql-file-loader": "0.9.9",
     "apollo-server": "2.11.0",

--- a/packages/cli/src/bin.ts
+++ b/packages/cli/src/bin.ts
@@ -52,12 +52,13 @@ export async function graphqlMesh() {
       },
       async args => {
         const meshConfig = await parseConfig();
-        const { schema } = await getMesh(meshConfig);
+        const { schema, destroy } = await getMesh(meshConfig);
         const result = await generateSdk(schema, args.operations);
         const outFile = resolve(process.cwd(), args.output);
         const dirName = dirname(outFile);
         mkdirp.sync(dirName);
         writeFileSync(outFile, result);
+        destroy();
       }
     )
     .command<{ output: string }>(
@@ -71,12 +72,13 @@ export async function graphqlMesh() {
       },
       async args => {
         const meshConfig = await parseConfig();
-        const { schema, rawSources } = await getMesh(meshConfig);
+        const { schema, rawSources, destroy } = await getMesh(meshConfig);
         const result = await generateTsTypes(schema, rawSources);
         const outFile = resolve(process.cwd(), args.output);
         const dirName = dirname(outFile);
         mkdirp.sync(dirName);
         writeFileSync(outFile, result);
+        destroy();
       }
     ).argv;
 }

--- a/packages/cli/src/commands/generate-sdk.ts
+++ b/packages/cli/src/commands/generate-sdk.ts
@@ -1,12 +1,12 @@
 import { GraphQLSchema, printSchema, parse } from 'graphql';
 import { codegen } from '@graphql-codegen/core';
-import * as addPlugin from '@graphql-codegen/add';
 import * as tsPlugin from '@graphql-codegen/typescript';
 import * as tsOperationsPlugin from '@graphql-codegen/typescript-operations';
 import * as tsGenericSdkPlugin from '@graphql-codegen/typescript-generic-sdk';
 import { loadDocuments as loadDocumentsToolkit } from '@graphql-toolkit/core';
 import { CodeFileLoader } from '@graphql-toolkit/code-file-loader';
 import { GraphQLFileLoader } from '@graphql-toolkit/graphql-file-loader';
+import { printSchemaWithDirectives } from '@graphql-toolkit/common';
 
 export async function generateSdk(
   schema: GraphQLSchema,
@@ -22,13 +22,12 @@ export async function generateSdk(
   const output = await codegen({
     filename: 'types.ts',
     pluginMap: {
-      add: addPlugin,
       typescript: tsPlugin,
       typescriptOperations: tsOperationsPlugin,
       typescriptGenericSdk: tsGenericSdkPlugin
     },
     documents,
-    schema: parse(printSchema(schema)),
+    schema: parse(printSchemaWithDirectives(schema)),
     schemaAst: schema,
     plugins: [
       {

--- a/packages/cli/src/commands/serve.ts
+++ b/packages/cli/src/commands/serve.ts
@@ -12,7 +12,6 @@ export async function serveMesh(
     context: contextBuilder,
   });
 
-  server.listen().then(({ url }) => {
-    logger.info(`🕸️ => Serving GraphQL Mesh GraphiQL: ${url}`);
-  });
+  const { url } = await server.listen();
+  logger.info(`🕸️ => Serving GraphQL Mesh GraphiQL: ${url}`);
 }

--- a/packages/cli/src/commands/typescript.ts
+++ b/packages/cli/src/commands/typescript.ts
@@ -12,11 +12,11 @@ import {
   isNonNullType,
   GraphQLNamedType,
   parse,
-  printSchema,
   NamedTypeNode,
   Kind
 } from 'graphql';
 import { codegen } from '@graphql-codegen/core';
+import { printSchemaWithDirectives } from '@graphql-toolkit/common';
 
 const unifiedContextIdentifier = 'MeshContext';
 
@@ -129,7 +129,7 @@ export async function generateTsTypes(
     documents: [],
     config: {},
     schemaAst: unifiedSchema,
-    schema: parse(printSchema(unifiedSchema)),
+    schema: parse(printSchemaWithDirectives(unifiedSchema)),
     pluginMap: {
       typescript: tsBasePlugin,
       resolvers: tsResolversPlugin,

--- a/packages/handlers/mongoose/src/index.ts
+++ b/packages/handlers/mongoose/src/index.ts
@@ -48,7 +48,7 @@ async function loadExternalModuleByExpression(
 }
 
 const handler: MeshHandlerLibrary<YamlConfig.MongooseHandler> = {
-  async getMeshSource({ config }) {
+  async getMeshSource({ config, hooks }) {
     if (config.connectionString) {
       await mongoose.connect(config.connectionString, {
         useNewUrlParser: true,
@@ -120,6 +120,8 @@ const handler: MeshHandlerLibrary<YamlConfig.MongooseHandler> = {
     schemaComposer.Mutation.addFields(mutationFields);
 
     const schema = schemaComposer.buildSchema();
+
+    hooks.on('destroy', () => mongoose.disconnect());
 
     return {
       schema

--- a/packages/runtime/src/get-mesh.ts
+++ b/packages/runtime/src/get-mesh.ts
@@ -37,6 +37,7 @@ export async function getMesh(
   rawSources: RawSourcesOutput;
   sdkRequester: Requester;
   contextBuilder: () => Promise<Record<string, any>>;
+  destroy: () => void;
 }> {
   const results: RawSourcesOutput = {};
   const hooks = new Hooks();
@@ -185,7 +186,8 @@ export async function getMesh(
     schema: unifiedSchema,
     contextBuilder: buildMeshContext,
     rawSources: results,
-    sdkRequester: localRequester
+    sdkRequester: localRequester,
+    destroy: () => { hooks.emit('destroy'); },
   };
 }
 

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -33,6 +33,7 @@ export type AllHooks = {
     originalResolveFn?: GraphQLFieldResolver<any, any>;
     replaceFn: (fn: Function) => void;
   }) => void;
+  destroy: () => void;
 };
 export class Hooks extends EventEmitter<AllHooks> {}
 export type HooksKeys = keyof AllHooks;

--- a/yarn.lock
+++ b/yarn.lock
@@ -869,14 +869,6 @@
   resolved "https://registry.npmjs.org/@graphile/lru/-/lru-4.5.0.tgz#e8fe036d322dfe1715675aab171979981e28ac9e"
   integrity sha512-OoIgewLowjegJzz3tpcRE5LpQKqsap1ETFaZtC1r9p36h5ieUJnWTxCTpB7XIsU9muMTt7MMt8x0E5apS47QIQ==
 
-"@graphql-codegen/add@1.13.1":
-  version "1.13.1"
-  resolved "https://registry.yarnpkg.com/@graphql-codegen/add/-/add-1.13.1.tgz#a45cf271ae9d00f44297164168f6091adbcbdef7"
-  integrity sha512-6vXfaRPlUKiwXId7YIFtDmKUgG5S8V/NTpgzQq/31wKXDo6ZIEjIW22s3nbDg5netot7Rlzu1LQ2MWUNdo5PhQ==
-  dependencies:
-    "@graphql-codegen/plugin-helpers" "1.13.1"
-    tslib "1.11.1"
-
 "@graphql-codegen/core@1.12.2":
   version "1.12.2"
   resolved "https://registry.yarnpkg.com/@graphql-codegen/core/-/core-1.12.2.tgz#85dcef3a9205f11aa910f0527c272967ed5c4427"


### PR DESCRIPTION
For both mongoose and postgraphile, now we have `destroy` method that emits `destroy` event so the event listeners close the db connections in order to prevent hanging issues.