### PR TITLE
Fix/openapi location weather

### DIFF
--- a/examples/openapi-location-weather/package.json
+++ b/examples/openapi-location-weather/package.json
@@ -22,10 +22,11 @@
   },
   "dependencies": {
     "@graphql-mesh/cli": "0.11.8",
-    "@graphql-mesh/openapi": "0.10.2",
     "@graphql-mesh/config": "0.10.13",
+    "@graphql-mesh/openapi": "0.10.2",
     "@graphql-mesh/runtime": "0.7.12",
     "@graphql-mesh/transform-cache": "0.7.10",
+    "apollo-server": "^2.19.0",
     "express": "4.17.1",
     "express-graphql": "0.11.0",
     "graphql": "15.3.0"

--- a/examples/openapi-location-weather/src/mesh/additional-resolvers.ts
+++ b/examples/openapi-location-weather/src/mesh/additional-resolvers.ts
@@ -12,7 +12,7 @@ export const resolvers: Resolvers = {
         }
       `,
       resolve: async (placeSummary, _, { Weather }) => {
-        const forecast = await Weather.api.getForecastDailyLatLatLonLon({
+        const forecast = await Weather.api.getForecastDailyLatequalToLatLonLon({
           lat: placeSummary.latitude!,
           lon: placeSummary.longitude!,
           key: WEATHER_API_KEY,
@@ -29,7 +29,7 @@ export const resolvers: Resolvers = {
         }
       `,
       resolve: async (placeSummary, _, { Weather }) => {
-        const forecast = await Weather.api.getForecastDailyLatLatLonLon({
+        const forecast = await Weather.api.getForecastDailyLatequalToLatLonLon({
           lat: placeSummary.latitude!,
           lon: placeSummary.longitude!,
           key: WEATHER_API_KEY,


### PR DESCRIPTION
Related to issue #1081 / openapi location weather exampel 

**Fix**
-  Update used types due to weather bit API changes.
- Add missing `apollo-server` dependency, since it was used in the example but not marked as dependency  inside the project.