### PR TITLE
origin: '*' is a valid config

### DIFF
--- a/packages/cli/src/commands/serve/yaml-config.graphql
+++ b/packages/cli/src/commands/serve/yaml-config.graphql
@@ -26,7 +26,7 @@ union Fork = Int | Boolean
 union Port = Int | String
 
 type CorsConfig {
-  origin: [String]
+  origin: [String] | String
   allowedHeaders: [String]
   exposedHeaders: [String]
   credentials: Boolean


### PR DESCRIPTION
This is a valid config:
```
origin: '*'
```