### PR TITLE
Fix/mysql handler pool usage

### DIFF
--- a/.changeset/light-days-cry.md
+++ b/.changeset/light-days-cry.md
@@ -1,0 +1,7 @@
+---
+'@graphql-mesh/mysql': patch
+'mysql-employees': patch
+'mysql-rfam': patch
+---
+
+Fix incorrect usage of the pool schema in MySQLHandler

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ temp
 ignored-demo
 package-lock.json
 .bob
+.history

--- a/packages/handlers/mysql/src/index.ts
+++ b/packages/handlers/mysql/src/index.ts
@@ -140,7 +140,7 @@ export default class MySQLHandler implements MeshHandler {
         },
       },
     });
-    const tables = await introspectionConnection.getDatabaseTables(this.config.database);
+    const tables = await introspectionConnection.getDatabaseTables(pool.config.connectionConfig.database);
     await Promise.all(
       Object.keys(tables).map(async tableName => {
         const table = tables[tableName];


### PR DESCRIPTION
Found a minor bug inside the MySQLHandler. It is using the database / schema name from the supplied config instead of from the created pool. Thus, if we do not supply a database name in the config, we cannot build the schema as the name is `undefined`

Related: #1157

Out Of Scope:
- Adding `.history` folder to `.gitignore` to remove a local folder from a VSCode extension