### PR TITLE
feat(grpc): add https connection config

### DIFF
--- a/.changeset/tricky-queens-enjoy.md
+++ b/.changeset/tricky-queens-enjoy.md
@@ -1,0 +1,6 @@
+---
+'@graphql-mesh/grpc': patch
+'@graphql-mesh/types': patch
+---
+
+Add 'useHTTPS' flag to gRPC config to allow SSL connections without providing a root CA

--- a/packages/handlers/grpc/src/index.ts
+++ b/packages/handlers/grpc/src/index.ts
@@ -60,6 +60,8 @@ export default class GrpcHandler implements MeshHandler {
       }
       const [rootCA, privateKey, certChain] = await Promise.all(sslFiles);
       creds = credentials.createSsl(rootCA, privateKey, certChain);
+    } else if (this.config.useHTTPS) {
+      creds = credentials.createSsl();
     } else {
       creds = credentials.createInsecure();
     }

--- a/packages/handlers/grpc/yaml-config.graphql
+++ b/packages/handlers/grpc/yaml-config.graphql
@@ -34,6 +34,10 @@ type GrpcHandler @md {
   """
   credentialsSsl: GrpcCredentialsSsl
   """
+  Use https instead of http for gRPC connection
+  """
+  useHTTPS: Boolean
+  """
   MetaData
   """
   metaData: JSON

--- a/packages/types/src/config-schema.json
+++ b/packages/types/src/config-schema.json
@@ -546,6 +546,10 @@
           "$ref": "#/definitions/GrpcCredentialsSsl",
           "description": "SSL Credentials"
         },
+        "useHTTPS": {
+          "type": "boolean",
+          "description": "Use https instead of http for gRPC connection"
+        },
         "metaData": {
           "type": "object",
           "properties": {},

--- a/packages/types/src/config.ts
+++ b/packages/types/src/config.ts
@@ -189,6 +189,10 @@ export interface GrpcHandler {
   requestTimeout?: number;
   credentialsSsl?: GrpcCredentialsSsl;
   /**
+   * Use https instead of http for gRPC connection
+   */
+  useHTTPS?: boolean;
+  /**
    * MetaData
    */
   metaData?: {


### PR DESCRIPTION
Allow GRPC connections to go over https. Previously this would only
happen when a root CA was provided. There are cases where instead of
providing a root CA, a CA like letencrypt is used to validate the
cert authority. In this case we want to create a secure connnection
by calling `createSsl` without any options.

This can now be done via the config option `useHTTPS`.