### PR TITLE
fix(postgraphile-getMeshSource): Fallback to empty array when no plugins

### DIFF
--- a/packages/handlers/postgraphile/src/index.ts
+++ b/packages/handlers/postgraphile/src/index.ts
@@ -27,7 +27,7 @@ const handler: MeshHandlerLibrary<YamlConfig.PostGraphileHandler> = {
 
     let writeCache: () => Promise<void>;
 
-    const appendPlugins = await Promise.all<Plugin>(config.plugins?.map(pluginName => import(pluginName)));
+    const appendPlugins = await Promise.all<Plugin>((config.plugins || []).map(pluginName => import(pluginName)));
 
     const builder = await getPostGraphileBuilder(pgPool, config.schemaName || 'public', {
       dynamicJson: true,


### PR DESCRIPTION
The [sample for postgres](https://github.com/Urigo/graphql-mesh/tree/master/examples/postgres-geodb) did not work after downloading. After looking into why I discovered that is was due to the fact that when no plugins are provided undefined was passed into Promise.all which causes `getMeshSource` to fail.

Luckily only a very minor fix was needed.

Fixes #604