### PR TITLE
Fix CLI usage of base-dir

### DIFF
--- a/.changeset/moody-suns-bow.md
+++ b/.changeset/moody-suns-bow.md
@@ -1,0 +1,11 @@
+---
+'@graphql-mesh/cli': minor
+---
+
+Fix CLI usage of base-dir
+
+**Breaking changes**
+This is technically just a bug fix, but it corrects a behaviour that will break if you relied on it.
+When using CLI commands with the `--dir` option, those commands were using your given `--dir` as the base directory.
+
+Now CLI commands always use the Current Working Directory (CWD) as the base directory and so the given `--dir` is used to only get the Mesh Config file and process any local file eventually defined in the Config.

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -79,7 +79,7 @@ export async function graphqlMesh() {
         });
         const { schema, destroy } = await getMesh(meshConfig);
         const result = await generateSdk(schema, args);
-        const outFile = resolve(baseDir, args.output);
+        const outFile = isAbsolute(args.output) ? args.output : resolve(process.cwd(), args.output);
         await writeFile(outFile, result);
         destroy();
       }
@@ -99,26 +99,26 @@ export async function graphqlMesh() {
           ignoreAdditionalResolvers: true,
         });
         const { schema, destroy } = await getMesh(meshConfig);
-        let outputFileContent: string;
-        const outputFileName = args.output;
-        if (outputFileName.endsWith('.json')) {
+        let fileContent: string;
+        const fileName = args.output;
+        if (fileName.endsWith('.json')) {
           const introspection = introspectionFromSchema(schema);
-          outputFileContent = JSON.stringify(introspection, null, 2);
+          fileContent = JSON.stringify(introspection, null, 2);
         } else if (
-          outputFileName.endsWith('.graphql') ||
-          outputFileName.endsWith('.graphqls') ||
-          outputFileName.endsWith('.gql') ||
-          outputFileName.endsWith('.gqls')
+          fileName.endsWith('.graphql') ||
+          fileName.endsWith('.graphqls') ||
+          fileName.endsWith('.gql') ||
+          fileName.endsWith('.gqls')
         ) {
           const printedSchema = printSchemaWithDirectives(schema);
-          outputFileContent = printedSchema;
+          fileContent = printedSchema;
         } else {
-          logger.error(`Invalid file extension ${outputFileName}`);
+          logger.error(`Invalid file extension ${fileName}`);
           destroy();
           return;
         }
-        const absoluteOutputFilePath = resolve(baseDir, outputFileName);
-        await writeFile(absoluteOutputFilePath, outputFileContent);
+        const outFile = isAbsolute(fileName) ? fileName : resolve(process.cwd(), fileName);
+        await writeFile(outFile, fileContent);
         destroy();
       }
     )
@@ -138,7 +138,7 @@ export async function graphqlMesh() {
         });
         const { schema, rawSources, destroy } = await getMesh(meshConfig);
         const result = await generateTsTypes(schema, rawSources, meshConfig.mergerType);
-        const outFile = resolve(baseDir, args.output);
+        const outFile = isAbsolute(args.output) ? args.output : resolve(process.cwd(), args.output);
         await writeFile(outFile, result);
         destroy();
       }


### PR DESCRIPTION
As per #1696, this PR fixes how Mesh CLI is using base-dir.
In fact, this should be used only for anything relative to Mesh Config file; whilst options like `output` should have CWD as base.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
Tested CLI commands relying on `output` option.

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
~- [ ] I have commented my code, particularly in hard-to-understand areas~
~- [ ] I have made corresponding changes to the documentation~
- [x] My changes generate no new warnings
~- [ ] I have added tests that prove my fix is effective or that my feature works~
- [x] New and existing unit tests and linter rules pass locally with my changes
~- [ ] Any dependent changes have been merged and published in downstream modules~