### PR TITLE
Extend OpenApi handler functionalities

### DIFF
--- a/.changeset/six-camels-study.md
+++ b/.changeset/six-camels-study.md
@@ -1,0 +1,6 @@
+---
+'@graphql-mesh/openapi': minor
+'@graphql-mesh/types': minor
+---
+
+feat(openapi): customize target root type for an operation and generic payload argument name

--- a/packages/handlers/openapi/package.json
+++ b/packages/handlers/openapi/package.json
@@ -26,6 +26,7 @@
     "json-ptr": "2.0.0",
     "graphql-scalars": "1.7.0",
     "graphql-subscriptions": "1.1.0",
+    "lodash": "4.17.20",
     "pluralize": "8.0.0",
     "swagger2openapi": "7.0.4",
     "url-join": "4.0.1"

--- a/packages/handlers/openapi/src/index.ts
+++ b/packages/handlers/openapi/src/index.ts
@@ -64,6 +64,8 @@ export default class OpenAPIHandler implements MeshHandler {
       operationIdFieldNames: true,
       fillEmptyResponses: true,
       includeHttpDetails: this.config.includeHttpDetails,
+      genericPayloadArgName: this.config.genericPayloadArgName === undefined ? false : this.config.genericPayloadArgName,
+      selectQueryOrMutationField: this.config.selectQueryOrMutationField === undefined ? {} : this.config.selectQueryOrMutationField,
       addLimitArgument: this.config.addLimitArgument === undefined ? true : this.config.addLimitArgument,
       sendOAuthTokenInQuery: true,
       viewer: false,

--- a/packages/handlers/openapi/yaml-config.graphql
+++ b/packages/handlers/openapi/yaml-config.graphql
@@ -43,6 +43,14 @@ type OpenapiHandler @md {
   Auto-generate a 'limit' argument for all fields that return lists of objects, including ones produced by links
   """
   addLimitArgument: Boolean
+  """
+  Set argument name for mutation payload to 'requestBody'. If false, name defaults to camelCased pathname
+  """
+  genericPayloadArgName: Boolean
+  """
+  Allows to explicitly override the default operation (Query or Mutation) for any OAS operation
+  """
+  selectQueryOrMutationField: Any
 }
 
 enum SourceFormat {

--- a/packages/handlers/openapi/yaml-config.graphql
+++ b/packages/handlers/openapi/yaml-config.graphql
@@ -50,10 +50,34 @@ type OpenapiHandler @md {
   """
   Allows to explicitly override the default operation (Query or Mutation) for any OAS operation
   """
-  selectQueryOrMutationField: Any
+  selectQueryOrMutationField: [SelectQueryOrMutationFieldConfig]
 }
 
 enum SourceFormat {
   json
   yaml
+}
+
+type SelectQueryOrMutationFieldConfig {
+  """
+  OAS Title
+  """
+  title: String
+  """
+  Operation Path
+  """
+  path: String
+  """
+  Target Root Type for this operation
+  """
+  type: QueryOrMutation
+  """
+  Which method is used for this operation
+  """
+  method: String
+}
+
+enum QueryOrMutation {
+  Query
+  Mutation
 }

--- a/packages/types/src/config-schema.json
+++ b/packages/types/src/config-schema.json
@@ -1363,6 +1363,22 @@
         "addLimitArgument": {
           "type": "boolean",
           "description": "Auto-generate a 'limit' argument for all fields that return lists of objects, including ones produced by links"
+        },
+        "genericPayloadArgName": {
+          "type": "boolean",
+          "description": "Set argument name for mutation payload to 'requestBody'. If false, name defaults to camelCased pathname"
+        },
+        "selectQueryOrMutationField": {
+          "anyOf": [
+            {
+              "type": "object",
+              "additionalProperties": true
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "description": "Allows to explicitly override the default operation (Query or Mutation) for any OAS operation"
         }
       },
       "required": ["source"]
@@ -1550,6 +1566,21 @@
         }
       },
       "required": ["hostName", "port", "serviceName", "idl"]
+    },
+    "TuqlHandler": {
+      "additionalProperties": false,
+      "type": "object",
+      "title": "TuqlHandler",
+      "properties": {
+        "db": {
+          "type": "string",
+          "description": "Pointer to your SQLite database"
+        },
+        "infile": {
+          "type": "string",
+          "description": "Path to the SQL Dump file if you want to build a in-memory database"
+        }
+      }
     },
     "CacheTransformConfig": {
       "additionalProperties": false,
@@ -2017,21 +2048,6 @@
         }
       },
       "required": ["apply", "outputDir"]
-    },
-    "TuqlHandler": {
-      "additionalProperties": false,
-      "type": "object",
-      "title": "TuqlHandler",
-      "properties": {
-        "db": {
-          "type": "string",
-          "description": "Pointer to your SQLite database"
-        },
-        "infile": {
-          "type": "string",
-          "description": "Path to the SQL Dump file if you want to build a in-memory database"
-        }
-      }
     }
   },
   "title": "Config",

--- a/packages/types/src/config-schema.json
+++ b/packages/types/src/config-schema.json
@@ -1369,19 +1369,36 @@
           "description": "Set argument name for mutation payload to 'requestBody'. If false, name defaults to camelCased pathname"
         },
         "selectQueryOrMutationField": {
-          "anyOf": [
-            {
-              "type": "object",
-              "additionalProperties": true
-            },
-            {
-              "type": "string"
-            }
-          ],
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/SelectQueryOrMutationFieldConfig"
+          },
+          "additionalItems": false,
           "description": "Allows to explicitly override the default operation (Query or Mutation) for any OAS operation"
         }
       },
       "required": ["source"]
+    },
+    "SelectQueryOrMutationFieldConfig": {
+      "additionalProperties": false,
+      "type": "object",
+      "title": "SelectQueryOrMutationFieldConfig",
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string",
+          "enum": ["Query", "Mutation"],
+          "description": "Allowed values: Query, Mutation"
+        },
+        "method": {
+          "type": "string"
+        }
+      }
     },
     "PostGraphileHandler": {
       "additionalProperties": false,
@@ -1566,21 +1583,6 @@
         }
       },
       "required": ["hostName", "port", "serviceName", "idl"]
-    },
-    "TuqlHandler": {
-      "additionalProperties": false,
-      "type": "object",
-      "title": "TuqlHandler",
-      "properties": {
-        "db": {
-          "type": "string",
-          "description": "Pointer to your SQLite database"
-        },
-        "infile": {
-          "type": "string",
-          "description": "Path to the SQL Dump file if you want to build a in-memory database"
-        }
-      }
     },
     "CacheTransformConfig": {
       "additionalProperties": false,
@@ -2048,6 +2050,21 @@
         }
       },
       "required": ["apply", "outputDir"]
+    },
+    "TuqlHandler": {
+      "additionalProperties": false,
+      "type": "object",
+      "title": "TuqlHandler",
+      "properties": {
+        "db": {
+          "type": "string",
+          "description": "Pointer to your SQLite database"
+        },
+        "infile": {
+          "type": "string",
+          "description": "Path to the SQL Dump file if you want to build a in-memory database"
+        }
+      }
     }
   },
   "title": "Config",

--- a/packages/types/src/config.ts
+++ b/packages/types/src/config.ts
@@ -618,7 +618,16 @@ export interface OpenapiHandler {
   /**
    * Allows to explicitly override the default operation (Query or Mutation) for any OAS operation
    */
-  selectQueryOrMutationField?: any;
+  selectQueryOrMutationField?: SelectQueryOrMutationFieldConfig[];
+}
+export interface SelectQueryOrMutationFieldConfig {
+  title?: string;
+  path?: string;
+  /**
+   * Allowed values: Query, Mutation
+   */
+  type?: 'Query' | 'Mutation';
+  method?: string;
 }
 /**
  * Handler for Postgres database, based on `postgraphile`

--- a/packages/types/src/config.ts
+++ b/packages/types/src/config.ts
@@ -611,6 +611,14 @@ export interface OpenapiHandler {
    * Auto-generate a 'limit' argument for all fields that return lists of objects, including ones produced by links
    */
   addLimitArgument?: boolean;
+  /**
+   * Set argument name for mutation payload to 'requestBody'. If false, name defaults to camelCased pathname
+   */
+  genericPayloadArgName?: boolean;
+  /**
+   * Allows to explicitly override the default operation (Query or Mutation) for any OAS operation
+   */
+  selectQueryOrMutationField?: any;
 }
 /**
  * Handler for Postgres database, based on `postgraphile`

--- a/website/docs/handlers/openapi.md
+++ b/website/docs/handlers/openapi.md
@@ -25,6 +25,25 @@ sources:
         source: ./my-schema.json
 ```
 
+## Overriding default Query/Mutation operations
+By default OpenAPI-to-GraphQL will place all GET operations into Query fields and all other operations into Mutation fields; with this option you can manually override this process.  
+The operation is identifed first by the title of the OAS, then the path of the operation, and lastly the method of the operation.  
+In order to switch between Query and Mutation operations you should change the value of the method to an integer corresponding to either 0, or 1; which stands to Query or Mutation respectively.
+
+```yaml
+sources:
+  - name: MyOpenapiApi
+    handler:
+      openapi:
+        source: ./my-schema.json
+        selectQueryOrMutationField:
+          "Weather Service v1": # OAS title
+            /weather/current: # operation path
+              post: 0 # switch method POST from default Mutation into Query
+            /weather/forecast: # operation path
+              get: 1 # switch method GET from default Query into Mutation
+```
+
 ## Dynamic Header Values
 
 Mesh can take dynamic values from the GraphQL Context or the environmental variables. If you use `mesh serve`, GraphQL Context will be the incoming HTTP request.

--- a/website/docs/handlers/openapi.md
+++ b/website/docs/handlers/openapi.md
@@ -37,11 +37,14 @@ sources:
       openapi:
         source: ./my-schema.json
         selectQueryOrMutationField:
-          "Weather Service v1": # OAS title
-            /weather/current: # operation path
-              post: 0 # switch method POST from default Mutation into Query
-            /weather/forecast: # operation path
-              get: 1 # switch method GET from default Query into Mutation
+          - title: "Weather Service v1" # OAS title
+            path: /weather/current # operation path
+            method: post
+            type: Query # switch method POST from default Mutation into Query
+          - title: "Weather Service v1" # OAS title
+            path: /weather/forecast # operation path
+            method: get
+            type: Mutation # switch method POST from default Mutation into Query
 ```
 
 ## Dynamic Header Values


### PR DESCRIPTION
This PR exposes `genericPayloadArgName` and `selectQueryOrMutationField` from OpenAPI-to-GraphQL handler through Mesh YAML config.

When true, `genericPayloadArgName`, allows setting argument name for mutation payload to `requestBody`. If false current behavior will continue to have default camelCased pathname.
This can really help when dealing with APIs that infer long classes names that make arguments required in GraphQL queries unreadable and so unfriendly as well.
Ultimately it can be helpful and seen as an alternative solution to #1422.

`selectQueryOrMutationField` is the thing any OpenApi user needs.
It allows to explicitly override GET/POST operations from Query to Mutation and vice versa; it effectively addresses #1113.
The current API for this is probably not the nicest but it works as follows:
```yaml
sources:
  - name: MyOpenapiApi
    handler:
      openapi:
        source: ./my-schema.json
        selectQueryOrMutationField:
          "Weather Service v1": # OAS title
            /weather/current: # operation path
              post: 0 # switch method POST from default Mutation into Query
            /weather/forecast: # operation path
              get: 1 # switch method GET from default Query into Mutation
```
In the future, this can be extracted to a transform plugin and ideally, we can automatically infer the OAS title rather than forcing users to specify that.

I added types and documentation and cannot wait for this to be released!

----------
As a side note, I didn't enjoy the fact that the JSON schema and TypeScript interfaces are automatically generated from a GraphQL `yaml-config.graphql` schema.
In this PR, for instance, this forced me to have a type `any` for the newly introduced `selectQueryOrMutationField`; whilst with typescript I could have written a more accurate interface like below:
```ts
export interface selectQueryOrMutationFieldObject {
  [title: string]: {
    [path: string]: {
      [method: string]: 0 | 1;
    };
  };
};

```