### PR TITLE
Fix grpc enum generation

### DIFF
--- a/examples/grpc-example/example-queries/GetMovies.query.graphql
+++ b/examples/grpc-example/example-queries/GetMovies.query.graphql
@@ -8,6 +8,7 @@ query GetMovies {
       time {
         seconds
       }
+      genre
     }
   }
 }

--- a/examples/grpc-example/proto/Example.proto
+++ b/examples/grpc-example/proto/Example.proto
@@ -4,6 +4,12 @@ package io.xtech.example;
 
 import "google/protobuf/timestamp.proto";
 
+enum Genre {
+    UNSPECIFIED = 0;
+    ACTION = 1;
+    DRAMA = 2;
+}
+
 /**
  * movie message payload
  */
@@ -16,7 +22,8 @@ message Movie {
      * list of cast
      */
     repeated string cast = 4;
-	google.protobuf.Timestamp time = 5;
+    google.protobuf.Timestamp time = 5;
+    Genre genre = 6;
 }
 
 message EmptyRequest {}

--- a/examples/grpc-example/src/server.ts
+++ b/examples/grpc-example/src/server.ts
@@ -1,7 +1,7 @@
 import * as grpc from 'grpc';
 
 import { ExampleService, IExampleServer } from './proto/Example_grpc_pb';
-import { EmptyRequest, Movie, MoviesResult, SearchByCastRequest } from './proto/Example_pb';
+import { EmptyRequest, Genre, Movie, MoviesResult, SearchByCastRequest } from './proto/Example_pb';
 import { Timestamp } from 'google-protobuf/google/protobuf/timestamp_pb';
 
 interface IRawMovie {
@@ -10,6 +10,7 @@ interface IRawMovie {
   rating: number;
   year: number;
   time: { seconds: number };
+  genre: Genre;
 }
 
 const seconds = Date.now();
@@ -23,6 +24,7 @@ const Movies = [
     time: {
       seconds,
     },
+    genre: Genre.ACTION,
   },
   {
     cast: ['Tom Cruise', 'Simon Pegg', 'Henry Cavill'],
@@ -32,6 +34,7 @@ const Movies = [
     time: {
       seconds,
     },
+    genre: Genre.ACTION,
   },
   {
     cast: ['Leonardo DiCaprio', 'Jonah Hill', 'Margot Robbie'],
@@ -41,6 +44,7 @@ const Movies = [
     time: {
       seconds,
     },
+    genre: Genre.DRAMA,
   },
 ];
 
@@ -54,6 +58,7 @@ function createMovie(movie: IRawMovie): Movie {
   const timestamp = new Timestamp();
   timestamp.setSeconds(movie.time.seconds);
   result.setTime(timestamp);
+  result.setGenre(movie.genre);
 
   return result;
 }

--- a/packages/handlers/grpc/src/index.ts
+++ b/packages/handlers/grpc/src/index.ts
@@ -65,9 +65,9 @@ const handler: MeshHandlerLibrary<YamlConfig.GrpcHandler> = {
           name: typeName,
           values: {},
         };
-        for (const key in nested.values) {
+        for (const [key, value] of Object.entries(nested.values)) {
           enumTypeConfig.values[key] = {
-            value: key,
+            value: value,
           };
         }
         schemaComposer.createEnumTC(enumTypeConfig);


### PR DESCRIPTION
for ... in will iterate over all entries on the prototype, which results in
enums getting numbered definitions.

e.g.
enum { ACTION = 0, DRAMA = 1 } will create a config with the values
ACTION, DRAMA, 0 and 1

Use Object.entries to only generate the enum config for ownProperties
of the enum proto object.