### PR TITLE
feat: schemaComposer.Query for RPC methods starting with list

### DIFF
--- a/.changeset/brave-jars-destroy.md
+++ b/.changeset/brave-jars-destroy.md
@@ -1,0 +1,5 @@
+---
+'@graphql-mesh/grpc': minor
+---
+
+Added schemaComposer.Query for RPC methods starting with list

--- a/packages/handlers/grpc/src/index.ts
+++ b/packages/handlers/grpc/src/index.ts
@@ -188,7 +188,7 @@ export default class GrpcHandler implements MeshHandler {
             } else {
               const clientMethod = promisify<ClientUnaryCall>(client[methodName].bind(client) as ClientMethod);
               const identifier = methodName.toLowerCase();
-              const rootTC = identifier.startsWith('get') ? schemaComposer.Query : schemaComposer.Mutation;
+              const rootTC = (identifier.startsWith('get') || identifier.startsWith('list')) ? schemaComposer.Query : schemaComposer.Mutation;
               rootTC.addFields({
                 [rootFieldName]: {
                   ...fieldConfig,


### PR DESCRIPTION
Changed graphql `schemaComposer` for RPC methods starting with `list` to `schemaComposer.Query`.