### PR TITLE
Use `Byte`, `Date`, `Time`, `UtcOffset` and `Timestamp` from graphql-scalars

### DIFF
--- a/packages/cli/src/commands/scalars-map.ts
+++ b/packages/cli/src/commands/scalars-map.ts
@@ -1,5 +1,7 @@
 export const scalarsMap = {
   BigInt: 'BigInt',
+  Byte: 'Buffer',
+  Date: 'Date',
   DateTime: 'Date',
   GUID: 'String',
 };

--- a/packages/handlers/grpc/package.json
+++ b/packages/handlers/grpc/package.json
@@ -19,7 +19,7 @@
     "@grpc/proto-loader": "0.5.4",
     "camel-case": "4.1.1",
     "fs-extra": "9.0.1",
-    "graphql-scalars": "1.1.5",
+    "graphql-scalars": "1.1.6",
     "graphql-compose": "7.18.1",
     "protobufjs": "6.9.0",
     "pascal-case": "3.1.1",

--- a/packages/handlers/json-schema/package.json
+++ b/packages/handlers/json-schema/package.json
@@ -24,7 +24,7 @@
     "fs-extra": "9.0.1",
     "lodash": "4.17.15",
     "graphql-compose": "7.18.1",
-    "graphql-scalars": "1.1.5",
+    "graphql-scalars": "1.1.6",
     "pascal-case": "3.1.1",
     "url-join": "4.0.1",
     "to-json-schema": "0.2.5"

--- a/packages/handlers/mysql/package.json
+++ b/packages/handlers/mysql/package.json
@@ -23,7 +23,7 @@
     "mysql-utilities": "1.1.0-alpha.4",
     "camel-case": "4.1.1",
     "pascal-case": "3.1.1",
-    "graphql-scalars": "1.1.5"
+    "graphql-scalars": "1.1.6"
   },
   "devDependencies": {
     "@types/graphql-fields": "1.3.2",

--- a/packages/handlers/mysql/src/index.ts
+++ b/packages/handlers/mysql/src/index.ts
@@ -6,7 +6,14 @@ import { promisify } from 'util';
 import { pascalCase } from 'pascal-case';
 import graphqlFields from 'graphql-fields';
 import { camelCase } from 'camel-case';
-import { GraphQLBigInt, GraphQLDateTime, GraphQLJSON } from 'graphql-scalars';
+import {
+  GraphQLBigInt,
+  GraphQLDateTime,
+  GraphQLJSON,
+  GraphQLDate,
+  GraphQLTimestamp,
+  GraphQLTime,
+} from 'graphql-scalars';
 import { execute } from 'graphql';
 
 const SCALARS = {
@@ -19,7 +26,7 @@ const SCALARS = {
 
   char: 'String',
 
-  date: 'DateTime',
+  date: 'Date',
   datetime: 'DateTime',
 
   dec: 'Float',
@@ -45,8 +52,8 @@ const SCALARS = {
   smallint: 'Int',
 
   text: 'String',
-  time: 'Date',
-  timestamp: 'Date',
+  time: 'Time',
+  timestamp: 'Timestamp',
   tinyblob: 'String',
   tinyint: 'Int',
   tinytext: 'String',
@@ -105,7 +112,10 @@ const handler: MeshHandlerLibrary<YamlConfig.MySQLHandler> = {
 
     schemaComposer.add(GraphQLBigInt);
     schemaComposer.add(GraphQLJSON);
+    schemaComposer.add(GraphQLDate);
+    schemaComposer.add(GraphQLTime);
     schemaComposer.add(GraphQLDateTime);
+    schemaComposer.add(GraphQLTimestamp);
     schemaComposer.createEnumTC({
       name: 'OrderBy',
       values: {

--- a/packages/handlers/odata/package.json
+++ b/packages/handlers/odata/package.json
@@ -26,7 +26,7 @@
     "fetchache": "0.0.3",
     "graphql-compose": "7.18.1",
     "graphql-parse-resolve-info": "4.7.0",
-    "graphql-scalars": "1.1.5",
+    "graphql-scalars": "1.1.6",
     "pascal-case": "3.1.1",
     "jsdom": "16.2.2",
     "url-join": "4.0.1"

--- a/packages/handlers/odata/src/index.ts
+++ b/packages/handlers/odata/src/index.ts
@@ -13,7 +13,15 @@ import {
   EnumTypeComposerValueConfigDefinition,
   InputTypeComposer,
 } from 'graphql-compose';
-import { GraphQLBigInt, GraphQLGUID, GraphQLDateTime, GraphQLJSON } from 'graphql-scalars';
+import {
+  GraphQLBigInt,
+  GraphQLGUID,
+  GraphQLDateTime,
+  GraphQLJSON,
+  GraphQLDate,
+  GraphQLByte,
+  GraphQLUtcOffset,
+} from 'graphql-scalars';
 import { isListType, GraphQLResolveInfo, isAbstractType, GraphQLObjectType, GraphQLSchema } from 'graphql';
 import { parseResolveInfo, ResolveTree, simplifyParsedResolveInfoFragmentWithType } from 'graphql-parse-resolve-info';
 import DataLoader from 'dataloader';
@@ -26,19 +34,19 @@ const SCALARS = new Map<string, string>([
   ['Edm.Stream', 'String'],
   ['Edm.String', 'String'],
   ['Edm.Int16', 'Int'],
-  ['Edm.Byte', 'Int'],
+  ['Edm.Byte', 'Byte'],
   ['Edm.Int32', 'Int'],
   ['Edm.Int64', 'BigInt'],
   ['Edm.Double', 'Float'],
   ['Edm.Boolean', 'Boolean'],
   ['Edm.Guid', 'GUID'],
-  ['Edm.DateTimeOffset', 'String'],
-  ['Edm.Date', 'DateTime'],
+  ['Edm.DateTimeOffset', 'UtcOffset'],
+  ['Edm.Date', 'Date'],
   ['Edm.TimeOfDay', 'String'],
   ['Edm.Single', 'Float'],
   ['Edm.Duration', 'String'],
   ['Edm.Decimal', 'Float'],
-  ['Edm.SByte', 'Int'],
+  ['Edm.SByte', 'Byte'],
   ['Edm.GeographyPoint', 'String'],
 ]);
 
@@ -72,6 +80,9 @@ const handler: MeshHandlerLibrary<YamlConfig.ODataHandler> = {
     schemaComposer.add(GraphQLGUID);
     schemaComposer.add(GraphQLDateTime);
     schemaComposer.add(GraphQLJSON);
+    schemaComposer.add(GraphQLByte);
+    schemaComposer.add(GraphQLDate);
+    schemaComposer.add(GraphQLUtcOffset);
 
     const aliasNamespaceMap = new Map<string, string>();
 

--- a/packages/handlers/odata/test/__snapshots__/handler.spec.ts.snap
+++ b/packages/handlers/odata/test/__snapshots__/handler.spec.ts.snap
@@ -177,8 +177,8 @@ type Trip implements ITrip {
   Budget: Float!
   Description: String
   Tags: [String]
-  StartsAt: String!
-  EndsAt: String!
+  StartsAt: UtcOffset!
+  EndsAt: UtcOffset!
   PlanItems(queryOptions: QueryOptions): [PlanItem]
   GetInvolvedPeople: [Person]
 }
@@ -190,8 +190,8 @@ interface ITrip {
   Budget: Float!
   Description: String
   Tags: [String]
-  StartsAt: String!
-  EndsAt: String!
+  StartsAt: UtcOffset!
+  EndsAt: UtcOffset!
   PlanItems(queryOptions: QueryOptions): [PlanItem]
   GetInvolvedPeople: [Person]
 }
@@ -201,19 +201,24 @@ A field whose value is a generic Globally Unique Identifier: https://en.wikipedi
 \\"\\"\\"
 scalar GUID
 
+\\"\\"\\"
+A field whose value is a UTC Offset: https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
+\\"\\"\\"
+scalar UtcOffset
+
 type PlanItem implements IPlanItem {
   PlanItemId: Int!
   ConfirmationCode: String
-  StartsAt: String!
-  EndsAt: String!
+  StartsAt: UtcOffset!
+  EndsAt: UtcOffset!
   Duration: String!
 }
 
 interface IPlanItem {
   PlanItemId: Int!
   ConfirmationCode: String
-  StartsAt: String!
-  EndsAt: String!
+  StartsAt: UtcOffset!
+  EndsAt: UtcOffset!
   Duration: String!
 }
 
@@ -222,8 +227,8 @@ type Event implements IPlanItem {
   Description: String
   PlanItemId: Int!
   ConfirmationCode: String
-  StartsAt: String!
-  EndsAt: String!
+  StartsAt: UtcOffset!
+  EndsAt: UtcOffset!
   Duration: String!
 }
 
@@ -231,8 +236,8 @@ type PublicTransportation implements IPublicTransportation & IPlanItem {
   SeatNumber: String
   PlanItemId: Int!
   ConfirmationCode: String
-  StartsAt: String!
-  EndsAt: String!
+  StartsAt: UtcOffset!
+  EndsAt: UtcOffset!
   Duration: String!
 }
 
@@ -240,8 +245,8 @@ interface IPublicTransportation {
   SeatNumber: String
   PlanItemId: Int!
   ConfirmationCode: String
-  StartsAt: String!
-  EndsAt: String!
+  StartsAt: UtcOffset!
+  EndsAt: UtcOffset!
   Duration: String!
 }
 
@@ -253,8 +258,8 @@ type Flight implements IPublicTransportation {
   SeatNumber: String
   PlanItemId: Int!
   ConfirmationCode: String
-  StartsAt: String!
-  EndsAt: String!
+  StartsAt: UtcOffset!
+  EndsAt: UtcOffset!
   Duration: String!
 }
 

--- a/packages/handlers/openapi/package.json
+++ b/packages/handlers/openapi/package.json
@@ -26,7 +26,7 @@
     "form-urlencoded": "4.1.4",
     "jsonpath-plus": "4.0.0",
     "oas-validator": "4.0.3",
-    "graphql-scalars": "1.1.5",
+    "graphql-scalars": "1.1.6",
     "pluralize": "8.0.0",
     "swagger2openapi": "6.0.3",
     "url-join": "4.0.1"

--- a/packages/handlers/thrift/package.json
+++ b/packages/handlers/thrift/package.json
@@ -24,7 +24,7 @@
     "@graphql-mesh/utils": "0.2.12",
     "aggregate-error": "3.0.1",
     "fetchache": "0.0.3",
-    "graphql-scalars": "1.1.5",
+    "graphql-scalars": "1.1.6",
     "url-join": "4.0.1",
     "thrift": "0.13.0"
   },

--- a/packages/handlers/thrift/src/index.ts
+++ b/packages/handlers/thrift/src/index.ts
@@ -20,7 +20,7 @@ import {
   GraphQLFieldConfigArgumentMap,
   GraphQLSchema,
 } from 'graphql';
-import { GraphQLBigInt, GraphQLJSON } from 'graphql-scalars';
+import { GraphQLBigInt, GraphQLJSON, GraphQLByte } from 'graphql-scalars';
 import { createHttpClient } from '@creditkarma/thrift-client';
 import {
   ThriftClient,
@@ -325,8 +325,8 @@ const handler: MeshHandlerLibrary<YamlConfig.ThriftHandler> = {
           typeVal = typeVal! || { type: TType.I32 };
           break;
         case SyntaxType.ByteKeyword:
-          inputType = GraphQLInt;
-          outputType = GraphQLInt;
+          inputType = GraphQLByte;
+          outputType = GraphQLByte;
           typeVal = typeVal! || { type: TType.BYTE };
           break;
         case SyntaxType.I64Keyword:

--- a/yarn.lock
+++ b/yarn.lock
@@ -7887,10 +7887,10 @@ graphql-relay@^0.6.0:
   dependencies:
     prettier "^1.16.0"
 
-graphql-scalars@1.1.5:
-  version "1.1.5"
-  resolved "https://registry.yarnpkg.com/graphql-scalars/-/graphql-scalars-1.1.5.tgz#9d0485e4f67a4120400dcbfa83797fc74f2f19af"
-  integrity sha512-2Kbq8VgreOB62eKUafwp7qvyvDIS3wmw+JNzyXydQS6I986/s4ceJZs6Hc7Ex/9zBrhFsUlVIEl0a6oUqGCU/Q==
+graphql-scalars@1.1.6:
+  version "1.1.6"
+  resolved "https://registry.yarnpkg.com/graphql-scalars/-/graphql-scalars-1.1.6.tgz#917560c22f4806a058ad75b870e995832c53c2d8"
+  integrity sha512-n8UIqzI5l2hyTdcH0pIVLEC/1iMJ7d+J2YR8rHiz2bNt4nOmFD6jibKSVpmxioD/4Uj0EsZzURxnphxGGTHPYw==
 
 graphql-sequelize@^9.3.6:
   version "9.4.0"


### PR DESCRIPTION
`Byte`, `Date`, `Time`, `UtcOffset` and `Timestamp` have been recently added to graphql-scalars. So, Mesh now uses those scalars in the handlers to handle those specific types properly.