### PR TITLE
Support cluster

### DIFF
--- a/packages/cli/src/bin.ts
+++ b/packages/cli/src/bin.ts
@@ -25,7 +25,14 @@ export async function graphqlMesh() {
     .command<{ fork: string | number }>(
       'serve',
       'Serves a GraphiQLApolloServer interface to test your Mesh API',
-      () => null,
+      builder => {
+        builder
+          .option('fork', {
+            required: false,
+            number: true,
+            count: true
+          });
+      },
       async ({ fork }) => {
         try {
           const meshConfig = await parseConfig();

--- a/packages/cli/src/bin.ts
+++ b/packages/cli/src/bin.ts
@@ -22,15 +22,15 @@ const logger = createLogger({
 
 export async function graphqlMesh() {
   yargs
-    .command<{}>(
+    .command<{ fork: string | number }>(
       'serve',
       'Serves a GraphiQLApolloServer interface to test your Mesh API',
       () => null,
-      async () => {
+      async ({ fork }) => {
         try {
           const meshConfig = await parseConfig();
           const { schema, contextBuilder } = await getMesh(meshConfig);
-          await serveMesh(logger, schema, contextBuilder, meshConfig.cache);
+          await serveMesh(logger, schema, contextBuilder, meshConfig.cache, fork);
         } catch (e) {
           logger.error('Unable to serve mesh: ', e);
         }

--- a/packages/cli/src/commands/serve.ts
+++ b/packages/cli/src/commands/serve.ts
@@ -14,10 +14,11 @@ export async function serveMesh(
 ): Promise<void> {
 
   if (isMaster && fork) {
-    for (let i = 0; i < (Number.isInteger(fork as number) ? parseInt(fork as string) : cpus().length); i++) {
+    fork = fork > 1 ? fork : cpus().length;
+    for (let i = 0; i < fork; i++) {
       clusterFork();
     }
-    logger.info(`🕸️ => Serving GraphQL Mesh GraphiQL: http://localhost:4000/`);
+    logger.info(`🕸️ => Serving GraphQL Mesh GraphiQL: http://localhost:4000 in ${fork} forks`);
   } else {
     const server = new ApolloServer({
       schema,
@@ -25,6 +26,10 @@ export async function serveMesh(
       cache,
     });
 
-    await server.listen();
+    const { url } = await server.listen();
+    if (!fork) {
+      logger.info(`🕸️ => Serving GraphQL Mesh GraphiQL: ${url}`);
+    }
   }
 }
+

--- a/packages/cli/src/commands/serve.ts
+++ b/packages/cli/src/commands/serve.ts
@@ -2,19 +2,29 @@ import { GraphQLSchema } from 'graphql';
 import { ApolloServer } from 'apollo-server';
 import { Logger } from 'winston';
 import { KeyValueCache } from '@graphql-mesh/types';
+import { fork as clusterFork, isMaster } from 'cluster';
+import { cpus } from 'os';
 
 export async function serveMesh(
   logger: Logger,
   schema: GraphQLSchema,
   contextBuilder: (initialContextValue?: any) => Record<string, any>,
   cache?: KeyValueCache,
+  fork?: string | number,
 ): Promise<void> {
-  const server = new ApolloServer({
-    schema,
-    context: contextBuilder,
-    cache,
-  });
 
-  const { url } = await server.listen();
-  logger.info(`🕸️ => Serving GraphQL Mesh GraphiQL: ${url}`);
+  if (isMaster && fork) {
+    for (let i = 0; i < (Number.isInteger(fork as number) ? parseInt(fork as string) : cpus().length); i++) {
+      clusterFork();
+    }
+    logger.info(`🕸️ => Serving GraphQL Mesh GraphiQL: http://localhost:4000/`);
+  } else {
+    const server = new ApolloServer({
+      schema,
+      context: contextBuilder,
+      cache,
+    });
+
+    await server.listen();
+  }
 }


### PR DESCRIPTION
https://nodejs.org/api/cluster.html

This PR implements NodeJS Cluster support for GraphQL Mesh `serve` command. If no number specified, number of CPUs is used by default.
`yarn graphql-mesh serve --fork=<number-of-workers>`