### PR TITLE
fix: condition to open browser was not right

### DIFF
--- a/packages/cli/src/commands/serve/serve.ts
+++ b/packages/cli/src/commands/serve/serve.ts
@@ -169,7 +169,7 @@ export async function serveMesh(baseDir: string, argsPort?: number) {
 
     httpServer
       .listen(parseInt(port.toString()), hostname, () => {
-        if (process.env.NODE_ENV?.toLowerCase() !== 'production' || !browser) {
+        if (process.env.NODE_ENV?.toLowerCase() !== 'production' && browser) {
           open(serverUrl, typeof browser === 'string' ? { app: browser } : undefined).catch(() => {});
         }
       })


### PR DESCRIPTION
## Description

When `browser` was set to `false`, the browser would still be open as first condition was still valid (`process.env.NODE_ENV?.toLowerCase() !== 'production'`). Using a AND condition fixes that.

Fixes #1847 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- set `browser: false` and launch `mesh serve`, browser should not be opened
- set `browser: true` and launch `mesh serve`, browser should be opened

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests and linter rules pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules