### PR TITLE
Fix federation example codesandbox

### DIFF
--- a/examples/federation-example/package.json
+++ b/examples/federation-example/package.json
@@ -4,7 +4,9 @@
   "license": "MIT",
   "private": true,
   "scripts": {
+    "start": "concurrently \"npm:start-services npm:start-gateway-delayed\"",
     "start-gateway": "mesh serve",
+    "start-gateway-delayed": "delay 1 && npm run start-gateway",
     "start-service-accounts": "nodemon services/accounts/index.js",
     "start-service-reviews": "nodemon services/reviews/index.js",
     "start-service-products": "nodemon services/products/index.js",
@@ -16,11 +18,12 @@
     "nodemon": "2.0.6"
   },
   "dependencies": {
-    "apollo-server": "2.21.0",
     "@graphql-mesh/cli": "0.24.1",
+    "@graphql-mesh/graphql": "0.13.18",
     "@graphql-mesh/merger-federation": "0.8.26",
     "@graphql-mesh/transform-federation": "0.4.55",
-    "@graphql-mesh/graphql": "0.13.18",
+    "apollo-server": "2.21.0",
+    "delay-cli": "^1.1.0",
     "graphql": "15.4.0"
   }
 }

--- a/examples/federation-example/sandbox.config.json
+++ b/examples/federation-example/sandbox.config.json
@@ -1,3 +1,7 @@
 {
-  "template": "node"
+  "template": "node",
+  "container": {
+    "node": "14",
+    "port": 4000
+  }
 }


### PR DESCRIPTION
Add delay to start gateway after services

## Description

Fix sandbox.config.json updating to node 14 as a dependency.
Add delay-cli package to create a run-task with a short 1s sleep before starting the gateway.
Add run-task to start services and gateway-delayed.

Fixes #1589 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Screenshots/Sandbox (if appropriate/relevant):

https://codesandbox.io/s/graphql-mesh-federation-sample-nficv

## How Has This Been Tested?

Manually in the sandbox above. 1s delay might not be enough on slow machines though. Better than a broken sandbox in any case.

**Test Environment**:
- OS: Windows 10/MacOS Big Sur
- `@graphql-mesh/...`: examples/federation-example
- NodeJS: 14

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests and linter rules pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

None