### PR TITLE
added additional configs to postgraphile handler

### DIFF
--- a/packages/handlers/postgraphile/src/index.ts
+++ b/packages/handlers/postgraphile/src/index.ts
@@ -29,8 +29,13 @@ const handler: MeshHandlerLibrary<YamlConfig.PostGraphileHandler> = {
     let writeCache: () => Promise<void>;
 
     const appendPlugins = await Promise.all<Plugin>(
-      (config.plugins || []).map(pluginName => loadFromModuleExportExpression(pluginName, 'default'))
+      (config.appendPlugins || []).map(pluginName => loadFromModuleExportExpression(pluginName))
     );
+    const skipPlugins = await Promise.all<Plugin>(
+      (config.skipPlugins || []).map(pluginName => loadFromModuleExportExpression(pluginName))
+    );
+    const options =
+      typeof config.options === 'string' ? await loadFromModuleExportExpression(config.options) : config.options;
 
     const builder = await getPostGraphileBuilder(pgPool, config.schemaName || 'public', {
       dynamicJson: true,
@@ -42,6 +47,8 @@ const handler: MeshHandlerLibrary<YamlConfig.PostGraphileHandler> = {
         writeCache = fn;
       },
       appendPlugins,
+      skipPlugins,
+      ...options,
     });
 
     const graphileSchema = builder.buildSchema();

--- a/packages/types/src/config.ts
+++ b/packages/types/src/config.ts
@@ -518,9 +518,17 @@ export interface PostGraphileHandler {
    */
   cacheIntrospection?: boolean;
   /**
-   * Extra Postgraphile Plugins
+   * Extra Postgraphile Plugins to append
    */
-  plugins?: string[];
+  appendPlugins?: string[];
+  /**
+   * Postgraphile Plugins to skip (e.g. "graphile-build#NodePlugin")
+   */
+  skipPlugins?: string[];
+  /**
+   * Extra Postgraphile options that will be added to the postgraphile constructor. It can either be an object or a string pointing to the object's path (e.g. "./my-config#options"). See the [postgraphile docs](https://www.graphile.org/postgraphile/usage-library/) for more information.
+   */
+  options?: string | JSON;
 }
 /**
  * Connection Pool settings


### PR DESCRIPTION
* added a `skipPlugins` option, similar to the `plugins` option.

* added an `options` field to allow passing additional configuration to the `postgraphile` constructor.

* renamed `plugins` to `appendPlugins` to further distinguish between new options.

I needed the ability to add more fine-tuned configuration to the postgraphile handler, so I'm opening this PR to add that capability. The most powerful feature is the ability to point the new `options` config field to an exported js object that can include plugin functions and other complex js objects within it. Let me know if you have any concerns. Thank you!