### PR TITLE
feat(runtime): add ability to specify base directory for relative paths in config

### DIFF
--- a/packages/runtime/src/get-mesh.ts
+++ b/packages/runtime/src/get-mesh.ts
@@ -49,7 +49,7 @@ export function groupTransforms({
 
 export async function getMesh(
   options: GetMeshOptions,
-  dir: string = process.cwd();
+  dir: string = process.cwd()
 ): Promise<{
   execute: ExecuteMeshFn;
   subscribe: SubscribeMeshFn;
@@ -63,7 +63,7 @@ export async function getMesh(
 }> {
   const originalCwd = process.cwd();
   
-  if(dir !== originalCwd){
+  if(dir !== originalCwd) {
     process.chdir(dir);
   }  
   
@@ -208,7 +208,7 @@ export async function getMesh(
     }
   };
   
-  if(dir !== originalCwd){
+  if(dir !== originalCwd) {
     process.chdir(originalCwd);
   }
 

--- a/packages/runtime/src/get-mesh.ts
+++ b/packages/runtime/src/get-mesh.ts
@@ -48,7 +48,8 @@ export function groupTransforms({
 }
 
 export async function getMesh(
-  options: GetMeshOptions
+  options: GetMeshOptions,
+  dir: string = process.cwd();
 ): Promise<{
   execute: ExecuteMeshFn;
   subscribe: SubscribeMeshFn;
@@ -60,6 +61,12 @@ export async function getMesh(
   hooks: Hooks;
   cache: KeyValueCache;
 }> {
+  const originalCwd = process.cwd();
+  
+  if(dir !== originalCwd){
+    process.chdir(dir);
+  }  
+  
   const rawSources: RawSourceOutput[] = [];
   let hooks = options.hooks!;
   if (!hooks) {
@@ -200,6 +207,10 @@ export async function getMesh(
       );
     }
   };
+  
+  if(dir !== originalCwd){
+    process.chdir(originalCwd);
+  }
 
   return {
     execute: meshExecute,


### PR DESCRIPTION
## Description

Allows the user to specify the base directory that is used when loading relative paths defined in the config. 

Before investing too much time into this I wanted to check with you if you are interested in enabling this use case. As well as if you are ok with this relatively blunt approach of temporarily changing the `pwd`. Hence this PR is meant to be understood as preliminary.

Fixes #1877 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Screenshots/Sandbox (if appropriate/relevant):

Adding links to sandbox or providing screenshots can help us understand more about this PR and take action on it as appropriate

## How Has This Been Tested?

We are actively using this approach with no issues, but no extensive tests have been performed.

**Test Environment**:
- OS: Alpine
- `@graphql-mesh@latest`
- NodeJS: 12.x latest

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests and linter rules pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
