### PR TITLE
OpenAPI allow source spec inline injection

### DIFF
--- a/.changeset/serious-hats-sniff.md
+++ b/.changeset/serious-hats-sniff.md
@@ -1,0 +1,6 @@
+---
+'@graphql-mesh/openapi': minor
+'@graphql-mesh/types': patch
+---
+
+feat(openapi): allow source spec inline injection

--- a/packages/handlers/openapi/src/index.ts
+++ b/packages/handlers/openapi/src/index.ts
@@ -46,7 +46,7 @@ export default class OpenAPIHandler implements MeshHandler {
       selectQueryOrMutationField,
       source,
     } = this.config;
-    const spec = await readFileOrUrlWithCache<Oas3>(source || source, this.cache, {
+    const spec = typeof source !== 'string' ? source : await readFileOrUrlWithCache<Oas3>(source, this.cache, {
       cwd: this.baseDir,
       fallbackFormat: this.config.sourceFormat,
       headers: this.config.schemaHeaders,

--- a/packages/handlers/openapi/yaml-config.graphql
+++ b/packages/handlers/openapi/yaml-config.graphql
@@ -9,7 +9,7 @@ type OpenapiHandler @md {
   """
   A pointer to your API source - could be a local file, remote file or url endpoint
   """
-  source: String!
+  source: Any!
   """
   Format of the source file
   """

--- a/packages/types/src/config-schema.json
+++ b/packages/types/src/config-schema.json
@@ -1488,7 +1488,19 @@
       "title": "OpenapiHandler",
       "properties": {
         "source": {
-          "type": "string",
+          "anyOf": [
+            {
+              "type": "object",
+              "additionalProperties": true
+            },
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "additionalItems": true
+            }
+          ],
           "description": "A pointer to your API source - could be a local file, remote file or url endpoint"
         },
         "sourceFormat": {

--- a/packages/types/src/config.ts
+++ b/packages/types/src/config.ts
@@ -650,7 +650,7 @@ export interface OpenapiHandler {
   /**
    * A pointer to your API source - could be a local file, remote file or url endpoint
    */
-  source: string;
+  source: any;
   /**
    * Format of the source file (Allowed values: json, yaml)
    */


### PR DESCRIPTION
🚨 **IMPORTANT: Please do not create a Pull Request without creating an issue first.**

*Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request.*

## Description
Allow for inline injection of the OpenAPIHandler spec via source as object.
For motivation see https://github.com/Urigo/graphql-mesh/issues/1747
It's not beautiful, feel free to solve this in a better way! I came up with this while taking a first look at the code, it fixed my blocker.

Partially Related #1747 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [?] This change requires a documentation update

## Screenshots/Sandbox (if appropriate/relevant):

Adding links to sandbox or providing screenshots can help us understand more about this PR and take action on it as appropriate

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] I have tested the change in an integrated way only by manually changing the line changed here in the cjs built file.

**Test Environment**:
- OS: MacOS
- `@graphql-mesh/openapi`:
- NodeJS: 14

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests and linter rules pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

I think there are some things missing here, like documentation and more testing.
Also I have to check if I can fix my original issue by using the basedir option or the --dir parameter
