### PR TITLE
fix(openapi): handle integers better for enums and 64-bit values

### DIFF
--- a/packages/handlers/openapi/src/openapi-to-graphql/oas_3_tools.ts
+++ b/packages/handlers/openapi/src/openapi-to-graphql/oas_3_tools.ts
@@ -411,7 +411,7 @@ export function getSchemaTargetGraphQLType(schema: SchemaObject, data: Preproces
   }
 
   // CASE: enum
-  if (schema.type === 'string' && Array.isArray(schema.enum)) {
+  if (schema.type !== 'integer' && Array.isArray(schema.enum)) {
     return 'enum';
   }
 
@@ -424,7 +424,7 @@ export function getSchemaTargetGraphQLType(schema: SchemaObject, data: Preproces
        * GraphQLFloat, which can support 64 bits:
        */
       if (schema.type === 'integer' && schema.format === 'int64') {
-        return 'number';
+        return 'int64';
 
         // CASE: id
       } else if (

--- a/packages/handlers/openapi/src/openapi-to-graphql/oas_3_tools.ts
+++ b/packages/handlers/openapi/src/openapi-to-graphql/oas_3_tools.ts
@@ -410,13 +410,12 @@ export function getSchemaTargetGraphQLType(schema: SchemaObject, data: Preproces
     return 'list';
   }
 
-  // CASE: enum
-  if (Array.isArray(schema.enum)) {
-    return 'enum';
-  }
-
   // CASE: a type is present
   if (typeof schema.type === 'string') {
+    // CASE: enum
+    if (Array.isArray(schema.enum)) {
+      return 'enum';
+    }
     // Special edge cases involving the schema format
     if (typeof schema.format === 'string') {
       /**

--- a/packages/handlers/openapi/src/openapi-to-graphql/oas_3_tools.ts
+++ b/packages/handlers/openapi/src/openapi-to-graphql/oas_3_tools.ts
@@ -410,12 +410,13 @@ export function getSchemaTargetGraphQLType(schema: SchemaObject, data: Preproces
     return 'list';
   }
 
+  // CASE: enum
+  if (schema.type === 'string' && Array.isArray(schema.enum)) {
+    return 'enum';
+  }
+
   // CASE: a type is present
   if (typeof schema.type === 'string') {
-    // CASE: enum
-    if (Array.isArray(schema.enum)) {
-      return 'enum';
-    }
     // Special edge cases involving the schema format
     if (typeof schema.format === 'string') {
       /**

--- a/packages/handlers/openapi/src/openapi-to-graphql/schema_builder.ts
+++ b/packages/handlers/openapi/src/openapi-to-graphql/schema_builder.ts
@@ -38,7 +38,7 @@ import { getResolver } from './resolver_builder';
 import { createDataDef } from './preprocessor';
 import debug from 'debug';
 import { handleWarning, sortObject } from './utils';
-import { GraphQLJSON } from 'graphql-scalars';
+import { GraphQLJSON, GraphQLBigInt } from 'graphql-scalars';
 
 type GetArgsParams = {
   requestPayloadDef?: DataDefinition;
@@ -478,6 +478,9 @@ function getScalarType({ def }: CreateOrReuseSimpleTypeParams): GraphQLScalarTyp
       break;
     case 'integer':
       def.graphQLType = GraphQLInt;
+      break;
+    case 'int64':
+      def.graphQLType = GraphQLBigInt;
       break;
     case 'number':
       def.graphQLType = GraphQLFloat;

--- a/packages/handlers/openapi/test/__snapshots__/handler.spec.ts.snap
+++ b/packages/handlers/openapi/test/__snapshots__/handler.spec.ts.snap
@@ -49,13 +49,13 @@ type Query {
     maxId: String
 
     \\"\\"\\"Return media before this UNIX timestamp.\\"\\"\\"
-    maxTimestamp: Float
+    maxTimestamp: BigInt
 
     \\"\\"\\"Return media before this \`min_id\`.\\"\\"\\"
     minId: String
 
     \\"\\"\\"Return media after this UNIX timestamp.\\"\\"\\"
-    minTimestamp: Float
+    minTimestamp: BigInt
   ): MediaListResponse
 
   \\"\\"\\"
@@ -156,12 +156,12 @@ type Query {
     \\"\\"\\"
     A unix timestamp. All media returned will be taken earlier than this timestamp.
     \\"\\"\\"
-    maxTimestamp: Float
+    maxTimestamp: BigInt
 
     \\"\\"\\"
     A unix timestamp. All media returned will be taken later than this timestamp.
     \\"\\"\\"
-    minTimestamp: Float
+    minTimestamp: BigInt
   ): MediaSearchResponse
 
   \\"\\"\\"
@@ -331,13 +331,13 @@ type Query {
     maxId: String
 
     \\"\\"\\"Return media before this UNIX timestamp.\\"\\"\\"
-    maxTimestamp: Float
+    maxTimestamp: BigInt
 
     \\"\\"\\"Return media later than this \`min_id\`.\\"\\"\\"
     minId: String
 
     \\"\\"\\"Return media after this UNIX timestamp.\\"\\"\\"
-    minTimestamp: Float
+    minTimestamp: BigInt
 
     \\"\\"\\"
     The ID of a user to get recent media of, or **self** to retrieve media of authenticated user.
@@ -533,6 +533,11 @@ type LocationInfoResponse {
   meta: MetaData
 }
 
+\\"\\"\\"
+The \`BigInt\` scalar type represents non-fractional signed whole numeric values.
+\\"\\"\\"
+scalar BigInt
+
 type LocationSearchResponse {
   \\"\\"\\"List of found locations\\"\\"\\"
   data: [LocationInfo]
@@ -570,7 +575,7 @@ type TagSearchResponse {
 
 type TagInfo {
   \\"\\"\\"Overall number of media entries taged with this name\\"\\"\\"
-  mediaCount: Float
+  mediaCount: BigInt
 
   \\"\\"\\"Tag name\\"\\"\\"
   name: String

--- a/packages/handlers/openapi/test/example_api.test.ts
+++ b/packages/handlers/openapi/test/example_api.test.ts
@@ -631,7 +631,7 @@ test('Ensure good naming for operations with duplicated schemas', () => {
  * CASE: 64 bit int - return number instead of integer, leading to use of
  * GraphQLFloat, which can support 64 bits:
  */
-test('Get response containing 64-bit integer (using GraphQLFloat)', () => {
+test('Get response containing 64-bit integer (using GraphQLBigInt)', () => {
   const query = `{
     productReviews (id: "100") {
       timestamp
@@ -641,7 +641,7 @@ test('Get response containing 64-bit integer (using GraphQLFloat)', () => {
   return graphql(createdSchema, query).then(result => {
     expect(result).toEqual({
       data: {
-        productReviews: [{ timestamp: 1502787600000000 }, { timestamp: 1502787400000000 }],
+        productReviews: [{ timestamp: 1502787600000000n }, { timestamp: 1502787400000000n }],
       },
     });
   });
@@ -929,24 +929,6 @@ test('Capitalized enum values can be returned', () => {
       data: {
         car: {
           kind: 'SEDAN',
-        },
-      },
-    });
-  });
-});
-
-test('Enum values that started as numbers in OAS can be returned as strings', () => {
-  const query = `{
-    car (username: "arlene") {
-      rating
-    }
-  }`;
-
-  return graphql(createdSchema, query, null, {}).then(result => {
-    expect(result).toEqual({
-      data: {
-        car: {
-          rating: '_100',
         },
       },
     });


### PR DESCRIPTION
- Do not create enum types for integer because GraphQL doesn't support enums with numeric keys
- Use GraphQLBigInt for 64-bit integers instead of `GraphQLFloat`.
