### PR TITLE
feat(runtime): Live Queries Support

### DIFF
--- a/.changeset/itchy-elephants-attack.md
+++ b/.changeset/itchy-elephants-attack.md
@@ -1,0 +1,9 @@
+---
+'json-schema-subscriptions': minor
+'@graphql-mesh/cli': minor
+'@graphql-mesh/config': minor
+'@graphql-mesh/runtime': minor
+'@graphql-mesh/types': minor
+---
+
+feat(runtime): Live Queries Support

--- a/examples/json-schema-subscriptions/.meshrc.yml
+++ b/examples/json-schema-subscriptions/.meshrc.yml
@@ -28,3 +28,7 @@ serve:
     - path: /webhooks/todo_added
       pubsubTopic: todoAdded
   exampleQuery: ./example-queries/**/*.graphql
+
+liveQueryInvalidations:
+  - field: Mutation.addTodo
+    invalidate: Query.todos

--- a/examples/json-schema-subscriptions/.meshrc.yml
+++ b/examples/json-schema-subscriptions/.meshrc.yml
@@ -31,4 +31,5 @@ serve:
 
 liveQueryInvalidations:
   - field: Mutation.addTodo
-    invalidate: Query.todos
+    invalidate:
+      - Query.todos

--- a/examples/json-schema-subscriptions/README.md
+++ b/examples/json-schema-subscriptions/README.md
@@ -11,3 +11,7 @@ Everytime you call `/todo` endpoint, it sends `Todo` as a payload
 
 You can run API server with `yarn start:api` command and Mesh with `yarn start:mesh` then you can try the example queries you see in the playground.
 You can go to the GraphQL Playground with this URL; `http://localhost:4000/graphql`
+
+#### Extra: Live Queries
+
+This example also shows Live Queries instead of Subscriptions

--- a/examples/json-schema-subscriptions/example-queries/todos.query.graphql
+++ b/examples/json-schema-subscriptions/example-queries/todos.query.graphql
@@ -1,4 +1,4 @@
-query getTodos {
+query getTodos @live {
   todos {
     id
     name

--- a/packages/cli/src/commands/serve/graphql-handler.ts
+++ b/packages/cli/src/commands/serve/graphql-handler.ts
@@ -49,7 +49,7 @@ export const graphqlHandler = (mesh$: ReturnType<typeof getMesh>): RequestHandle
       const { operationName, query, variables } = getGraphQLParameters(request);
 
       Promise.resolve().then(async function () {
-        const { schema, contextBuilder } = await mesh$;
+        const { schema, execute, subscribe, contextBuilder } = await mesh$;
 
         // Validate and execute the query
         const result = await processRequest({
@@ -58,6 +58,10 @@ export const graphqlHandler = (mesh$: ReturnType<typeof getMesh>): RequestHandle
           variables,
           request,
           schema,
+          execute: (_schema, documentAST, rootValue, contextValue, variableValues, operationName) =>
+            execute(documentAST, variableValues, contextValue, rootValue, operationName),
+          subscribe: (_schema, documentAST, rootValue, contextValue, variableValues, operationName) =>
+            subscribe(documentAST, variableValues, contextValue, rootValue, operationName),
           contextFactory: () => contextBuilder(req),
         });
 

--- a/packages/cli/src/commands/serve/serve.ts
+++ b/packages/cli/src/commands/serve/serve.ts
@@ -1,5 +1,4 @@
 /* eslint-disable dot-notation */
-import { execute, subscribe } from 'graphql';
 import express, { RequestHandler } from 'express';
 import { fork as clusterFork, isMaster } from 'cluster';
 import { cpus } from 'os';
@@ -116,20 +115,12 @@ export async function serveMesh(baseDir: string, argsPort?: number): Promise<voi
 
     useServer(
       {
-        execute: async args => {
-          const { schema } = await mesh$;
-          return execute({
-            ...args,
-            schema,
-          });
-        },
-        subscribe: async args => {
-          const { schema } = await mesh$;
-          return subscribe({
-            ...args,
-            schema,
-          });
-        },
+        execute: args =>
+          mesh$.then(({ execute }) => execute(args.document, args.variableValues, args.contextValue, args.rootValue)),
+        subscribe: args =>
+          mesh$.then(({ subscribe }) =>
+            subscribe(args.document, args.variableValues, args.contextValue, args.rootValue)
+          ),
         context: async ctx => {
           const { contextBuilder } = await mesh$;
           return contextBuilder(ctx.extra.request);

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -64,6 +64,7 @@ export type ProcessedConfig = {
   merger: MergerFn;
   mergerType: string;
   pubsub: MeshPubSub;
+  liveQueryInvalidations: YamlConfig.LiveQueryInvalidation[];
   config: YamlConfig.Config;
 };
 
@@ -155,6 +156,7 @@ export async function processConfig(
     merger,
     mergerType: config.merger,
     pubsub,
+    liveQueryInvalidations: config.liveQueryInvalidations,
     config,
   };
 }

--- a/packages/config/yaml-config.graphql
+++ b/packages/config/yaml-config.graphql
@@ -89,5 +89,5 @@ type PubSubConfig {
 
 type LiveQueryInvalidation {
   field: String!
-  invalidate: String!
+  invalidate: [String!]!
 }

--- a/packages/config/yaml-config.graphql
+++ b/packages/config/yaml-config.graphql
@@ -28,6 +28,10 @@ type Query {
   PubSub Implementation
   """
   pubsub: PubSub
+  """
+  Live Query Invalidations
+  """
+  liveQueryInvalidations: [LiveQueryInvalidation]
 }
 
 scalar JSON
@@ -81,4 +85,9 @@ union PubSub = String | PubSubConfig
 type PubSubConfig {
   name: String!
   config: Any
+}
+
+type LiveQueryInvalidation {
+  field: String!
+  invalidate: String!
 }

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -13,6 +13,8 @@
     "definition": "dist/index.d.ts"
   },
   "dependencies": {
+    "@n1ru4l/graphql-live-query": "0.7.1",
+    "@n1ru4l/in-memory-live-query-store": "0.6.0",
     "@graphql-mesh/types": "0.30.1",
     "@graphql-mesh/utils": "0.8.7",
     "@graphql-tools/delegate": "7.0.10",

--- a/packages/runtime/src/get-mesh.ts
+++ b/packages/runtime/src/get-mesh.ts
@@ -1,11 +1,13 @@
 /* eslint-disable no-unused-expressions */
-import { GraphQLSchema, execute, DocumentNode, GraphQLError, subscribe } from 'graphql';
+import { GraphQLSchema, DocumentNode, GraphQLError, subscribe, parse } from 'graphql';
 import { ExecuteMeshFn, GetMeshOptions, Requester, SubscribeMeshFn } from './types';
 import { MeshPubSub, KeyValueCache, RawSourceOutput, GraphQLOperation } from '@graphql-mesh/types';
 
 import { applyResolversHooksToSchema } from './resolvers-hooks';
 import { MESH_CONTEXT_SYMBOL, MESH_API_CONTEXT_SYMBOL } from './constants';
 import { applySchemaTransforms, ensureDocumentNode, groupTransforms } from '@graphql-mesh/utils';
+
+import { InMemoryLiveQueryStore } from '@n1ru4l/in-memory-live-query-store';
 
 export async function getMesh(
   options: GetMeshOptions
@@ -19,6 +21,7 @@ export async function getMesh(
   destroy: () => void;
   pubsub: MeshPubSub;
   cache: KeyValueCache;
+  liveQueryStore: InMemoryLiveQueryStore;
 }> {
   const rawSources: RawSourceOutput[] = [];
   const { pubsub, cache } = options;
@@ -55,6 +58,13 @@ export async function getMesh(
     })
   );
 
+  options.additionalTypeDefs = options.additionalTypeDefs || [];
+  options.additionalTypeDefs.push(
+    parse(/* GraphQL */ `
+      directive @live on QUERY
+    `)
+  );
+
   let unifiedSchema = await options.merger({
     rawSources,
     cache,
@@ -66,12 +76,29 @@ export async function getMesh(
 
   unifiedSchema = applyResolversHooksToSchema(unifiedSchema, pubsub);
 
+  const liveQueryStore = new InMemoryLiveQueryStore();
+
+  const liveQueryInvalidationMap = new Map<string, string>();
+
+  options.liveQueryInvalidations?.forEach(liveQueryInvalidation => {
+    liveQueryInvalidationMap.set(liveQueryInvalidation.field, liveQueryInvalidation.invalidate);
+  });
+
+  pubsub.subscribe('resolverDone', ({ resolverData }) => {
+    const path = `${resolverData.info.parentType.name}.${resolverData.info.fieldName}`;
+    if (liveQueryInvalidationMap.has(path)) {
+      const invalidationPath = liveQueryInvalidationMap.get(path);
+      liveQueryStore.invalidate(invalidationPath);
+    }
+  });
+
   async function buildMeshContext<TAdditionalContext, TContext extends TAdditionalContext = any>(
     additionalContext: TAdditionalContext = {} as any
   ): Promise<TContext> {
     const context: TContext = Object.assign(additionalContext as any, {
       pubsub,
       cache,
+      liveQueryStore,
       [MESH_CONTEXT_SYMBOL]: true,
     });
 
@@ -102,16 +129,18 @@ export async function getMesh(
     document: GraphQLOperation<TData, TVariables>,
     variables?: TVariables,
     context?: TContext,
-    rootValue?: TRootValue
+    rootValue?: TRootValue,
+    operationName?: string
   ) {
-    const contextValue = await buildMeshContext(context);
+    const contextValue = context && context[MESH_CONTEXT_SYMBOL] ? context : await buildMeshContext(context);
 
-    return execute({
+    return liveQueryStore.execute({
       document: ensureDocumentNode(document),
       contextValue,
       rootValue: rootValue || {},
       variableValues: variables || {},
       schema: unifiedSchema,
+      operationName,
     });
   }
 
@@ -119,9 +148,10 @@ export async function getMesh(
     document: GraphQLOperation<TData, TVariables>,
     variables?: TVariables,
     context?: TContext,
-    rootValue?: TRootValue
+    rootValue?: TRootValue,
+    operationName?: string
   ) {
-    const contextValue = await buildMeshContext(context);
+    const contextValue = context && context[MESH_CONTEXT_SYMBOL] ? context : await buildMeshContext(context);
 
     return subscribe({
       document: ensureDocumentNode(document),
@@ -129,15 +159,24 @@ export async function getMesh(
       rootValue: rootValue || {},
       variableValues: variables || {},
       schema: unifiedSchema,
+      operationName,
     });
   }
 
   const localRequester: Requester = async <Result, TVariables, TContext, TRootValue>(
     document: DocumentNode,
     variables: TVariables,
-    context: TContext
+    contextValue?: TContext,
+    rootValue?: TRootValue,
+    operationName?: string
   ) => {
-    const executionResult = await meshExecute<TVariables, TContext, TRootValue>(document, variables, context);
+    const executionResult = await meshExecute<TVariables, TContext, TRootValue>(
+      document,
+      variables,
+      contextValue,
+      rootValue,
+      operationName
+    );
 
     if ('data' in executionResult) {
       if (executionResult.data && !executionResult.errors) {
@@ -165,6 +204,7 @@ export async function getMesh(
     cache,
     pubsub,
     destroy: () => pubsub.publish('destroy', undefined),
+    liveQueryStore,
   };
 }
 

--- a/packages/runtime/src/types.ts
+++ b/packages/runtime/src/types.ts
@@ -6,6 +6,7 @@ import {
   GraphQLOperation,
   MeshHandler,
   MeshTransform,
+  YamlConfig,
 } from '@graphql-mesh/types';
 import { DocumentNode } from 'graphql';
 import { IResolvers } from '@graphql-tools/utils';
@@ -20,6 +21,7 @@ export type GetMeshOptions = {
   pubsub: MeshPubSub;
   ignoreAdditionalResolvers?: boolean;
   merger: MergerFn;
+  liveQueryInvalidations?: YamlConfig.LiveQueryInvalidation[];
 };
 
 export type MeshResolvedSource<TContext = any> = {
@@ -28,14 +30,20 @@ export type MeshResolvedSource<TContext = any> = {
   transforms?: MeshTransform[];
 };
 
-export type ExecuteMeshFn<TData = any, TVariables = any> = (
+export type ExecuteMeshFn<TData = any, TVariables = any, TContext = any, TRootValue = any> = (
   document: GraphQLOperation<TData, TVariables>,
-  variables: TVariables
+  variables: TVariables,
+  context?: TContext,
+  rootValue?: TRootValue,
+  operationName?: string
 ) => Promise<TData | null | undefined>;
 
-export type SubscribeMeshFn<TData = any, TVariables = any> = (
+export type SubscribeMeshFn<TVariables = any, TContext = any, TRootValue = any, TData = any> = (
   document: GraphQLOperation<TData, TVariables>,
-  variables: TVariables
+  variables?: TVariables,
+  context?: TContext,
+  rootValue?: TRootValue,
+  operationName?: string
 ) => Promise<TData | null | undefined | AsyncIterableIterator<TData | null | undefined>>;
 
 export type Requester<C = any> = <R, V>(doc: DocumentNode, vars?: V, options?: C) => Promise<R>;

--- a/packages/types/src/config-schema.json
+++ b/packages/types/src/config-schema.json
@@ -522,6 +522,20 @@
       },
       "required": ["name"]
     },
+    "LiveQueryInvalidation": {
+      "additionalProperties": false,
+      "type": "object",
+      "title": "LiveQueryInvalidation",
+      "properties": {
+        "field": {
+          "type": "string"
+        },
+        "invalidate": {
+          "type": "string"
+        }
+      },
+      "required": ["field", "invalidate"]
+    },
     "FhirHandler": {
       "additionalProperties": false,
       "type": "object",
@@ -2302,6 +2316,14 @@
           "$ref": "#/definitions/PubSubConfig"
         }
       ]
+    },
+    "liveQueryInvalidations": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/LiveQueryInvalidation"
+      },
+      "additionalItems": false,
+      "description": "Live Query Invalidations"
     }
   },
   "additionalProperties": false

--- a/packages/types/src/config-schema.json
+++ b/packages/types/src/config-schema.json
@@ -531,7 +531,11 @@
           "type": "string"
         },
         "invalidate": {
-          "type": "string"
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "additionalItems": false
         }
       },
       "required": ["field", "invalidate"]

--- a/packages/types/src/config.ts
+++ b/packages/types/src/config.ts
@@ -33,6 +33,10 @@ export interface Config {
    * PubSub Implementation (Any of: String, PubSubConfig)
    */
   pubsub?: string | PubSubConfig;
+  /**
+   * Live Query Invalidations
+   */
+  liveQueryInvalidations?: LiveQueryInvalidation[];
 }
 /**
  * Configuration for `mesh serve` command.
@@ -1234,4 +1238,8 @@ export interface RedisConfig {
 export interface PubSubConfig {
   name: string;
   config?: any;
+}
+export interface LiveQueryInvalidation {
+  field: string;
+  invalidate: string;
 }

--- a/packages/types/src/config.ts
+++ b/packages/types/src/config.ts
@@ -1241,5 +1241,5 @@ export interface PubSubConfig {
 }
 export interface LiveQueryInvalidation {
   field: string;
-  invalidate: string;
+  invalidate: string[];
 }

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -37,11 +37,12 @@ export interface MeshHandlerLibrary<TConfig = any, TContext = any> {
   new (options: GetMeshSourceOptions<TConfig>): MeshHandler<TContext>;
 }
 
-export type ResolverData<TParent = any, TArgs = any, TContext = any> = {
+export type ResolverData<TParent = any, TArgs = any, TContext = any, TResult = any> = {
   root?: TParent;
   args?: TArgs;
   context?: TContext;
   info?: GraphQLResolveInfo;
+  result?: TResult;
 };
 
 // Hooks

--- a/website/docs/recipes/as-gateway.md
+++ b/website/docs/recipes/as-gateway.md
@@ -4,6 +4,11 @@ title: Mesh as Gateway
 sidebar_label: Mesh as Gateway
 ---
 
+<p align="center">
+  <img src="/img/as-gateway.png" width="450" alt="Apollo Federation" />
+  <br/>
+</p>
+
 You can use GraphQL Mesh as a gateway for your data sources. CLI's `serve` command creates a GraphQL Endpoint with GraphQL Playground.
 
 ```bash
@@ -19,4 +24,3 @@ serve:
 
 {@import ../generated-markdown/ServeConfig.generated.md}
 
-![GraphQL Mesh](/img/as-gateway.png)

--- a/website/docs/recipes/federation.md
+++ b/website/docs/recipes/federation.md
@@ -4,6 +4,11 @@ title: Apollo Federation
 sidebar_label: Apollo Federation
 ---
 
+<p align="center">
+  <img src="https://storage.googleapis.com/xebia-blog/1/2019/10/apollo-federation.jpg" width="300" alt="Apollo Federation" />
+<br/>
+</p>
+
 You can use Apollo Federation as a merging strategy in favor of Schema Stitching approach.
 
 To get started, install the merger library from NPM:

--- a/website/docs/recipes/live-queries.md
+++ b/website/docs/recipes/live-queries.md
@@ -1,0 +1,91 @@
+---
+id: live-queries
+title: Live Queries
+sidebar_label: Live Queries
+---
+
+[Laurin Quast](https://github.com/n1ru4l)'s GraphQL Live Query implementation can be used in GraphQL Mesh with a few addition in the configuration.
+
+Let's say you have a `Query` root field that returns all `Todo` entities from your data source like below;
+
+```graphql
+query getTodos {
+    todos {
+        id
+        content
+    }
+}
+```
+
+And you want to update this operation result automatically without manual refresh when `Mutation.addTodo` is called.
+
+The only thing you need is to add the following configuration to your existing configuration;
+
+```yml
+liveQueryInvalidations:
+    - field: Mutation.addTodo
+      invalidate: 
+        - Query.todos
+```
+
+Then you can send a live query with `@live` directive;
+
+```graphql
+query getTodos @live {
+    todos {
+        id
+        content
+    }
+}
+```
+
+This will start a real-time connection between server and your client, then the response of `todos` will get updated whenever `addTodo` is called.
+
+### ID Based Invalidation
+
+Let's say you have the following query that returns specific `Todo` entity based on `id` field;
+
+```graphql
+query getTodo($id: ID!) {
+    todo(id: $id) {]
+        id
+        content
+    }
+}
+```
+
+And you update this entity with `editTodo` mutation field on your backend then you want to invalidate this entity specifically instead of validating all `todo` queries;
+
+```yml
+liveQueryInvalidations:
+    - field: Mutation.editTodo
+      invalidate: 
+        - Todo:{args.id}
+```
+
+### Programmatic Usage
+
+`liveQueryStore` is available in GraphQL Context so you can access it in resolvers composition functions that wrap existing resolvers or additional resolvers;
+
+See [Resolvers Composition](/docs/transforms/resolvers-composition)
+
+```yml
+transforms:
+    - resolversComposition:
+        - resolver: Mutation.editTodo
+          composer: invalidate-todo#invalidateTodo
+```
+
+And in this code file;
+
+```js
+module.exports = {
+    invalidateTodo: next => (root, args, context, info) => {
+        const result = await next(root, args, context, info);
+        context.liveQueryStore.invalidate(`Todo:${args.id}`);
+        return result;
+    }
+}
+```
+
+> You can learn more about [GraphQL Live Query](https://github.com/n1ru4l/graphql-live-query) in its documentation.

--- a/website/docs/recipes/live-queries.md
+++ b/website/docs/recipes/live-queries.md
@@ -4,6 +4,8 @@ title: Live Queries
 sidebar_label: Live Queries
 ---
 
+![image](https://raw.githubusercontent.com/n1ru4l/graphql-live-query/main/assets/logo.svg)
+
 [Laurin Quast](https://github.com/n1ru4l)'s GraphQL Live Query implementation can be used in GraphQL Mesh with a few addition in the configuration.
 
 Let's say you have a `Query` root field that returns all `Todo` entities from your data source like below;

--- a/website/docs/recipes/live-queries.md
+++ b/website/docs/recipes/live-queries.md
@@ -4,9 +4,14 @@ title: Live Queries
 sidebar_label: Live Queries
 ---
 
-![image](https://raw.githubusercontent.com/n1ru4l/graphql-live-query/main/assets/logo.svg)
+<p align="center">
+  <img src="https://raw.githubusercontent.com/n1ru4l/graphql-live-query/main/assets/logo.svg" width="300" alt="GraphQL Live Query" />
+  <br/>
+</p>
 
-[Laurin Quast](https://github.com/n1ru4l)'s GraphQL Live Query implementation can be used in GraphQL Mesh with a few addition in the configuration.
+GraphQL Live Query implementation from [Laurin Quast](https://github.com/n1ru4l) can be used in GraphQL Mesh with a few addition in the configuration.
+
+### Basic Usage
 
 Let's say you have a `Query` root field that returns all `Todo` entities from your data source like below;
 

--- a/website/docs/recipes/subscriptions-webhooks.md
+++ b/website/docs/recipes/subscriptions-webhooks.md
@@ -4,6 +4,11 @@ title: Handle Webhooks with GraphQL Subscriptions
 sidebar_label: Subscriptions & Webhooks
 ---
 
+<p align="center">
+  <img src="https://the-guild.dev/blog-assets/graphql-mesh-subscriptions/cover.png" width="300"  />
+  <br/>
+</p>
+
 GraphQL Mesh can consume Webhooks as GraphQL Subscriptions in the unified schema by using built-in PubSub implementation
 
 ## Add new Subscription field

--- a/website/docs/transforms/resolvers-composition.md
+++ b/website/docs/transforms/resolvers-composition.md
@@ -24,12 +24,14 @@ transforms:
 ```
 
 ```ts
-export const isAuth = next => (root, args, context, info) => {
-    if(!context.currentUser) {
-        throw new Error('Unauthorized');
-    }
-    return next(root, args, context, info);
-}
+module.exports = {
+  isAuth: next => (root, args, context, info) => {
+      if(!context.currentUser) {
+          throw new Error('Unauthorized');
+      }
+      return next(root, args, context, info);
+  }
+};
 ```
 
 

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -41,6 +41,7 @@ module.exports = {
       'recipes/as-gateway',
       'recipes/federation',
       'recipes/subscriptions-webhooks',
+      'recipes/live-queries'
     ],
     "API Reference": require('./api-sidebar.json')
     // 'Extend Your Mesh': ['extend/custom-handler', 'extend/custom-transform']

--- a/yarn.lock
+++ b/yarn.lock
@@ -3380,6 +3380,25 @@
     call-me-maybe "^1.0.1"
     glob-to-regexp "^0.3.0"
 
+"@n1ru4l/graphql-live-query@0.7.1":
+  version "0.7.1"
+  resolved "https://registry.yarnpkg.com/@n1ru4l/graphql-live-query/-/graphql-live-query-0.7.1.tgz#c020d017c3ed6bcfdde49a7106ba035e4d0774f5"
+  integrity sha512-5kJPe2FkPNsCGu9tocKIzUSNO986qAqdnbk8hIFqWlpVPBAmEAOYb1mr6PA18FYAlu7ojWm9Hm13k29aj2GGlQ==
+
+"@n1ru4l/in-memory-live-query-store@0.6.0":
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/@n1ru4l/in-memory-live-query-store/-/in-memory-live-query-store-0.6.0.tgz#37803d8a269da9d2f145edec5d163fcdb333a0d5"
+  integrity sha512-zBGXCq8yih6GbXOnouUejqZnfGmXGX5BTIURv0e28fVpWVEXpMVax+jAvyN9DdBTbFWuI6k2MR56BPP5LF1smg==
+  dependencies:
+    "@graphql-tools/wrap" "^7.0.3"
+    "@n1ru4l/graphql-live-query" "0.7.1"
+    "@n1ru4l/push-pull-async-iterable-iterator" "^2.0.0"
+
+"@n1ru4l/push-pull-async-iterable-iterator@^2.0.0":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@n1ru4l/push-pull-async-iterable-iterator/-/push-pull-async-iterable-iterator-2.0.1.tgz#8fc68e0e9e8bd3826d727b96ddd2afba2a7f26c7"
+  integrity sha512-3nDfpI/4WZgdocw75cxG4Qwmi3yp5zOleaT23EpVUhwVwlYzb4kDojl0nCZKB5lCGcTqT5wFlKepShs4Q+hymw==
+
 "@nodelib/fs.scandir@2.1.3":
   version "2.1.3"
   resolved "https://registry.yarnpkg.com/@nodelib/fs.scandir/-/fs.scandir-2.1.3.tgz#3a582bdb53804c6ba6d146579c46e52130cf4a3b"


### PR DESCRIPTION
Based on the amazing work at https://github.com/n1ru4l/graphql-live-query

Configuration:
```yml
liveQueryInvalidations:
  - field: Mutation.addTodo
    invalidate: 
       - Query.todos
  - field: Mutation.editTodo
    invalidate:
      - Todo:{args.id} # Invalidates updated Todo
```

And query;
```graphql
query getTodos @live {
  todos {
     ...
  }
}
```