### PR TITLE
Introduce new declarative syntax for filtering Types

### DIFF
--- a/packages/transforms/filter-schema/src/bareFilter.ts
+++ b/packages/transforms/filter-schema/src/bareFilter.ts
@@ -20,18 +20,25 @@ export default class BareFilter implements MeshTransform {
     for (const filter of filters) {
       const [typeName, fieldNameOrGlob, argsGlob] = filter.split('.');
 
+      // TODO: deprecate this in next major release as dscussed in #1605
       if (!fieldNameOrGlob) {
         this.typeGlobs.push(typeName);
         continue;
       }
 
       const rawGlob = argsGlob || fieldNameOrGlob;
-      const mapName = argsGlob ? 'argsMap' : 'fieldsMap';
-      const mapKey = argsGlob ? `${typeName}_${fieldNameOrGlob}` : typeName;
-      const currentRules = this[mapName].get(mapKey) || [];
       const fixedGlob =
         rawGlob.includes('{') && !rawGlob.includes(',') ? rawGlob.replace('{', '').replace('}', '') : rawGlob;
       const polishedGlob = fixedGlob.split(', ').join(',').trim();
+
+      if (typeName === 'Type') {
+        this.typeGlobs.push(polishedGlob);
+        continue;
+      }
+
+      const mapName = argsGlob ? 'argsMap' : 'fieldsMap';
+      const mapKey = argsGlob ? `${typeName}_${fieldNameOrGlob}` : typeName;
+      const currentRules = this[mapName].get(mapKey) || [];
 
       this[mapName].set(mapKey, [...currentRules, polishedGlob]);
     }

--- a/website/docs/transforms/filter-schema.md
+++ b/website/docs/transforms/filter-schema.md
@@ -19,7 +19,8 @@ transforms:
   - filterSchema:
       mode: bare | wrap
       filters:
-        - "!User" # <-- This will remove `User` type
+        - "Type.!User" # <-- This will remove `User` type
+        - "Type.!{User, Post}" # <-- This will remove `User` and `Post` types
 
         - Query.!admins # <-- This will remove field `admins` from `Query` type
         - Mutation.!{addUser, removeUser} # <-- This will remove fields `addUser` and `removeUser` from `Mutation` type
@@ -55,6 +56,11 @@ type User {
   age: Int
   ipAddress: String
 }
+
+type LooseType {
+  foo: String
+  bar: String
+}
 ```
 
 With the following Filter Schema config,
@@ -63,11 +69,11 @@ transforms:
   - filterSchema:
       mode: bare | wrap
       filters:
+        - Type.!LooseType
         - Query.!admins
         - Mutation.!{addUser, removeUser}
-        - User.{username, name, age} # <-- This will remove all fields, from User type, except `id`, `username`, `name` and `age`
-
-        - Query.user.!name # <-- This will remove argument `id` from field `user`, in Query type
+        - User.{username, name, age}
+        - Query.user.!name
 ```
 
 It would become the following schema:


### PR DESCRIPTION
## Description
As per #1605, this PR introduces declarative syntax for filtering Types.
This is still backward compatible with previous syntax. Comments have been added to remind removing this support in next major release.

## Type of change
Motivation explained in #1605
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Differences
Previous syntax (could only address one type per string)
```yaml
transforms:
  - filterSchema:
      filters:
        - "!User"
```

New syntax (multiple types and potentially regex as well)
```yaml
transforms:
  - filterSchema:
      filters:
        - Type.!{User, Post}
```

## How Has This Been Tested?
Introduced new unit tests to cover both old and new syntax on bare and wrap transform mode.

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests and linter rules pass locally with my changes