### PR TITLE
Make documentation more precise and correct the order of steps.

### DIFF
--- a/website/docs/recipes/typescript.md
+++ b/website/docs/recipes/typescript.md
@@ -4,14 +4,23 @@ title: TypeScript Support
 sidebar_label: TypeScript Support
 ---
 
-GraphQL Mesh supports TypeScript, and you can easily use it to generate typings for the fetched data, or for you custom resolvers that specific under `additionalResolvers`
+GraphQL Mesh supports TypeScript, and you can easily use it to generate typings for the fetched data, and for you custom resolvers that specific under `additionalResolvers`
 
 ## Type safety for custom resolvers
 
-GraphQL Mesh allow API handler packages to provide TypeScript typings in order to have types support in your code.
+GraphQL Mesh allows for API handler packages to provide TypeScript typings in order to have types support in your code.
 
-In order to use the TypeScript support, use the CLI to generate typings file based on your unified GraphQL schema:
+In order to use the TypeScript support, make sure you have the `require` section set in your config file (to allow for the GraphQL Mesh to compile TypeScript files):
 
+```yaml
+require:
+  - ts-node/register/transpile-only
+
+additionalResolvers:
+  - ./src/mesh-resolvers.ts  
+```
+
+Then, use the CLI command to generate the typings file based on your unified GraphQL schema:
 ```
 graphql-mesh typescript --output ./src/generated/mesh.ts
 ```
@@ -26,14 +35,6 @@ export const resolvers: Resolvers = {
 };
 ```
 
-And make sure you have `require` section set in your config file (to allow GraphQL Mesh to compile TypeScript files):
-
-```yaml
-require:
-  - ts-node/register/transpile-only
-additionalResolvers:
-  - ./src/mesh-resolvers.ts  
-```
 
 ## Type safety for fetched data
 


### PR DESCRIPTION
## Description
First, before the CLI command can be executed, the `require: -ts-node...` should be in the .yaml file, thus I've moved it above the CLI step.

Second, the API here only describes how to generate Typescript types for the entire schema. From this API it is clear that that is the only option available, and the description should be clear on that part. 
If, however, it is possible to do achieve more, then please clarify that in the documentation.

Fixes # https://github.com/Urigo/graphql-mesh/issues/1919

## Type of change

- [X] This change requires a documentation update

**Test Environment**:
- OS:
- "@graphql-mesh/cli": "0.26.2",
- "@graphql-mesh/graphql": "0.15.2",
- "@graphql-mesh/openapi": "0.13.3",
- "@graphql-mesh/runtime": "0.12.0",
- "@graphql-mesh/transform-mock": "0.8.5",
- NodeJS:

## Checklist:

- [X] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests and linter rules pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
