### PR TITLE
Make runtime package browser friendly

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,12 +90,12 @@ query wikipediaMetrics {
 Now that you know that your Mesh works, you can use it directly within your application:
 
 ```js
-const { getMesh, parseConfig } = require('@graphql-mesh/runtime');
+const { getMesh, findAndParseConfig } = require('@graphql-mesh/runtime');
 const { ApolloServer } = require('apollo-server');
 
 async function test() {
   // This will load the config file from the default location (process.cwd)
-  const meshConfig = await parseConfig();
+  const meshConfig = await findAndParseConfig();
   const { execute, schema, contextBuilder } = await getMesh(meshConfig);
 
   // Use `execute` to run a query directly and fetch data from your APIs
@@ -281,12 +281,12 @@ Now, instead of using `execute` manually, you can use the generated `getSdk` met
 
 ```ts
 import { getSdk } from './generated/sdk';
-import { getMesh, parseConfig } from '@graphql-mesh/runtime';
+import { getMesh, findAndParseConfig } from '@graphql-mesh/runtime';
 import { ApolloServer } from 'apollo-server';
 
 async function test() {
   // Load mesh config and get the sdkClient from it
-  const meshConfig = await parseConfig();
+  const meshConfig = await findAndParseConfig();
   const { sdkRequester } = await getMesh(meshConfig);
   // Get fully-typed SDK using the Mesh client and based on your GraphQL operations
   const sdk = getSdk(sdkRequester);

--- a/examples/location-weather/src/index.ts
+++ b/examples/location-weather/src/index.ts
@@ -1,8 +1,8 @@
 import { ApolloServer } from 'apollo-server';
-import { getMesh, parseConfig } from '@graphql-mesh/runtime';
+import { getMesh, findAndParseConfig } from '@graphql-mesh/runtime';
 
 async function main() {
-  const meshConfig = await parseConfig();
+  const meshConfig = await findAndParseConfig();
   const { schema, contextBuilder } = await getMesh(meshConfig);
 
   const server = new ApolloServer({

--- a/examples/postgres-geodb/src/test.ts
+++ b/examples/postgres-geodb/src/test.ts
@@ -1,9 +1,9 @@
 import { getSdk } from './sdk.generated';
-import { parseConfig, getMesh } from '@graphql-mesh/runtime';
+import { getMesh, findAndParseConfig } from '@graphql-mesh/runtime';
 
 async function testSdk(city: string) {
   console.log(`Loading Mesh config...`)
-  const meshConfig = await parseConfig();
+  const meshConfig = await findAndParseConfig();
   console.log(`Loading Mesh schema...`)
   const { sdkRequester, destroy } = await getMesh(meshConfig);
   const sdk = getSdk(sdkRequester);

--- a/packages/cli/src/bin.ts
+++ b/packages/cli/src/bin.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 import { writeFileSync } from 'fs';
-import { parseConfig, getMesh } from '@graphql-mesh/runtime';
+import { findAndParseConfig, getMesh } from '@graphql-mesh/runtime';
 import * as yargs from 'yargs';
 import { createLogger, format, transports } from 'winston';
 import { generateTsTypes } from './commands/typescript';
@@ -28,7 +28,7 @@ export async function graphqlMesh() {
       () => null,
       async () => {
         try {
-          const meshConfig = await parseConfig();
+          const meshConfig = await findAndParseConfig();
           const { schema, contextBuilder } = await getMesh(meshConfig);
           await serveMesh(logger, schema, contextBuilder, meshConfig.cache);
         } catch (e) {
@@ -51,7 +51,7 @@ export async function graphqlMesh() {
           });
       },
       async args => {
-        const meshConfig = await parseConfig(undefined, undefined, true);
+        const meshConfig = await findAndParseConfig(undefined, undefined, true);
         const { schema, destroy } = await getMesh(meshConfig);
         const result = await generateSdk(schema, args.operations);
         const outFile = resolve(process.cwd(), args.output);
@@ -71,7 +71,7 @@ export async function graphqlMesh() {
         });
       },
       async args => {
-        const meshConfig = await parseConfig(undefined, undefined, true);
+        const meshConfig = await findAndParseConfig(undefined, undefined, true);
         const { schema, rawSources, destroy } = await getMesh(meshConfig);
         const result = await generateTsTypes(schema, rawSources);
         const outFile = resolve(process.cwd(), args.output);

--- a/packages/cli/src/bin.ts
+++ b/packages/cli/src/bin.ts
@@ -51,7 +51,9 @@ export async function graphqlMesh() {
           });
       },
       async args => {
-        const meshConfig = await findAndParseConfig(undefined, undefined, true);
+        const meshConfig = await findAndParseConfig({
+          ignoreAdditionalResolvers: true,
+        });
         const { schema, destroy } = await getMesh(meshConfig);
         const result = await generateSdk(schema, args.operations);
         const outFile = resolve(process.cwd(), args.output);
@@ -71,7 +73,9 @@ export async function graphqlMesh() {
         });
       },
       async args => {
-        const meshConfig = await findAndParseConfig(undefined, undefined, true);
+        const meshConfig = await findAndParseConfig({
+          ignoreAdditionalResolvers: true,
+        });
         const { schema, rawSources, destroy } = await getMesh(meshConfig);
         const result = await generateTsTypes(schema, rawSources);
         const outFile = resolve(process.cwd(), args.output);

--- a/packages/runtime/src/utils.ts
+++ b/packages/runtime/src/utils.ts
@@ -106,7 +106,7 @@ export async function resolveAdditionalResolvers(
 ): Promise<IResolvers> {
   const loaded = await Promise.all(
     (additionalResolvers || []).map(async filePath => {
-      const exported = require(resolve(baseDir, filePath));
+      const exported = await import(resolve(baseDir, filePath));
       let resolvers = null;
 
       if (exported.default) {


### PR DESCRIPTION
Related https://github.com/Urigo/graphql-mesh/issues/150
**BREAKING CHANGE:**
- `parseConfig` takes two parameters to parse the configuration file which has been already read. This function doesn't need NodeJS File System module (but uses module system to load packages and stuff)
`parseConfig(yamlString | jsonString | configObject, { configFormat: 'json' , 'yaml', 'object' })`

- `findAndParseConfig` finds and parses the configuration file using NodeJS File System.
- `processConfig` can be used for programmatic API which takes preloaded configuration object with preloaded handlers and transforms etc. It needs nothing from the platform it is running at such as File or Module System