### PR TITLE
fix(docs): Remove leading $ to fix copy

### DIFF
--- a/website/docs/getting-started/basic-example.md
+++ b/website/docs/getting-started/basic-example.md
@@ -17,7 +17,7 @@ sources:
 This demo will use the public API pf Wikipedia, which uses `openapi` spec, so we'll need to make sure we have `@graphql-mesh/openapi` handler installed as well:
 
 ```
-$ yarn add graphql @graphql-mesh/openapi
+yarn add graphql @graphql-mesh/openapi
 ```
 
 ### Try your new API
@@ -27,7 +27,7 @@ GraphQL Mesh comes with a built in GraphiQL interface, so it means that you can 
 To test your new GraphQL API based on your API specs, you can run:
 
 ```
-$ yarn graphql-mesh serve
+yarn graphql-mesh serve
 ```
 
 This will serve a GraphiQL interface with your schema, so you'll be able to test it right away, before intergrating it to your application, you can try to run a test query.
@@ -68,7 +68,7 @@ Start by load and parsing your configuration file, and pass it to `getMesh`, thi
 You need to install `@graphql-mesh/runtime` and `@graphql-mesh/config` to access GraphQL Mesh Schema inside your code.
 
 ```
-$ yarn add @graphql-mesh/runtime
+yarn add @graphql-mesh/runtime
 ```
 
 ```js

--- a/website/docs/getting-started/installation.md
+++ b/website/docs/getting-started/installation.md
@@ -9,7 +9,7 @@ GraphQL Mesh comes in multiple packages, which you should install according to y
 To get started with the basics, install the following:
 
 ```
-$ yarn add graphql @graphql-mesh/cli
+yarn add graphql @graphql-mesh/cli
 ```
 
 Then, you need to install a Mesh handler, according to your API needs. You can see the list of [all available built-in handlers in here](/docs/handlers/available-handlers).
@@ -17,7 +17,7 @@ Then, you need to install a Mesh handler, according to your API needs. You can s
 For example, if you wish to use OpenAPI handler, install the handler that matches you needs:
 
 ```
-$ yarn add graphql @graphql-mesh/openapi
+yarn add graphql @graphql-mesh/openapi
 ```
 
 Then, this handler will be available for you to use in your config file.


### PR DESCRIPTION
Removes leading $ from commands so that the result of copy can be used directly.