### PR TITLE
Fix grpc method inference

### DIFF
--- a/examples/grpc-example/proto/io/xtech/service.proto
+++ b/examples/grpc-example/proto/io/xtech/service.proto
@@ -36,3 +36,16 @@ service Example {
   rpc SearchMoviesByCast (SearchByCastRequest) returns (stream Movie) {}
 
 }
+
+service AnotherExample {
+  /**
+  * get all movies
+  */
+  rpc GetMovies (MovieRequest) returns (MoviesResult) {}
+
+  /**
+  * search movies by the name of the cast
+  */
+  rpc SearchMoviesByCast (SearchByCastRequest) returns (stream Movie) {}
+
+}

--- a/packages/handlers/grpc/src/index.ts
+++ b/packages/handlers/grpc/src/index.ts
@@ -170,7 +170,7 @@ const handler: MeshHandlerLibrary<YamlConfig.GrpcHandler> = {
                 },
               });
             } else {
-              const identifier = rootFieldName.toLowerCase();
+              const identifier = methodName.toLowerCase();
               const rootTC = identifier.startsWith('get') ? schemaComposer.Query : schemaComposer.Mutation;
               rootTC.addFields({
                 [rootFieldName]: {


### PR DESCRIPTION
Use the original mehtod name to identify the type.

When the service names doesn't match the name in the config, the
service name is prepended to the method name. This results in query
methods incorrectly being identified as mutations.