### PR TITLE
feat: allow to filter by type

### DIFF
--- a/.changeset/dirty-geese-chew.md
+++ b/.changeset/dirty-geese-chew.md
@@ -1,0 +1,5 @@
+---
+'@graphql-mesh/transform-filter-schema': minor
+---
+
+allow to filter schema by type

--- a/packages/transforms/filter-schema/src/index.ts
+++ b/packages/transforms/filter-schema/src/index.ts
@@ -2,7 +2,7 @@ import { matcher } from 'micromatch';
 
 import { GraphQLSchema } from 'graphql';
 import { MeshTransform, YamlConfig, MeshTransformOptions } from '@graphql-mesh/types';
-import { FilterRootFields, FilterObjectFields, FilterInputObjectFields } from '@graphql-tools/wrap';
+import { FilterRootFields, FilterObjectFields, FilterInputObjectFields, FilterTypes } from '@graphql-tools/wrap';
 import {
   applySchemaTransforms,
   applyRequestTransforms,
@@ -18,6 +18,15 @@ export default class FilterTransform implements MeshTransform {
     const { config } = options;
     for (const filter of config) {
       const [typeName, fieldGlob] = filter.split('.');
+      if (!fieldGlob) {
+        const isMatch = matcher(typeName);
+        this.transforms.push(
+          new FilterTypes(type => {
+            return !isMatch(type.name);
+          })
+        );
+        continue;
+      }
       let fixedFieldGlob = fieldGlob;
       if (fixedFieldGlob.includes('{') && !fixedFieldGlob.includes(',')) {
         fixedFieldGlob = fieldGlob.replace('{', '').replace('}', '');

--- a/packages/transforms/filter-schema/test/transform.spec.ts
+++ b/packages/transforms/filter-schema/test/transform.spec.ts
@@ -148,4 +148,183 @@ type Query {
 `.trim()
     );
   });
+
+  it('should filter out types', async () => {
+    let schema = buildSchema(/* GraphQL */ `
+      type User {
+        id: ID
+        name: String
+        username: String
+        a: String
+        b: String
+        c: String
+        d: String
+        e: String
+      }
+
+      type Book {
+        id: ID
+        name: String
+        authorId: ID
+        author: User
+      }
+
+      type Query {
+        user: User
+        admin: User
+      }
+    `);
+    schema = wrapSchema({
+      schema,
+      transforms: [
+        new FilterSchemaTransform({
+          config: ['Book'],
+          cache,
+          pubsub,
+        }),
+      ],
+    });
+
+    expect(printSchema(schema).trim()).toBe(
+      /* GraphQL */ `
+type User {
+  id: ID
+  name: String
+  username: String
+  a: String
+  b: String
+  c: String
+  d: String
+  e: String
+}
+
+type Query {
+  user: User
+  admin: User
+}
+`.trim()
+    );
+  });
+
+  it('should filter out fields of filtered types', async () => {
+    let schema = buildSchema(/* GraphQL */ `
+      type User {
+        id: ID
+        name: String
+        username: String
+        a: String
+        b: String
+        c: String
+        d: String
+        e: String
+      }
+
+      type Book {
+        id: ID
+        name: String
+        authorId: ID
+        author: User
+      }
+
+      type Query {
+        user: User
+        admin: User
+      }
+    `);
+    schema = wrapSchema({
+      schema,
+      transforms: [
+        new FilterSchemaTransform({
+          config: ['User'],
+          cache,
+          pubsub,
+        }),
+      ],
+    });
+
+    expect(printSchema(schema).trim()).toBe(
+      /* GraphQL */ `
+type Book {
+  id: ID
+  name: String
+  authorId: ID
+}
+`.trim()
+    );
+  });
+
+  it('should filter out directive fields of filtered types', async () => {
+    let schema = buildSchema(/* GraphQL */ `
+      input AuthRule {
+        and: [AuthRule]
+        or: [AuthRule]
+        not: AuthRule
+        rule: String
+      }
+
+      directive @auth(query: AuthRule, add: AuthRule, update: AuthRule, delete: AuthRule, role: String!) on OBJECT
+
+      type User {
+        id: ID
+        name: String
+        username: String
+        a: String
+        b: String
+        c: String
+        d: String
+        e: String
+      }
+
+      type Book {
+        id: ID
+        name: String
+        authorId: ID
+        author: User
+      }
+
+      type Query {
+        user: User
+        admin: User
+      }
+    `);
+    schema = wrapSchema({
+      schema,
+      transforms: [
+        new FilterSchemaTransform({
+          config: ['AuthRule'],
+          cache,
+          pubsub,
+        }),
+      ],
+    });
+
+    expect(printSchema(schema).trim()).toBe(
+      /* GraphQL */ `
+directive @auth(role: String!) on OBJECT
+
+type User {
+  id: ID
+  name: String
+  username: String
+  a: String
+  b: String
+  c: String
+  d: String
+  e: String
+}
+
+type Book {
+  id: ID
+  name: String
+  authorId: ID
+  author: User
+}
+
+type Query {
+  user: User
+  admin: User
+}
+`.trim()
+    );
+  });
 });


### PR DESCRIPTION
Allows to filter schema types.
How it works:
* if filter does not contain a `.` it filters the type matching the pattern using `FilterTypes`.
* if it does contain a `.` the behavior is the same as previous.
Previous behavior was to fail on `fixedFieldGlob.contains` when `.` wasn't specified.