### PR TITLE
Filter arguments

### DIFF
--- a/packages/transforms/filter-schema/src/FilterObjectFieldsAndArguments.ts
+++ b/packages/transforms/filter-schema/src/FilterObjectFieldsAndArguments.ts
@@ -1,0 +1,30 @@
+import { SubschemaConfig, Transform } from '@graphql-tools/delegate';
+import { FieldFilter } from '@graphql-tools/utils';
+import { TransformObjectFields } from '@graphql-tools/wrap';
+import { GraphQLFieldConfig, GraphQLSchema } from 'graphql';
+
+import { FieldArgumentFilter, filterFieldArguments } from './common';
+
+export default class FilterObjectFieldsAndArguments implements Transform {
+  private readonly transformer: TransformObjectFields;
+
+  constructor(fieldFilter: FieldFilter, argFilter: FieldArgumentFilter) {
+    this.transformer = new TransformObjectFields(
+      (typeName: string, fieldName: string, fieldConfig: GraphQLFieldConfig<any, any>) => {
+        if (fieldFilter(typeName, fieldName, fieldConfig)) {
+          return filterFieldArguments(fieldName, fieldConfig, argFilter);
+        }
+
+        return null;
+      }
+    );
+  }
+
+  public transformSchema(
+    originalWrappingSchema: GraphQLSchema,
+    subschemaConfig: SubschemaConfig,
+    transformedSchema?: GraphQLSchema
+  ): GraphQLSchema {
+    return this.transformer.transformSchema(originalWrappingSchema, subschemaConfig, transformedSchema);
+  }
+}

--- a/packages/transforms/filter-schema/src/FilterRootFieldsAndArguments.ts
+++ b/packages/transforms/filter-schema/src/FilterRootFieldsAndArguments.ts
@@ -1,11 +1,11 @@
 import { SubschemaConfig, Transform } from '@graphql-tools/delegate';
 import { RootFieldFilter } from '@graphql-tools/utils';
 import { TransformRootFields } from '@graphql-tools/wrap';
-import { GraphQLFieldConfig, GraphQLFieldConfigArgumentMap, GraphQLSchema } from 'graphql';
+import { GraphQLFieldConfig, GraphQLSchema } from 'graphql';
 
-export type FieldArgumentFilter = (argName: string) => boolean;
+import { FieldArgumentFilter, filterFieldArguments } from './common';
 
-export class FilterRootFieldArguments implements Transform {
+export class FilterRootFieldsAndArguments implements Transform {
   private readonly transformer: TransformRootFields;
 
   constructor(fieldFilter: RootFieldFilter, argFilter: FieldArgumentFilter) {
@@ -16,14 +16,7 @@ export class FilterRootFieldArguments implements Transform {
         fieldConfig: GraphQLFieldConfig<any, any>
       ) => {
         if (fieldFilter(operation, fieldName, fieldConfig)) {
-          const args = Object.keys(fieldConfig.args)
-            .filter((argName: string) => argFilter(argName))
-            .reduce((prev, key) => {
-              prev[key] = fieldConfig.args[key];
-              return prev;
-            }, {} as GraphQLFieldConfigArgumentMap);
-
-          return { ...fieldConfig, args };
+          return filterFieldArguments(fieldName, fieldConfig, argFilter);
         }
 
         return null;

--- a/packages/transforms/filter-schema/src/common.ts
+++ b/packages/transforms/filter-schema/src/common.ts
@@ -1,0 +1,18 @@
+import { GraphQLFieldConfig, GraphQLFieldConfigArgumentMap } from 'graphql';
+
+export type FieldArgumentFilter = (fieldName: string, argName: string) => boolean;
+
+export function filterFieldArguments(
+  fieldName: string,
+  fieldConfig: GraphQLFieldConfig<any, any>,
+  argFilter: FieldArgumentFilter
+) {
+  const args = Object.keys(fieldConfig.args)
+    .filter((argName: string) => argFilter(fieldName, argName))
+    .reduce((prev, key) => {
+      prev[key] = fieldConfig.args[key];
+      return prev;
+    }, {} as GraphQLFieldConfigArgumentMap);
+
+  return { ...fieldConfig, args };
+}

--- a/packages/transforms/filter-schema/src/filter-arguments.ts
+++ b/packages/transforms/filter-schema/src/filter-arguments.ts
@@ -1,0 +1,41 @@
+import { SubschemaConfig, Transform } from '@graphql-tools/delegate';
+import { RootFieldFilter } from '@graphql-tools/utils';
+import { TransformRootFields } from '@graphql-tools/wrap';
+import { GraphQLFieldConfig, GraphQLFieldConfigArgumentMap, GraphQLSchema } from 'graphql';
+
+export type FieldArgumentFilter = (argName: string) => boolean;
+
+export class FilterRootFieldArguments implements Transform {
+  private readonly transformer: TransformRootFields;
+
+  constructor(fieldFilter: RootFieldFilter, argFilter: FieldArgumentFilter) {
+    this.transformer = new TransformRootFields(
+      (
+        operation: 'Query' | 'Mutation' | 'Subscription',
+        fieldName: string,
+        fieldConfig: GraphQLFieldConfig<any, any>
+      ) => {
+        if (fieldFilter(operation, fieldName, fieldConfig)) {
+          const args = Object.keys(fieldConfig.args)
+            .filter((argName: string) => argFilter(argName))
+            .reduce((prev, key) => {
+              prev[key] = fieldConfig.args[key];
+              return prev;
+            }, {} as GraphQLFieldConfigArgumentMap);
+
+          return { ...fieldConfig, args };
+        }
+
+        return null;
+      }
+    );
+  }
+
+  public transformSchema(
+    originalWrappingSchema: GraphQLSchema,
+    subschemaConfig: SubschemaConfig,
+    transformedSchema?: GraphQLSchema
+  ): GraphQLSchema {
+    return this.transformer.transformSchema(originalWrappingSchema, subschemaConfig, transformedSchema);
+  }
+}

--- a/packages/transforms/filter-schema/src/index.ts
+++ b/packages/transforms/filter-schema/src/index.ts
@@ -1,12 +1,13 @@
+import { MeshTransform, MeshTransformOptions, YamlConfig } from '@graphql-mesh/types';
+import { applyRequestTransforms, applyResultTransforms, applySchemaTransforms } from '@graphql-mesh/utils';
+import { DelegationContext, SubschemaConfig, Transform } from '@graphql-tools/delegate';
+import { ExecutionResult, pruneSchema, Request } from '@graphql-tools/utils';
+import { FilterInputObjectFields, FilterTypes } from '@graphql-tools/wrap';
+import { GraphQLSchema } from 'graphql';
 import { matcher } from 'micromatch';
 
-import { GraphQLSchema } from 'graphql';
-import { MeshTransform, YamlConfig, MeshTransformOptions } from '@graphql-mesh/types';
-import { FilterRootFields, FilterObjectFields, FilterInputObjectFields, FilterTypes } from '@graphql-tools/wrap';
-import { ExecutionResult, Request, pruneSchema } from '@graphql-tools/utils';
-import { Transform, SubschemaConfig, DelegationContext } from '@graphql-tools/delegate';
-import { applyRequestTransforms, applyResultTransforms, applySchemaTransforms } from '@graphql-mesh/utils';
-import { FilterRootFieldArguments } from './filter-arguments';
+import FilterObjectFieldsAndArguments from './FilterObjectFieldsAndArguments';
+import { FilterRootFieldsAndArguments } from './FilterRootFieldsAndArguments';
 
 export default class FilterTransform implements MeshTransform {
   private transforms: Transform[] = [];
@@ -21,51 +22,80 @@ export default class FilterTransform implements MeshTransform {
             return !isTypeMatch(type.name);
           })
         );
-      } else if (fieldGlob.includes('(')) {
-        const parts = fieldGlob.split('(');
-        const fixedFieldGlob = parts[0];
-        let fixedArgGlob = parts[1];
-
-        if (!fixedArgGlob.includes(',')) {
-          fixedArgGlob = fixedArgGlob.replace('(', '').replace(')', '');
-        }
-
-        fixedArgGlob = fixedArgGlob.replace(', ', ',');
-
-        const isMatch = matcher(fixedFieldGlob.trim());
-        const isArgumentMatch = matcher(fixedArgGlob.trim());
-        this.transforms.push(
-          new FilterRootFieldArguments((rootTypeName, rootFieldName) => {
-            if (isTypeMatch(rootTypeName)) {
-              return isMatch(rootFieldName);
-            }
-            return true;
-          }, isArgumentMatch)
-        );
       } else {
-        let fixedFieldGlob = fieldGlob;
-        if (fixedFieldGlob.includes('{') && !fixedFieldGlob.includes(',')) {
-          fixedFieldGlob = fieldGlob.replace('{', '').replace('}', '');
+        // returns a match where second match = '{' or '!{' and third match being the content of the array
+        const outerArrayMatch = fieldGlob.match(/^(\{|!{)(.*)(?=\}$)/);
+        const fieldGlobStripped = outerArrayMatch ? outerArrayMatch[2] : fieldGlob;
+
+        // split field parts (might include argument filter)
+        const fieldPatterns = fieldGlobStripped.match(/[\w-!*?[\]]+(\(.*?\))?/g);
+
+        // extract field names only
+        let fixedFieldGlob = fieldPatterns.map(i => i.split('(')[0].trim()).join(',');
+
+        // if input was glob glob array
+        if (outerArrayMatch) {
+          // strip array for single field inputs
+          if (fieldPatterns.length === 1) {
+            fixedFieldGlob = `${outerArrayMatch[1].replace('{', '')}${fixedFieldGlob}`;
+          } else {
+            fixedFieldGlob = `${outerArrayMatch[1]}${fixedFieldGlob}}`;
+          }
         }
-        fixedFieldGlob = fixedFieldGlob.split(', ').join(',');
+
+        const fieldArgsPatternMap = fieldPatterns.reduce((prev, match) => {
+          const fieldParts = match.split('(');
+
+          if (fieldParts.length !== 2) {
+            return prev;
+          }
+
+          const fieldName = fieldParts[0].replace(/!{|{|}/g, '').trim();
+          const fixedArgGlob = fieldParts[1]
+            .split(')')[0]
+            .split(',')
+            .map(i => i.trim())
+            .join(',');
+
+          prev[fieldName] = fixedArgGlob;
+          return prev;
+        }, {});
 
         const isMatch = matcher(fixedFieldGlob.trim());
         this.transforms.push(
-          new FilterRootFields((rootTypeName, rootFieldName) => {
-            if (isTypeMatch(rootTypeName)) {
-              return isMatch(rootFieldName);
+          new FilterRootFieldsAndArguments(
+            (rootTypeName, rootFieldName) => {
+              if (isTypeMatch(rootTypeName)) {
+                return isMatch(rootFieldName);
+              }
+              return true;
+            },
+            (fieldName, argName) => {
+              if (!fieldArgsPatternMap[fieldName]) {
+                return true;
+              }
+              return matcher(fieldArgsPatternMap[fieldName])(argName);
             }
-            return true;
-          })
+          )
         );
+
         this.transforms.push(
-          new FilterObjectFields((objectTypeName, objectFieldName) => {
-            if (isTypeMatch(objectTypeName)) {
-              return isMatch(objectFieldName);
+          new FilterObjectFieldsAndArguments(
+            (rootTypeName, rootFieldName) => {
+              if (isTypeMatch(rootTypeName)) {
+                return isMatch(rootFieldName);
+              }
+              return true;
+            },
+            (fieldName, argName) => {
+              if (!fieldArgsPatternMap[fieldName]) {
+                return true;
+              }
+              return matcher(fieldArgsPatternMap[fieldName])(argName);
             }
-            return true;
-          })
+          )
         );
+
         this.transforms.push(
           new FilterInputObjectFields((inputObjectTypeName, inputObjectFieldName) => {
             if (isTypeMatch(inputObjectTypeName)) {

--- a/packages/transforms/filter-schema/test/transform.spec.ts
+++ b/packages/transforms/filter-schema/test/transform.spec.ts
@@ -334,4 +334,57 @@ type Query {
 `.trim()
     );
   });
+
+  it('should filter out arguments of root field', async () => {
+    let schema = buildSchema(/* GraphQL */ `
+      type User {
+        id: ID
+        name: String
+        username: String
+      }
+
+      type Book {
+        id: ID
+        name: String
+        author: User
+      }
+
+      type Query {
+        user(pk: ID!, name: String): User
+        book: Book
+      }
+    `);
+    schema = wrapSchema({
+      schema,
+      transforms: [
+        new FilterSchemaTransform({
+          config: ['Query.user(!pk)'],
+          cache,
+          pubsub,
+        }),
+      ],
+    });
+
+    console.log(printSchema(schema));
+
+    expect(printSchema(schema).trim()).toBe(
+      /* GraphQL */ `
+type User {
+  id: ID
+  name: String
+  username: String
+}
+
+type Book {
+  id: ID
+  name: String
+  author: User
+}
+
+type Query {
+  user(name: String): User
+}
+`.trim()
+    );
+  });
 });

--- a/packages/transforms/filter-schema/test/transform.spec.ts
+++ b/packages/transforms/filter-schema/test/transform.spec.ts
@@ -350,22 +350,20 @@ type Query {
       }
 
       type Query {
-        user(pk: ID!, name: String): User
-        book: Book
+        user(pk: ID!, name: String, age: Int): User
+        book(pk: ID!): Book
       }
     `);
     schema = wrapSchema({
       schema,
       transforms: [
         new FilterSchemaTransform({
-          config: ['Query.user(!pk)'],
+          config: ['Query.{user(!{pk, name}), book(!pk)}'],
           cache,
           pubsub,
         }),
       ],
     });
-
-    console.log(printSchema(schema));
 
     expect(printSchema(schema).trim()).toBe(
       /* GraphQL */ `
@@ -382,7 +380,8 @@ type Book {
 }
 
 type Query {
-  user(name: String): User
+  user(age: Int): User
+  book: Book
 }
 `.trim()
     );


### PR DESCRIPTION
This PR is work in progress.

Some comments:
- Argument filtering is implemented unit test run through I'm planning to add more cases before the PR
- Changes to the micro syntax and how its parsed
   - Previously there were a max of 2 levels of information
      - type or root field
      - and the fields on the above
   - Now there is (potentially) a third level
      - arguments on the individual fields
- This required a significantly higher complexity in parsing the second and third level
   - this is done by a couple of regex which also take into account glob pattern syntax to ensure this stays intact

Limitations:
- filtering of arguments is only possible when field name is explicitly supplied
  -  `Query.{user(!pk),book}` works
  -  `Query.{user(!{pk, name}),book}` works
  -  `Query.{u*(!pk),book}` does **not** work
  -  `Query.*(!pk)` does **not** works
- While glob pattern syntax is taken into account when parsing the micro syntax. There are likely cases where advanced usage of glob patters will cause problems

Suggestions for an additional package:
While the above works and likely will be enough for majority of users. After spending some time on this I believe there is also room for a separate package dedicated to argument filtering and default value setting:
- this transform would not filter fields at all but only focus on arguments
  - this significantly reduces the level of complexity in parsing the micro syntax and would allow for full glob pattern matching (see limitations above)
- as part of the configuration to exclude an argument it would also be possible to provide a hidden default value (not exposed to the user)
- in addition this transform would allow to provide default values in a similar manner as in other transforms `Authorization: Bearer {context.headers['x-my-api-token']}`
- It should also be possible to apply the same default value in multiple places to reduce exploding configs