### PR TITLE
feat(openapi): add sourceFormat option to provide schema format explicitly

### DIFF
--- a/.changeset/nice-frogs-vanish.md
+++ b/.changeset/nice-frogs-vanish.md
@@ -1,0 +1,7 @@
+---
+'@graphql-mesh/openapi': minor
+'@graphql-mesh/types': minor
+'@graphql-mesh/utils': minor
+---
+
+feat(openapi): add sourceFormat option to provide schema format explicitly

--- a/packages/handlers/openapi/src/index.ts
+++ b/packages/handlers/openapi/src/index.ts
@@ -34,6 +34,7 @@ export default class OpenAPIHandler implements MeshHandler {
     const path = this.config.source;
     const spec = await readFileOrUrlWithCache<Oas3>(path, this.cache, {
       headers: this.config.schemaHeaders,
+      fallbackFormat: this.config.sourceFormat,
     });
 
     let fetch: WindowOrWorkerGlobalScope['fetch'];

--- a/packages/handlers/openapi/yaml-config.graphql
+++ b/packages/handlers/openapi/yaml-config.graphql
@@ -11,6 +11,10 @@ type OpenapiHandler @md {
   """
   source: String!
   """
+  Format of the source file
+  """
+  sourceFormat: SourceFormat
+  """
   JSON object representing the Headers to add to the runtime of the API calls
   """
   operationHeaders: JSON
@@ -35,4 +39,9 @@ type OpenapiHandler @md {
   Include HTTP Response details to the result object
   """
   includeHttpDetails: Boolean
+}
+
+enum SourceFormat {
+  json
+  yaml
 }

--- a/packages/types/src/config-schema.json
+++ b/packages/types/src/config-schema.json
@@ -1188,6 +1188,11 @@
           "type": "string",
           "description": "A pointer to your API source - could be a local file, remote file or url endpoint"
         },
+        "sourceFormat": {
+          "type": "string",
+          "enum": ["json", "yaml"],
+          "description": "Format of the source file (Allowed values: json, yaml)"
+        },
         "operationHeaders": {
           "type": "object",
           "properties": {},

--- a/packages/types/src/config.ts
+++ b/packages/types/src/config.ts
@@ -512,6 +512,10 @@ export interface OpenapiHandler {
    */
   source: string;
   /**
+   * Format of the source file (Allowed values: json, yaml)
+   */
+  sourceFormat?: 'json' | 'yaml';
+  /**
    * JSON object representing the Headers to add to the runtime of the API calls
    */
   operationHeaders?: {

--- a/packages/utils/src/read-file-or-url.ts
+++ b/packages/utils/src/read-file-or-url.ts
@@ -7,6 +7,7 @@ export { isUrl };
 
 interface ReadFileOrUrlOptions extends RequestInit {
   allowUnknownExtensions?: boolean;
+  fallbackFormat?: 'json' | 'yaml';
 }
 
 export async function readFileOrUrlWithCache<T>(
@@ -41,6 +42,15 @@ export async function readFileWithCache<T>(
     result = JSON.parse(result);
   } else if (/yaml$/.test(filePath) || /yml$/.test(filePath)) {
     result = loadYaml(result);
+  } else if (config?.fallbackFormat) {
+    switch (config.fallbackFormat) {
+      case 'json':
+        result = JSON.parse(result);
+        break;
+      case 'yaml':
+        result = loadYaml(result);
+        break;
+    }
   } else if (!config?.allowUnknownExtensions) {
     throw new Error(
       `Failed to parse JSON/YAML. Ensure file '${filePath}' has ` +


### PR DESCRIPTION
Related #955 
Some URLs don't have file extension or mime type information on HTTP headers. Now user is able to define `sourceFormat` in the configuration;
```
sources:
  name: Kube
    handler:
      openapi:
        source: http://localhost:8003/openapi/v2
        sourceFormat: json
        baseUrl: http://localhost:8003/
```