### PR TITLE
fix(handlers): grpc empty proto

### DIFF
--- a/.changeset/tiny-cherries-happen.md
+++ b/.changeset/tiny-cherries-happen.md
@@ -1,0 +1,5 @@
+---
+'@graphql-mesh/grpc': patch
+---
+
+Fix empty proto message behavior. Include `_` field only in empty protobuf definitions

--- a/packages/handlers/grpc/src/utils.ts
+++ b/packages/handlers/grpc/src/utils.ts
@@ -118,7 +118,7 @@ export function createFieldsType(typeName: string): InputOutputTypes {
   };
 }
 
-async function addInputOutputFields(
+export async function addInputOutputFields(
   schemaComposer: SchemaComposer<unknown>,
   inputTC: InputTypeComposer,
   outputTC: ObjectTypeComposer,
@@ -128,7 +128,7 @@ async function addInputOutputFields(
   packageName: string
 ): Promise<void> {
   const fieldKeys = Object.keys(fields);
-  if (!fields.length) {
+  if (!fieldKeys.length) {
     // This is a empty proto type
     inputTC.addFields({
       _: {

--- a/packages/handlers/grpc/test/handler.spec.ts
+++ b/packages/handlers/grpc/test/handler.spec.ts
@@ -4,6 +4,7 @@ import { GraphQLSchema } from 'graphql';
 import handler from '../src';
 import InMemoryLRUCache from '@graphql-mesh/cache-inmemory-lru';
 import { EventEmitter } from 'events';
+import { validateSchema } from 'graphql';
 import { Hooks } from '@graphql-mesh/types';
 
 describe.each<[string, string, string]>([
@@ -29,5 +30,6 @@ describe.each<[string, string, string]>([
     };
     const { schema } = await handler.getMeshSource({ name: Date.now().toString(), config, cache, hooks });
     expect(schema).toBeInstanceOf(GraphQLSchema);
+    expect(validateSchema(schema)).toHaveLength(0);
   });
 });

--- a/packages/handlers/grpc/test/utils.spec.ts
+++ b/packages/handlers/grpc/test/utils.spec.ts
@@ -1,7 +1,14 @@
 import { Metadata } from '@grpc/grpc-js';
 import { SchemaComposer } from 'graphql-compose';
 
-import { addMetaDataToCall, createEnum, createFieldsType, getTypeName, toSnakeCase } from '../src/utils';
+import {
+  addInputOutputFields,
+  addMetaDataToCall,
+  createEnum,
+  createFieldsType,
+  getTypeName,
+  toSnakeCase,
+} from '../src/utils';
 
 describe('grpc utils', () => {
   describe('addMetaDataToCall', () => {
@@ -133,6 +140,40 @@ describe('grpc utils', () => {
   describe('toSnakeCase', () => {
     test('should convert dot separated string to snake case', () => {
       expect(toSnakeCase('Sports.Baseball.Team')).toEqual('Sports_Baseball_Team');
+    });
+  });
+
+  describe('addInputOutputFields', () => {
+    test('should add `_` field for empty protos', async () => {
+      const schemaComposer = new SchemaComposer();
+      const inputTC = schemaComposer.createInputTC({
+        name: 'input',
+        fields: {},
+      });
+      const outputTC = schemaComposer.createObjectTC({
+        name: 'output',
+        fields: {},
+      });
+      const fields = {};
+      await addInputOutputFields(schemaComposer, inputTC, outputTC, fields);
+      expect(inputTC.getFields()).toHaveProperty('_', expect.anything());
+      expect(outputTC.getFields()).toHaveProperty('_', expect.anything());
+    });
+
+    test('should add not `_` field for non empty protos', async () => {
+      const schemaComposer = new SchemaComposer();
+      const inputTC = schemaComposer.createInputTC({
+        name: 'input',
+        fields: {},
+      });
+      const outputTC = schemaComposer.createObjectTC({
+        name: 'output',
+        fields: {},
+      });
+      const fields = { someField: { type: 'string', name: 'someField', id: 0 } };
+      await addInputOutputFields(schemaComposer, inputTC, outputTC, fields);
+      expect(inputTC.getFields()).not.toHaveProperty('_', expect.anything());
+      expect(outputTC.getFields()).not.toHaveProperty('_', expect.anything());
     });
   });
 });


### PR DESCRIPTION
Should only be creating a `_` field for empty protos, not all proto
definitions.

- Add a test to verify the correct behavior
- Fix this oversight in `addInputOutputFields`