### PR TITLE
Fix default port in config

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -33,7 +33,7 @@ export async function graphqlMesh() {
           const { schema, contextBuilder, pubsub } = await getMesh(meshConfig);
           const serveConfig = meshConfig.config.serve || {};
           serveConfig.port = args.port || parseInt(process.env.PORT) || serveConfig.port || 4000;
-          await serveMesh(logger, schema, contextBuilder, pubsub, meshConfig.config.serve);
+          await serveMesh(logger, schema, contextBuilder, pubsub, serveConfig);
         } catch (e) {
           logger.error('Unable to serve mesh: ', e);
         }


### PR DESCRIPTION
In case `meshConfig.config.serve` is `undefined`, `serveConfig` is initialized with a new object which gets the port added, but afterwards `undefined` is passed to the `serveMesh` function.

Fixes #1012