### PR TITLE
OpenAPI: fix and tune add limit argument

### DIFF
--- a/.changeset/warm-monkeys-dance.md
+++ b/.changeset/warm-monkeys-dance.md
@@ -1,0 +1,10 @@
+---
+'@graphql-mesh/openapi': patch
+'@graphql-mesh/types': patch
+---
+
+feat(openapi): addLinitArgument is configurable
+
+fix(openapi): auto generated limit value is not mandatory
+
+fix(openapi): generate limit parameter for composed types

--- a/packages/handlers/openapi/src/index.ts
+++ b/packages/handlers/openapi/src/index.ts
@@ -62,7 +62,7 @@ export default class OpenAPIHandler implements MeshHandler {
       operationIdFieldNames: true,
       fillEmptyResponses: true,
       includeHttpDetails: this.config.includeHttpDetails,
-      addLimitArgument: true,
+      addLimitArgument: this.config.addLimitArgument === undefined ? true : this.config.addLimitArgument,
       sendOAuthTokenInQuery: true,
       viewer: false,
       equivalentToMessages: true,

--- a/packages/handlers/openapi/src/openapi-to-graphql/resolver_builder.ts
+++ b/packages/handlers/openapi/src/openapi-to-graphql/resolver_builder.ts
@@ -684,20 +684,17 @@ export function getResolver<TSource, TContext, TArgs>(
             // Only array of objects/arrays
             saneData.some(data => {
               return typeof data === 'object';
-            })
+            }) &&
+            'limit' in args
           ) {
             let arraySaneData = saneData;
 
-            if ('limit' in args) {
-              const limit = args.limit;
+            const limit = args.limit;
 
-              if (limit >= 0) {
-                arraySaneData = arraySaneData.slice(0, limit);
-              } else {
-                throw new Error(`Auto-generated 'limit' argument must be greater than or equal to 0`);
-              }
+            if (limit >= 0) {
+              arraySaneData = arraySaneData.slice(0, limit);
             } else {
-              throw new Error(`Cannot get value for auto-generated 'limit' argument`);
+              throw new Error(`Auto-generated 'limit' argument must be greater than or equal to 0`);
             }
 
             saneData = arraySaneData;

--- a/packages/handlers/openapi/src/openapi-to-graphql/schema_builder.ts
+++ b/packages/handlers/openapi/src/openapi-to-graphql/schema_builder.ts
@@ -1145,7 +1145,11 @@ export function getArgs<TSource, TContext, TArgs>({
     operation.responseDefinition.schema.type === 'array' &&
     // Only add limit argument to lists of object types, not to lists of scalar types
     ((operation.responseDefinition.subDefinitions as DataDefinition).schema.type === 'object' ||
-      (operation.responseDefinition.subDefinitions as DataDefinition).schema.type === 'array')
+      (operation.responseDefinition.subDefinitions as DataDefinition).schema.type === 'array' ||
+      ((operation.responseDefinition.subDefinitions as DataDefinition).schema.type === undefined &&
+        ((operation.responseDefinition.subDefinitions as DataDefinition).schema.allOf ||
+          (operation.responseDefinition.subDefinitions as DataDefinition).schema.anyOf ||
+          (operation.responseDefinition.subDefinitions as DataDefinition).schema.oneOf)))
   ) {
     // Make sure slicing arguments will not overwrite preexisting arguments
     if ('limit' in args) {

--- a/packages/handlers/openapi/test/example_api_combined.test.ts
+++ b/packages/handlers/openapi/test/example_api_combined.test.ts
@@ -55,3 +55,26 @@ test('addLimitArgument and allOf', () => {
     });
   });
 });
+
+test('addLimitArgument but no value provided', () => {
+  const options: Options<any, any, any> = {
+    addLimitArgument: true,
+    fetch,
+  };
+
+  const query = `query {
+    cars {
+      model
+    }
+  }`;
+
+  return openAPIToGraphQL.createGraphQLSchema(oas, options).then(({ schema }) => {
+    const ast = parse(query);
+    const errors = validate(schema, ast);
+    expect(errors).toEqual([]);
+    return graphql(schema, query).then(result => {
+      expect(result.errors).toBeUndefined();
+      expect(result.data.cars.length).toEqual(4);
+    });
+  });
+});

--- a/packages/handlers/openapi/test/example_api_combined.test.ts
+++ b/packages/handlers/openapi/test/example_api_combined.test.ts
@@ -1,0 +1,57 @@
+'use strict';
+
+/* globals beforeAll, test, expect */
+
+import { graphql, parse, validate } from 'graphql';
+
+import * as openAPIToGraphQL from '../src/openapi-to-graphql/index';
+import { Options } from '../src/openapi-to-graphql/types/options';
+import { startServer, stopServer } from './example_api_server';
+import fetch from 'cross-fetch';
+
+const oas = require('./fixtures/example_oas_combined.json');
+const PORT = 3010;
+// Update PORT for this test case:
+oas.servers[0].variables.port.default = String(PORT);
+
+/**
+ * Set up the schema first and run example API server
+ */
+beforeAll(() => {
+  return Promise.all([
+    openAPIToGraphQL.createGraphQLSchema(oas, {
+      fillEmptyResponses: true,
+      fetch,
+    }),
+    startServer(PORT),
+  ]);
+});
+
+/**
+ * Shut down API server
+ */
+afterAll(() => {
+  return stopServer();
+});
+
+test('addLimitArgument and allOf', () => {
+  const options: Options<any, any, any> = {
+    addLimitArgument: true,
+    fetch,
+  };
+
+  const query = `query {
+    cars(limit: 1) {
+      model
+    }
+  }`;
+
+  return openAPIToGraphQL.createGraphQLSchema(oas, options).then(({ schema }) => {
+    const ast = parse(query);
+    const errors = validate(schema, ast);
+    expect(errors).toEqual([]);
+    return graphql(schema, query).then(result => {
+      expect(result.data.cars.length).toEqual(1);
+    });
+  });
+});

--- a/packages/handlers/openapi/test/fixtures/example_oas_combined.json
+++ b/packages/handlers/openapi/test/fixtures/example_oas_combined.json
@@ -1,0 +1,122 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Example API combined",
+    "description": "An API to test converting Open API Specs 3.0 to GraphQL",
+    "version": "1.0.0",
+    "termsOfService": "http://example.com/terms/",
+    "contact": {
+      "name": "Erik Wittern",
+      "url": "http://www.example.com/support"
+    },
+    "license": {
+      "name": "Apache 2.0",
+      "url": "http://www.apache.org/licenses/LICENSE-2.0.html"
+    }
+  },
+  "externalDocs": {
+    "url": "http://example.com/docs",
+    "description": "Some more natural language description."
+  },
+  "tags": [
+    {
+      "name": "test",
+      "description": "Indicates this API is for testing"
+    }
+  ],
+  "servers": [
+    {
+      "url": "http://localhost:{port}/{basePath}",
+      "description": "The location of the local test server.",
+      "variables": {
+        "port": {
+          "default": "3004"
+        },
+        "basePath": {
+          "default": "api"
+        }
+      }
+    }
+  ],
+  "paths": {
+    "/cars": {
+      "get": {
+        "operationId": "getAllCars",
+        "description": "Returns information about all employee cars",
+        "responses": {
+          "200": {
+            "description": "Everyone's cars",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "allOf": [
+                      {
+                        "$ref": "#/components/schemas/car"
+                      },
+                      {
+                        "$ref": "#/components/schemas/hasTags"
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "car": {
+        "type": "object",
+        "description": "A car",
+        "properties": {
+          "model": {
+            "type": "string",
+            "description": "The model of the car."
+          },
+          "color": {
+            "type": "string",
+            "description": "The color of the car."
+          },
+          "features": {
+            "properties": {}
+          },
+          "tags": {
+            "$ref": "#/components/schemas/tags"
+          },
+          "kind": {
+            "type": "string",
+            "enum": ["SEDAN", "SUV", "MINIVAN", "LIMOSINE", "RACE_CAR"]
+          },
+          "rating": {
+            "type": "number",
+            "enum": [100, 101, 200],
+            "description": "The rating of the car."
+          }
+        }
+      },
+      "hasTags": {
+        "type": "object",
+        "description": "A thing with tags",
+        "properties": {
+          "tags": {
+            "$ref": "#/components/schemas/tags"
+          }
+        }
+      },
+      "tags": {
+        "type": "object",
+        "title": "Tags",
+        "description": "Arbitrary (string) tags describing an entity.",
+        "additionalProperties": {
+          "type": "string"
+        }
+      }
+    }
+  },
+  "security": []
+}

--- a/packages/handlers/openapi/test/handler.spec.ts
+++ b/packages/handlers/openapi/test/handler.spec.ts
@@ -18,4 +18,41 @@ describe('openapi', () => {
 
     expect(printSchemaWithDirectives(source.schema)).toMatchSnapshot();
   });
+
+  it('should create a GraphQL schema from a simple local openapi file, adding limit arg', async () => {
+    const handler = new OpenAPIHandler({
+      name: 'Example OAS3',
+      config: {
+        source: resolve(__dirname, './fixtures/example_oas_combined.json'),
+      },
+      pubsub: new PubSub(),
+      cache: new InMemoryLRUCache(),
+    });
+    const source = await handler.getMeshSource();
+    expect(
+      source.schema
+        .getQueryType()
+        .getFields()
+        ['getAllCars'].args.some(it => it.name === 'limit')
+    ).toBe(true);
+  });
+
+  it('should create a GraphQL schema from a simple local openapi file, without limit arg', async () => {
+    const handler = new OpenAPIHandler({
+      name: 'Example OAS3',
+      config: {
+        source: resolve(__dirname, './fixtures/example_oas_combined.json'),
+        addLimitArgument: false,
+      },
+      pubsub: new PubSub(),
+      cache: new InMemoryLRUCache(),
+    });
+    const source = await handler.getMeshSource();
+    expect(
+      source.schema
+        .getQueryType()
+        .getFields()
+        ['getAllCars'].args.some(it => it.name === 'limit')
+    ).toBe(false);
+  });
 });

--- a/packages/handlers/openapi/yaml-config.graphql
+++ b/packages/handlers/openapi/yaml-config.graphql
@@ -39,6 +39,10 @@ type OpenapiHandler @md {
   Include HTTP Response details to the result object
   """
   includeHttpDetails: Boolean
+  """
+  Auto-generate a 'limit' argument for all fields that return lists of objects, including ones produced by links
+  """
+  addLimitArgument: Boolean
 }
 
 enum SourceFormat {

--- a/packages/types/src/config.ts
+++ b/packages/types/src/config.ts
@@ -583,6 +583,11 @@ export interface OpenapiHandler {
    * Include HTTP Response details to the result object
    */
   includeHttpDetails?: boolean;
+  /**
+   * Auto-generate a 'limit' argument for all fields that return lists of
+   * objects, including ones produced by links
+   */
+  addLimitArgument?: boolean;
 }
 /**
  * Handler for Postgres database, based on `postgraphile`


### PR DESCRIPTION
This pull request includes two fixes:
* limit argument will be generated for composed types (allOf, anyOf, oneOf)
* limit value is not mandatory for generated argument

And includes also a new feature:
* New config option `addLimitArgument` to be disable this argument generation, default value is true.`