### PR TITLE
use baseDir for path defined in config file

### DIFF
--- a/.changeset/loud-coats-think.md
+++ b/.changeset/loud-coats-think.md
@@ -1,0 +1,5 @@
+---
+'@graphql-mesh/cli': patch
+---
+
+fix(cli): use baseDir for path defined in config file

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -155,7 +155,7 @@ export async function graphqlMesh() {
         const { destroy } = await getMesh(meshConfig);
         const outFile = isAbsolute(meshConfig.config.introspectionCache)
           ? meshConfig.config.introspectionCache
-          : resolve(process.cwd(), meshConfig.config.introspectionCache);
+          : resolve(baseDir, meshConfig.config.introspectionCache);
         await writeJSON(outFile, meshConfig.introspectionCache);
         destroy();
       }


### PR DESCRIPTION
Quick one-line fix.

In #1820 you have introduced introspection cache functionality, as discussed before.
However, as suggested in [PR review](https://github.com/Urigo/graphql-mesh/pull/1820/files#r598774580), we should use `baseDir` for the `introspectionCache` file and not `process.cwd()`.

This is because the file path is defined in Mesh Config file, and not as a command argument.
Anything inside the Mesh Config file should always be relative to the `baseDir` the same Config file lives in.