### PR TITLE
Allow users to specify baseUrl for OpenAPI Handler

### DIFF
--- a/packages/handlers/openapi/src/index.ts
+++ b/packages/handlers/openapi/src/index.ts
@@ -7,10 +7,11 @@ const handler: MeshHandlerLibrary<YamlConfig.OpenapiHandler> = {
   async getMeshSource({ config, cache }) {
     const path = config.source;
     const spec: Oas3 = await readFileOrUrlWithCache(path, cache, {
-      headers: config.schemaHeaders
+      headers: config.schemaHeaders,
     });
 
     const { schema } = await createGraphQLSchema(spec, {
+      baseUrl: config.baseUrl,
       headers: config.operationHeaders,
       operationIdFieldNames: true,
       viewer: false, // Viewer set to false in order to force users to specify auth via config file

--- a/packages/handlers/openapi/yaml-config.graphql
+++ b/packages/handlers/openapi/yaml-config.graphql
@@ -18,4 +18,9 @@ type OpenapiHandler @md {
   If you are using a remote URL endpoint to fetch your schema, you can set headers for the HTTP request to fetch your schema.
   """
   schemaHeaders: JSON
+  """
+  Specifies the URL on which all paths will be based on.
+  Overrides the server object in the OAS.
+  """
+  baseUrl: String
 }


### PR DESCRIPTION
Related https://github.com/Urigo/graphql-mesh/issues/198#issuecomment-610058320
Allow users to specify baseUrl to override server config for OpenAPI Handler