### PR TITLE
Updating website README to reflect the fixes made in issue #1543

### DIFF
--- a/website/README.md
+++ b/website/README.md
@@ -5,8 +5,18 @@ This website is built using [Docusaurus 2](https://v2.docusaurus.io/), a modern 
 ### Installation
 
 ```
-$ yarn
+$ yarn --ignore-engines --ignore-optional
 ```
+
+`--ignore-engines` is required if you are using node versions greater than `14.0` since the `@apollo/federation` package being used is incompatible with them.
+
+## Pre-requisites
+
+In order to run the project successfully in your system, you would require `python 2.x` to be installed (used by `node-pre-gyp` to build some of the dependencies)
+
+You can install it in Linux based distributions using `sudo apt update && sudo apt install python`
+
+More about this [here](https://github.com/Urigo/graphql-mesh/issues/1543)
 
 ### Local Development
 


### PR DESCRIPTION
Added instructions:

- Use `--ignore-engines` when using node versions greater than `14.0`
- You need python 2.x as the dependency without which the pre-gyp build would fail (https://github.com/Urigo/graphql-mesh/issues/1543)

