### PR TITLE
feat(graphql): Allow providing static schema

### DIFF
--- a/.changeset/gentle-berries-mate.md
+++ b/.changeset/gentle-berries-mate.md
@@ -1,0 +1,16 @@
+---
+'@graphql-mesh/graphql': minor
+'@graphql-mesh/types': minor
+---
+
+## What the change is
+
+Allows providing a static schema definition to the GraphQL handler
+
+## Why the change was made
+
+Network requests to fetch a runtime introspection query cause problems in static workflows (e.g. type generation).
+
+## How a consumer should update their code
+
+Add a list of paths under the `schema` field in the handler config. This will be used to load the schema using [GraphQL Tools](https://www.graphql-tools.com/docs/schema-loading/). If the schema is omitted, a runtime introspection will be used as before.

--- a/packages/handlers/graphql/package.json
+++ b/packages/handlers/graphql/package.json
@@ -16,6 +16,9 @@
     "@graphql-mesh/types": "0.16.0",
     "@graphql-mesh/utils": "0.6.0",
     "fetchache": "0.0.4",
+    "@graphql-tools/code-file-loader": "6.2.5",
+    "@graphql-tools/graphql-file-loader": "6.2.4",
+    "@graphql-tools/load": "6.2.5",
     "@graphql-tools/url-loader": "6.3.0",
     "@graphql-tools/wrap": "6.2.3"
   },

--- a/packages/handlers/graphql/yaml-config.graphql
+++ b/packages/handlers/graphql/yaml-config.graphql
@@ -39,6 +39,10 @@ type GraphQLHandler @md {
   """
   webSocketImpl: String
   """
+  Paths to the schema
+  """
+  schema: [String]
+  """
   Path to the introspection
   You can seperately give schema introspection
   """

--- a/packages/types/src/config-schema.json
+++ b/packages/types/src/config-schema.json
@@ -485,6 +485,14 @@
           "type": "string",
           "description": "Path to a custom W3 Compatible WebSocket Implementation"
         },
+        "schema": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "additionalItems": false,
+          "description": "Paths to the schema"
+        },
         "introspection": {
           "type": "string",
           "description": "Path to the introspection\nYou can seperately give schema introspection"

--- a/packages/types/src/config.ts
+++ b/packages/types/src/config.ts
@@ -146,6 +146,10 @@ export interface GraphQLHandler {
    */
   webSocketImpl?: string;
   /**
+   * Paths to the schema
+   */
+  schema?: string[];
+  /**
    * Path to the introspection
    * You can seperately give schema introspection
    */


### PR DESCRIPTION
Continuation of #1069. 

## What does this PR do?

Adds an additional configuration option `schema?: string[]` to the GraphQL handler. This new option is used to load the schema for the corresponding handler.

## What problem does it solve?

Currently the schema is fetched at startup with an introspection query to the configured endpoint. This has a few problems, most notably that the introspection may not be available.

Our specific use case is to mesh together multiple services and then run graphql-codegen on the resulting schema. We wish to be able to load the schema in the same manner as the code generator, i.e. via the multiple sources accepted by graphql-tools.


```diff
 sources:
   - name: Example
     handler:
       graphql:
         endpoint: http://example.com/graphql
+        schema:
+          - src/schema.graphql
 ```

This allows [comsuming the schema in code](https://graphql-mesh.com/docs/getting-started/basic-example#consuming-mesh-schema-in-code) without a remote network request which would otherwise make certain workflows very difficult if not impossible. It very closely resembles the [`schema` field](https://graphql-code-generator.com/docs/getting-started/schema-field) of GraphQL Code Generator.
