### PR TITLE
Less strict validation for OpenAPI Handler

### DIFF
--- a/examples/openapi-stackexchange/.meshrc.yml
+++ b/examples/openapi-stackexchange/.meshrc.yml
@@ -1,0 +1,5 @@
+sources:
+  - name: StackExchange
+    handler:
+      openapi:
+        source: https://grokify.github.io/api-specs/stackexchange/stackexchange-api-v2.2_openapi-v3.0.yaml

--- a/examples/openapi-stackexchange/get-questions.query.graphql
+++ b/examples/openapi-stackexchange/get-questions.query.graphql
@@ -1,0 +1,11 @@
+query GetQuestions {
+  getQuestions(site: "stackoverflow") {
+    items {
+      title
+      tags
+      isAnswered
+      answerCount
+      link
+    }
+  }
+}

--- a/examples/openapi-stackexchange/package.json
+++ b/examples/openapi-stackexchange/package.json
@@ -1,0 +1,15 @@
+{
+    "name": "openapi-stackexchange",
+    "version": "0.1.15",
+    "license": "MIT",
+    "private": true,
+    "scripts": {
+      "start": "graphql-mesh serve --example-query get-questions.query.graphql"
+    },
+    "dependencies": {
+      "@graphql-mesh/cli": "0.1.15",
+      "@graphql-mesh/openapi": "0.1.15",
+      "graphql": "15.0.0",
+      "graphql-fields": "2.0.3"
+    }
+  }

--- a/packages/handlers/openapi/src/openapi-to-graphql/oas_3_tools.ts
+++ b/packages/handlers/openapi/src/openapi-to-graphql/oas_3_tools.ts
@@ -774,7 +774,7 @@ export function getResponseStatusCode(path: string, method: string, oas: Oas3, d
   if (typeof endpoint.responses === 'object') {
     const codes = Object.keys(endpoint.responses);
     const successCodes = codes.filter(code => {
-      return SUCCESS_STATUS_RX.test(code);
+      return SUCCESS_STATUS_RX.test(code) || code === 'default';
     });
     if (successCodes.length === 1) {
       return successCodes[0];

--- a/packages/handlers/openapi/src/openapi-to-graphql/utils.ts
+++ b/packages/handlers/openapi/src/openapi-to-graphql/utils.ts
@@ -87,7 +87,7 @@ export function handleWarning({
     if (typeof log === 'function') {
       log(output);
     } else {
-      console.log(output);
+      console.warn(output);
     }
     data.options.report.warnings.push(warning);
   }

--- a/website/src/components/live-demo/index.js
+++ b/website/src/components/live-demo/index.js
@@ -7,6 +7,7 @@ const EXAMPLES = {
         'Location Weather': 'openapi-location-weather',
         'YouTrack': 'openapi-youtrack',
         'Stripe': 'openapi-stripe',
+        'StackExchange': 'openapi-stackexchange'
     },
     'JSON Schema': {
         'Fake API': 'json-schema-example',

--- a/yarn.lock
+++ b/yarn.lock
@@ -1411,63 +1411,6 @@
     pascal-case "3.1.1"
     tslib "~1.11.1"
 
-"@graphql-mesh/cache-inmemory-lru@0.1.13":
-  version "0.1.13"
-  resolved "https://registry.yarnpkg.com/@graphql-mesh/cache-inmemory-lru/-/cache-inmemory-lru-0.1.13.tgz#4d1fda882691eb2085753c22a8ef08950b73f640"
-  integrity sha512-m6VJ+kNnWAhM2g/ojnJBidd+oXMLmeYMrCoxPq/Z1H0q7bmEEje27OTvrRcIL6QKJKNn5XUV6M+qxt5TXDv9IQ==
-  dependencies:
-    "@graphql-mesh/types" "0.1.13"
-    "@types/lru-cache" "5.1.0"
-    lru-cache "5.1.1"
-
-"@graphql-mesh/odata@0.1.13":
-  version "0.1.13"
-  resolved "https://registry.yarnpkg.com/@graphql-mesh/odata/-/odata-0.1.13.tgz#8f4d41656aba030ac3eb46e5552b45ca37fea1bf"
-  integrity sha512-bPNjfykWAQ69g4JmxVaJttremV20uQuNAqIOkYH9hdG/zRaoxWQxHuAOCX6pEXBRQuvuXFcfvyNr5fWu0Z7FaQ==
-  dependencies:
-    "@graphql-mesh/types" "0.1.13"
-    "@graphql-mesh/utils" "0.1.13"
-    fetchache "0.0.3"
-    graphql-fields "2.0.3"
-    graphql-scalars "1.1.2"
-    jsdom "16.2.2"
-    url-join "4.0.1"
-
-"@graphql-mesh/runtime@0.1.13":
-  version "0.1.13"
-  resolved "https://registry.yarnpkg.com/@graphql-mesh/runtime/-/runtime-0.1.13.tgz#22cdbb1fb2b5d1d27c3497bce2184b76669d9878"
-  integrity sha512-2P3hU0mpk8bHxYjI3Zblw3sLOk5IyfDfoQav3xfZHqYShBSSAGORfs5x387kZwExnhsrSPzLK73VuOdqOW2KKA==
-  dependencies:
-    "@graphql-mesh/cache-inmemory-lru" "0.1.13"
-    "@graphql-mesh/types" "0.1.13"
-    "@graphql-toolkit/common" "0.10.6"
-    "@graphql-toolkit/schema-merging" "0.10.6"
-    aggregate-error "3.0.1"
-    ajv "6.12.2"
-    cosmiconfig "6.0.0"
-    graphql-tools "5.0.0"
-    param-case "3.0.3"
-
-"@graphql-mesh/types@0.1.13":
-  version "0.1.13"
-  resolved "https://registry.yarnpkg.com/@graphql-mesh/types/-/types-0.1.13.tgz#216109bdd143e5f1e4485f65d3d160c99d430e38"
-  integrity sha512-tYbiNMaX2EvD4t3dlTDopMTH1eU/u/FNsNcvEOJ88GfHcU9uZri36b+6XuMYmLERmBkBOilDIigtBHUZiN9iOA==
-  dependencies:
-    fetchache "0.0.3"
-    tsee "1.3.0"
-
-"@graphql-mesh/utils@0.1.13":
-  version "0.1.13"
-  resolved "https://registry.yarnpkg.com/@graphql-mesh/utils/-/utils-0.1.13.tgz#125d89d54665b58da519d3b2afc9f3a9797526ba"
-  integrity sha512-uH6Ma+5fgKZ5/Z0ewfcr09ZoFz8wh2Bb9r0soEsuPDyHgfq7kP16slQ0zwSEdzATbrDfPJUgxLbxfo9ZurkoKw==
-  dependencies:
-    "@ardatan/string-interpolation" "1.2.8"
-    date-fns "2.12.0"
-    fetchache "0.0.3"
-    is-url "1.2.4"
-    js-yaml "3.13.1"
-    object-hash "2.0.3"
-
 "@graphql-toolkit/code-file-loader@0.10.6":
   version "0.10.6"
   resolved "https://registry.yarnpkg.com/@graphql-toolkit/code-file-loader/-/code-file-loader-0.10.6.tgz#eadb9dece4850701a7bbdacb7824c19f11e80f29"
@@ -5427,11 +5370,6 @@ dataloader@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/dataloader/-/dataloader-2.0.0.tgz#41eaf123db115987e21ca93c005cd7753c55fe6f"
   integrity sha512-YzhyDAwA4TaQIhM5go+vCLmU0UikghC/t9DTQYZR2M/UvZ1MdOhPezSDZcjj9uqQJOMqjLcpWtyW2iNINdlatQ==
-
-date-fns@2.12.0:
-  version "2.12.0"
-  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.12.0.tgz#01754c8a2f3368fc1119cf4625c3dad8c1845ee6"
-  integrity sha512-qJgn99xxKnFgB1qL4jpxU7Q2t0LOn1p8KMIveef3UZD7kqjT3tpFNNdXJelEHhE+rUgffriXriw/sOSU+cS1Hw==
 
 date-fns@2.13.0:
   version "2.13.0"


### PR DESCRIPTION
- If response code is `default`, pretend it is like `2xx`.
- If response content type definition has `json` in the mimetype, pretend it is `application/json`.
Related #248 and #355