### PR TITLE
Add new grpc handler functionality, refactor and add tests

### DIFF
--- a/packages/handlers/grpc/src/index.ts
+++ b/packages/handlers/grpc/src/index.ts
@@ -45,11 +45,14 @@ const handler: MeshHandlerLibrary<YamlConfig.GrpcHandler> = {
 
     let creds: ChannelCredentials;
     if (config.credentialsSsl) {
-      const [rootCA, privateKey, certChain] = await Promise.all([
-        getBuffer(config.credentialsSsl.rootCA, cache),
+      const sslFiles = [
         getBuffer(config.credentialsSsl.privateKey, cache),
         getBuffer(config.credentialsSsl.certChain, cache),
-      ]);
+      ];
+      if (config.credentialsSsl.rootCA !== 'rootCA') {
+        sslFiles.unshift(getBuffer(config.credentialsSsl.rootCA, cache));
+      }
+      const [rootCA, privateKey, certChain] = await Promise.all(sslFiles);
       creds = credentials.createSsl(rootCA, privateKey, certChain);
     } else {
       creds = credentials.createInsecure();

--- a/packages/handlers/grpc/src/scalars.ts
+++ b/packages/handlers/grpc/src/scalars.ts
@@ -1,0 +1,31 @@
+type ScalarMap = Map<string, string>;
+
+const SCALARS: ScalarMap = new Map([
+  ['bool', 'Boolean'],
+  ['bytes', 'Byte'],
+  ['double', 'Float'],
+  ['fixed32', 'Int'],
+  ['fixed64', 'BigInt'],
+  ['float', 'Float'],
+  ['int32', 'Int'],
+  ['int64', 'BigInt'],
+  ['sfixed32', 'Int'],
+  ['sfixed64', 'BigInt'],
+  ['sint32', 'Int'],
+  ['sint64', 'BigInt'],
+  ['string', 'String'],
+  ['uint32', 'Int'],
+  ['uint64', 'BigInt'],
+]);
+
+export function isScalarType(type: string): boolean {
+  return SCALARS.has(type);
+}
+
+export function getGraphQLScalar(scalarType: string): string {
+  const gqlScalar = SCALARS.get(scalarType);
+  if (!gqlScalar) {
+    throw new Error(`Could not find GraphQL Scalar for type ${scalarType}`);
+  }
+  return SCALARS.get(scalarType);
+}

--- a/packages/handlers/grpc/src/utils.ts
+++ b/packages/handlers/grpc/src/utils.ts
@@ -1,0 +1,208 @@
+import { KeyValueCache } from '@graphql-mesh/types';
+import { readFileOrUrlWithCache } from '@graphql-mesh/utils';
+import { ClientReadableStream, ClientUnaryCall, Metadata, MetadataValue } from '@grpc/grpc-js';
+import { pathExistsSync } from 'fs-extra';
+import { GraphQLEnumTypeConfig } from 'graphql';
+import { InputTypeComposer, ObjectTypeComposer, SchemaComposer } from 'graphql-compose';
+import { get } from 'lodash';
+import { pascalCase } from 'pascal-case';
+import { isAbsolute, join } from 'path';
+import { IField, Root } from 'protobufjs';
+
+import { getGraphQLScalar, isScalarType } from './scalars';
+
+export type ClientMethod = (
+  input: unknown,
+  metaData?: Metadata
+) => Promise<ClientUnaryCall> | AsyncIterator<ClientReadableStream<unknown>>;
+
+interface InputOutputTypes {
+  input: string;
+  output: string;
+}
+
+export function toSnakeCase(str: string): string {
+  return str.split('.').join('_');
+}
+
+export function addIncludePathResolver(root: Root, includePaths: string[]): void {
+  const originalResolvePath = root.resolvePath;
+  root.resolvePath = (origin: string, target: string) => {
+    if (isAbsolute(target)) {
+      return target;
+    }
+    for (const directory of includePaths) {
+      const fullPath: string = join(directory, target);
+      if (pathExistsSync(fullPath)) {
+        return fullPath;
+      }
+    }
+    const path = originalResolvePath(origin, target);
+    if (path === null) {
+      console.warn(`${target} not found in any of the include paths ${includePaths}`);
+    }
+    return path;
+  };
+}
+
+export function addMetaDataToCall(
+  call: ClientMethod,
+  input: unknown,
+  context: Record<string, unknown>,
+  metaData: Record<string, string | string[] | Buffer>
+): Promise<ClientUnaryCall> | AsyncIterator<ClientReadableStream<unknown>> {
+  if (metaData) {
+    const meta = new Metadata();
+    for (const [key, value] of Object.entries(metaData)) {
+      let metaValue: unknown = value;
+      if (Array.isArray(value)) {
+        // Extract data from context
+        metaValue = get(context, value);
+      }
+      // Ensure that the metadata is compatible with what node-grpc expects
+      if (typeof metaValue !== 'string' && !(metaValue instanceof Buffer)) {
+        metaValue = JSON.stringify(metaValue);
+      }
+
+      meta.add(key, metaValue as MetadataValue);
+    }
+
+    return call(input, meta);
+  }
+  return call(input);
+}
+
+export async function getBuffer(path: string, cache: KeyValueCache): Promise<Buffer> {
+  if (path) {
+    const result = await readFileOrUrlWithCache<string>(path, cache, {
+      allowUnknownExtensions: true,
+    });
+    return Buffer.from(result);
+  }
+  return undefined;
+}
+
+export function getTypeName(
+  schemaComposer: SchemaComposer<unknown>,
+  typePath: string,
+  isInput: boolean,
+  packageName: string
+): string {
+  if (isScalarType(typePath)) {
+    return getGraphQLScalar(typePath);
+  }
+  let baseTypeName = pascalCase(toSnakeCase(typePath.replace(packageName + '.', '')));
+  if (isInput && !schemaComposer.isEnumType(baseTypeName)) {
+    baseTypeName += 'Input';
+  }
+  return baseTypeName;
+}
+
+export function createEnum(typeName: string, values: Record<string, number>): GraphQLEnumTypeConfig {
+  const enumTypeConfig: GraphQLEnumTypeConfig = {
+    name: typeName,
+    values: {},
+  };
+  for (const [key, value] of Object.entries(values)) {
+    enumTypeConfig.values[key] = {
+      value,
+    };
+  }
+  return enumTypeConfig;
+}
+
+export function createFieldsType(typeName: string): InputOutputTypes {
+  return {
+    input: typeName + 'Input',
+    output: typeName,
+  };
+}
+
+async function addInputOutputFields(
+  schemaComposer: SchemaComposer<unknown>,
+  inputTC: InputTypeComposer,
+  outputTC: ObjectTypeComposer,
+  fields: { [k: string]: IField },
+  name: string,
+  currentPath: string,
+  packageName: string
+): Promise<void> {
+  const fieldKeys = Object.keys(fields);
+  if (!fields.length) {
+    // This is a empty proto type
+    inputTC.addFields({
+      _: {
+        type: () => {
+          return getTypeName(schemaComposer, 'bool', true, packageName);
+        },
+      },
+    });
+    outputTC.addFields({
+      _: {
+        type: () => {
+          return getTypeName(schemaComposer, 'bool', true, packageName);
+        },
+      },
+    });
+  }
+  await Promise.all(
+    fieldKeys.map(async fieldName => {
+      const { type, rule } = fields[fieldName];
+      let fullType = type;
+      if (
+        packageName &&
+        !isScalarType(type) &&
+        !type.includes('.') &&
+        currentPath.length &&
+        name.includes(currentPath)
+      ) {
+        fullType = pascalCase(currentPath + type);
+      }
+
+      inputTC.addFields({
+        [fieldName]: {
+          type: () => {
+            const inputTypeName = getTypeName(schemaComposer, fullType, true, packageName);
+            return rule === 'repeated' ? `[${inputTypeName}]` : inputTypeName;
+          },
+        },
+      });
+      outputTC.addFields({
+        [fieldName]: {
+          type: () => {
+            const typeName = getTypeName(schemaComposer, fullType, false, packageName);
+            return rule === 'repeated' ? `[${typeName}]` : typeName;
+          },
+        },
+      });
+    })
+  );
+}
+
+export function createInputOutput(
+  schemaComposer: SchemaComposer<unknown>,
+  name: string,
+  currentPath: string,
+  packageName: string,
+  fields: { [k: string]: IField }
+): void {
+  const { input, output } = createFieldsType(name);
+
+  const inputTC = schemaComposer.createInputTC({
+    name: input,
+    fields: {},
+  });
+  const outputTC = schemaComposer.createObjectTC({
+    name: output,
+    fields: {},
+  });
+  addInputOutputFields(
+    schemaComposer,
+    inputTC,
+    outputTC,
+    fields,
+    name,
+    pascalCase(toSnakeCase(currentPath)),
+    packageName
+  );
+}

--- a/packages/handlers/grpc/test/fixtures/proto-tests/allvalues.proto
+++ b/packages/handlers/grpc/test/fixtures/proto-tests/allvalues.proto
@@ -1,0 +1,28 @@
+syntax = "proto3";
+
+message Item {
+  bool boolean = 1;
+  bytes bytesType = 2;
+  double doubleNum = 3;
+  fixed32 fixedint32 = 4;
+  fixed64 fixedint64 = 5;
+  float floatNum = 6;
+  int32 integer32 = 7;
+  int64 integer64 = 8;
+  sfixed32 sfixedint32 = 9;
+  sfixed64 sfixedint64 = 10;
+  sint32 sinteger32 = 11;
+  sint64 sinteger64 = 12;
+  string str = 13;
+  uint32 uinteger32 = 14;
+  uint64 uinteger64 = 15;
+}
+
+message Result {
+  repeated Item result = 1;
+}
+
+
+service Example {
+  rpc Get (Item) returns (Result) {}
+}

--- a/packages/handlers/grpc/test/fixtures/proto-tests/empty.proto
+++ b/packages/handlers/grpc/test/fixtures/proto-tests/empty.proto
@@ -1,0 +1,75 @@
+syntax = "proto3";
+
+package io.xtech;
+
+import "google/protobuf/timestamp.proto";
+
+enum Genre {
+    UNSPECIFIED = 0;
+    ACTION = 1;
+    DRAMA = 2;
+}
+
+/**
+ * movie message payload
+ */
+message Movie {
+    string name = 1;
+    int32 year = 2;
+    float rating = 3;
+
+    /**
+     * list of cast
+     */
+    repeated string cast = 4;
+    google.protobuf.Timestamp time = 5;
+    Genre genre = 6;
+}
+
+message EmptyRequest {}
+
+message MovieRequest {
+    Movie movie = 1;
+}
+
+message SearchByCastRequest {
+    string castName = 1;
+}
+
+/**
+ * movie result message, contains list of movies
+ */
+message MoviesResult {
+    /**
+     * list of movies
+     */
+    repeated Movie result = 1;
+}
+
+service Example {
+  /**
+  * get all movies
+  */
+  rpc GetMovies (MovieRequest) returns (MoviesResult) {}
+
+  rpc GetEmpty (MovieRequest) returns (EmptyRequest) {}
+
+  /**
+  * search movies by the name of the cast
+  */
+  rpc SearchMoviesByCast (SearchByCastRequest) returns (stream Movie) {}
+
+}
+
+service AnotherExample {
+  /**
+  * get all movies
+  */
+  rpc GetMovies (MovieRequest) returns (MoviesResult) {}
+
+  /**
+  * search movies by the name of the cast
+  */
+  rpc SearchMoviesByCast (SearchByCastRequest) returns (stream Movie) {}
+
+}

--- a/packages/handlers/grpc/test/fixtures/proto-tests/movie.proto
+++ b/packages/handlers/grpc/test/fixtures/proto-tests/movie.proto
@@ -1,0 +1,73 @@
+syntax = "proto3";
+
+package io.xtech;
+
+import "google/protobuf/timestamp.proto";
+
+enum Genre {
+    UNSPECIFIED = 0;
+    ACTION = 1;
+    DRAMA = 2;
+}
+
+/**
+ * movie message payload
+ */
+message Movie {
+    string name = 1;
+    int32 year = 2;
+    float rating = 3;
+
+    /**
+     * list of cast
+     */
+    repeated string cast = 4;
+    google.protobuf.Timestamp time = 5;
+    Genre genre = 6;
+}
+
+message EmptyRequest {}
+
+message MovieRequest {
+    Movie movie = 1;
+}
+
+message SearchByCastRequest {
+    string castName = 1;
+}
+
+/**
+ * movie result message, contains list of movies
+ */
+message MoviesResult {
+    /**
+     * list of movies
+     */
+    repeated Movie result = 1;
+}
+
+service Example {
+  /**
+  * get all movies
+  */
+  rpc GetMovies (MovieRequest) returns (MoviesResult) {}
+
+  /**
+  * search movies by the name of the cast
+  */
+  rpc SearchMoviesByCast (SearchByCastRequest) returns (stream Movie) {}
+
+}
+
+service AnotherExample {
+  /**
+  * get all movies
+  */
+  rpc GetMovies (MovieRequest) returns (MoviesResult) {}
+
+  /**
+  * search movies by the name of the cast
+  */
+  rpc SearchMoviesByCast (SearchByCastRequest) returns (stream Movie) {}
+
+}

--- a/packages/handlers/grpc/test/fixtures/proto-tests/nested.proto
+++ b/packages/handlers/grpc/test/fixtures/proto-tests/nested.proto
@@ -1,0 +1,26 @@
+syntax = "proto3";
+
+package io.xtech;
+
+message Item {
+  string name = 1;
+}
+
+message TopLevel {
+  string value = 1;
+
+  message Nested {
+    Item movie = 2;
+  }
+
+  Nested nested_usage = 3;
+}
+
+message Result {
+  repeated Item result = 1;
+}
+
+
+service Example {
+  rpc Get (TopLevel.Nested) returns (Result) {}
+}

--- a/packages/handlers/grpc/test/fixtures/proto-tests/nopackage-nested.proto
+++ b/packages/handlers/grpc/test/fixtures/proto-tests/nopackage-nested.proto
@@ -1,0 +1,24 @@
+syntax = "proto3";
+
+message Item {
+  string name = 1;
+}
+
+message TopLevel {
+  string value = 1;
+
+  message Nested {
+    Item movie = 2;
+  }
+
+  Nested nested_usage = 3;
+}
+
+message Result {
+  repeated Item result = 1;
+}
+
+
+service Example {
+  rpc Get (TopLevel.Nested) returns (Result) {}
+}

--- a/packages/handlers/grpc/test/fixtures/proto-tests/outside.proto
+++ b/packages/handlers/grpc/test/fixtures/proto-tests/outside.proto
@@ -1,0 +1,18 @@
+syntax = "proto3";
+
+package io.outside;
+
+import "movie.proto";
+
+message MovieRequest {
+  io.xtech.Movie movie = 1;
+}
+
+message MoviesResult {
+  repeated io.xtech.Movie result = 1;
+}
+
+
+service Example {
+  rpc GetMovies (MovieRequest) returns (MoviesResult) {}
+}

--- a/packages/handlers/grpc/test/fixtures/proto-tests/underscores.proto
+++ b/packages/handlers/grpc/test/fixtures/proto-tests/underscores.proto
@@ -1,0 +1,73 @@
+syntax = "proto3";
+
+package io.xtech;
+
+import "google/protobuf/timestamp.proto";
+
+enum Genre {
+    UNSPECIFIED = 0;
+    ACTION = 1;
+    DRAMA = 2;
+}
+
+/**
+ * movie message payload
+ */
+message Movie {
+    string name = 1;
+    int32 year = 2;
+    float rating = 3;
+
+    /**
+     * list of cast
+     */
+    repeated string cast = 4;
+    google.protobuf.Timestamp time = 5;
+    Genre genre = 6;
+}
+
+message EmptyRequest {}
+
+message movie_request {
+    Movie movie = 1;
+}
+
+message SearchByCastRequest {
+    string castName = 1;
+}
+
+/**
+ * movie result message, contains list of movies
+ */
+message MoviesResult {
+    /**
+     * list of movies
+     */
+    repeated Movie result = 1;
+}
+
+service Example {
+  /**
+  * get all movies
+  */
+  rpc GetMovies (movie_request) returns (MoviesResult) {}
+
+  /**
+  * search movies by the name of the cast
+  */
+  rpc SearchMoviesByCast (SearchByCastRequest) returns (stream Movie) {}
+
+}
+
+service AnotherExample {
+  /**
+  * get all movies
+  */
+  rpc GetMovies (movie_request) returns (MoviesResult) {}
+
+  /**
+  * search movies by the name of the cast
+  */
+  rpc SearchMoviesByCast (SearchByCastRequest) returns (stream Movie) {}
+
+}

--- a/packages/handlers/grpc/test/handler.spec.ts
+++ b/packages/handlers/grpc/test/handler.spec.ts
@@ -1,3 +1,28 @@
-describe('grpc', () => {
-  it('dummy', async () => {});
+import { join } from 'path';
+import { GraphQLSchema } from 'graphql';
+
+import handler from '../src';
+
+describe.each<[string, string, string]>([
+  ['Movie', 'io.xtech', 'movie.proto'],
+  ['Empty', 'io.xtech', 'empty.proto'],
+  ['Nested', 'io.xtech', 'nested.proto'],
+  ['With All Values', 'io.xtech', 'allvalues.proto'],
+  ['No Package Nested', '', 'nopackage-nested.proto'],
+  ['With Underscores', 'io.xtech', 'underscores.proto'],
+  ['Outide', 'io.outside', 'outside.proto'],
+])('Interpreting Protos', (name, packageName, file) => {
+  test(`should load the ${name} proto`, async () => {
+    const config = {
+      endpoint: 'localhost',
+      serviceName: 'Example',
+      packageName,
+      protoFilePath: {
+        file,
+        load: { includeDirs: [join(__dirname, './fixtures/proto-tests')] },
+      },
+    };
+    const { schema } = await handler.getMeshSource({ config });
+    expect(schema).toBeInstanceOf(GraphQLSchema);
+  });
 });

--- a/packages/handlers/grpc/test/scalars.spec.ts
+++ b/packages/handlers/grpc/test/scalars.spec.ts
@@ -1,0 +1,35 @@
+import { getGraphQLScalar, isScalarType } from '../src/scalars';
+
+describe.each<[string, string]>([
+  ['bool', 'Boolean'],
+  ['bytes', 'Byte'],
+  ['double', 'Float'],
+  ['fixed32', 'Int'],
+  ['fixed64', 'BigInt'],
+  ['float', 'Float'],
+  ['int32', 'Int'],
+  ['int64', 'BigInt'],
+  ['sfixed32', 'Int'],
+  ['sfixed64', 'BigInt'],
+  ['sint32', 'Int'],
+  ['sint64', 'BigInt'],
+  ['string', 'String'],
+  ['uint32', 'Int'],
+  ['uint64', 'BigInt'],
+])('Valid Scalars', (scalarType, scalarGqlType) => {
+  test(`getGraphQLScalar should return the proper graphql scalar for ${scalarType}`, () => {
+    expect(getGraphQLScalar(scalarType)).toBe(scalarGqlType);
+  });
+  test(`isScalarType should return true for ${scalarType}`, () => {
+    expect(isScalarType(scalarType)).toBe(true);
+  });
+});
+
+describe('Invalid Scalars', () => {
+  test('getGraphQLScalar should throw an error', () => {
+    expect(() => getGraphQLScalar('randomType')).toThrow(/Could not find GraphQL Scalar for type/);
+  });
+  test('isScalarType should return false for none scalars', () => {
+    expect(isScalarType('randomType')).toBe(false);
+  });
+});

--- a/packages/handlers/grpc/test/utils.spec.ts
+++ b/packages/handlers/grpc/test/utils.spec.ts
@@ -1,0 +1,138 @@
+import { Metadata } from '@grpc/grpc-js';
+import { SchemaComposer } from 'graphql-compose';
+
+import { addMetaDataToCall, createEnum, createFieldsType, getTypeName, toSnakeCase } from '../src/utils';
+
+describe('grpc utils', () => {
+  describe('addMetaDataToCall', () => {
+    const grpcClientMethod = jest.fn();
+    const input = { sport: 'Baseball' };
+    const context = { team: 'Oakland As', players: { pitcher: 'Kershaw' }, number: 42 };
+    const binarySportsTeam = Buffer.from([68, 111, 100, 103, 101, 114, 115, 32, 82, 117, 108, 101, 33]);
+    const binaryPlayer = Buffer.from([75, 101, 114, 115, 104, 97, 119]);
+
+    function createExpectedMetadata(key: string, value: string | Buffer): Metadata {
+      const meta = new Metadata();
+      meta.add(key, value);
+
+      return meta;
+    }
+
+    test(`when no metadata is supplied by the config`, () => {
+      addMetaDataToCall(grpcClientMethod, input, context, undefined);
+      expect(grpcClientMethod).toHaveBeenCalledWith(input);
+    });
+
+    describe.each<[string, Record<string, string | Buffer | string[]>, Metadata]>([
+      ['static', { sportsTeam: 'Dodgers' }, createExpectedMetadata('sportsTeam', 'Dodgers')],
+      ['static all lowercase', { sportsteam: 'Dodgers' }, createExpectedMetadata('sportsteam', 'Dodgers')],
+      ['dynamic', { bestPlayer: ['players', 'pitcher'] }, createExpectedMetadata('bestplayer', 'Kershaw')],
+      ['dynamic number', { jerseyNumber: ['number'] }, createExpectedMetadata('jerseynumber', '42')],
+      [
+        'dynamic underscore key',
+        { best_player: ['players', 'pitcher'] },
+        createExpectedMetadata('best_player', 'Kershaw'),
+      ],
+      [
+        'static binary',
+        { 'sportsTeam-bin': binarySportsTeam },
+        createExpectedMetadata('sportsTeam-bin', binarySportsTeam),
+      ],
+      ['dynamic binary', { 'bestPlayer-bin': binaryPlayer }, createExpectedMetadata('bestPlayer-bin', binaryPlayer)],
+    ])('should generate gRPC Metadata', (type, config, expectedMetadata) => {
+      beforeEach(() => {
+        grpcClientMethod.mockClear();
+      });
+
+      test(`when ${type} metadata is supplied by the config`, () => {
+        addMetaDataToCall(grpcClientMethod, input, context, config);
+        expect(grpcClientMethod).toHaveBeenCalledWith(input, expectedMetadata);
+      });
+    });
+
+    describe.each<[string, Record<string, string | Buffer | string[]>]>([
+      ['static binary', { sportsTeam: binarySportsTeam }],
+      ['dynamic binary', { bestPlayer: binaryPlayer }],
+    ])('should throw errors when generating gRPC Metadata', (type, config) => {
+      test(`when ${type} metadata is supplied by the config`, () => {
+        expect(() => addMetaDataToCall(grpcClientMethod, input, context, config)).toThrow(
+          /keys that don't end with '-bin' must have String values/
+        );
+      });
+    });
+  });
+
+  describe('createEnum', () => {
+    test('should create an enum with the proper type name and values', () => {
+      const typeName = 'Sports';
+      const fields = { BASEBALL: 0, BASKETBALL: 1 };
+
+      expect(createEnum(typeName, fields)).toEqual({
+        name: typeName,
+        values: { BASEBALL: { value: 0 }, BASKETBALL: { value: 1 } },
+      });
+    });
+  });
+
+  describe('getTypeName', () => {
+    const schemaComposer = new SchemaComposer();
+    const enumType = 'Arena';
+    schemaComposer.createEnumTC({ name: enumType, values: {} });
+    const inputFlag = 'Input';
+    const packageName = 'Sports';
+    const type = 'Team';
+
+    describe.each<[string, string]>([
+      ['bool', 'Boolean'],
+      ['bytes', 'Byte'],
+      ['double', 'Float'],
+      ['fixed32', 'Int'],
+      ['fixed64', 'BigInt'],
+      ['float', 'Float'],
+      ['int32', 'Int'],
+      ['int64', 'BigInt'],
+      ['sfixed32', 'Int'],
+      ['sfixed64', 'BigInt'],
+      ['sint32', 'Int'],
+      ['sint64', 'BigInt'],
+      ['string', 'String'],
+      ['uint32', 'Int'],
+      ['uint64', 'BigInt'],
+    ])('scalar types', (scalarType, scalarGqlType) => {
+      test(`should return the proper name for ${scalarType}`, () => {
+        expect(getTypeName(schemaComposer, scalarType, false, 'Sports')).toBe(scalarGqlType);
+      });
+
+      test(`should return the same name for ${scalarType} regardless of input status or package name`, () => {
+        expect(getTypeName(schemaComposer, scalarType, true, '')).toBe(scalarGqlType);
+      });
+    });
+
+    test('should return type without package name prefix', () => {
+      const fullTypeName = `${packageName}.Team`;
+
+      expect(getTypeName(schemaComposer, fullTypeName, false, packageName)).toBe(type);
+      expect(getTypeName(schemaComposer, fullTypeName, true, packageName)).toBe(type + inputFlag);
+    });
+
+    test('should return type with input flag postfix, when it is an input', () => {
+      expect(getTypeName(schemaComposer, type, true, packageName)).toBe(type + inputFlag);
+    });
+
+    test('should return type without input flag postfix, when it is an input, but also an enum in the schema', () => {
+      expect(getTypeName(schemaComposer, enumType, true, packageName)).toBe(enumType);
+    });
+  });
+
+  describe('createFieldsType', () => {
+    test('should create input and output field types', () => {
+      expect(createFieldsType('Dodgers')).toEqual({ input: 'DodgersInput', output: 'Dodgers' });
+    });
+  });
+
+  describe('toSnakeCase', () => {
+    test('should convert dot separated string to snake case', () => {
+      expect(toSnakeCase('Sports.Baseball.Team')).toEqual('Sports_Baseball_Team');
+    });
+  });
+});

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -21,10 +21,10 @@ export type MeshSource<ContextType = any, InitialContext = any> = {
 };
 
 export type GetMeshSourceOptions<THandlerConfig> = {
-  name: string;
-  hooks: Hooks;
+  name?: string;
+  hooks?: Hooks;
   config: THandlerConfig;
-  cache: KeyValueCache;
+  cache?: KeyValueCache;
 };
 
 // Handlers


### PR DESCRIPTION
**New Functionatlity**
- Protobuf supports an empty type, add support for those types in
  graphql
- Protobuf messages can be defined in a nested way. Support this
  nested way of defining and referencing proto messages.

**Refactor**
- Move helper functions to utils into their own file.
- Move scalar related stuff into it's own file. This will allow for
  manipulating scalar mappings externally.

**Tests**
- Add helper function unit tests.
- Add tests for valid proto file use cases.