### PR TITLE
Add wrap mode to resolvers-composition transform

### DIFF
--- a/packages/transforms/resolvers-composition/src/index.ts
+++ b/packages/transforms/resolvers-composition/src/index.ts
@@ -5,19 +5,20 @@ import { composeResolvers, ResolversComposerMapping } from '@graphql-tools/resol
 import { extractResolvers, loadFromModuleExportExpressionSync } from '@graphql-mesh/utils';
 
 export default class ResolversCompositionTransform implements MeshTransform {
-  public noWrap = true;
-  private config: YamlConfig.Transform['resolversComposition'];
+  public noWrap: boolean;
+  private compositions: YamlConfig.ResolversCompositionTransform['compositions'];
   private baseDir: string;
 
   constructor({ baseDir, config }: MeshTransformOptions<YamlConfig.Transform['resolversComposition']>) {
-    this.config = config;
+    this.noWrap = config.mode ? config.mode !== 'wrap' : false; // use config.mode value or default to false
+    this.compositions = Array.isArray(config) ? config : config.compositions;
     this.baseDir = baseDir;
   }
 
   transformSchema(schema: GraphQLSchema) {
     const resolversComposition: ResolversComposerMapping = {};
 
-    for (const { resolver, composer } of this.config) {
+    for (const { resolver, composer } of this.compositions) {
       resolversComposition[resolver] = loadFromModuleExportExpressionSync(composer, {
         defaultExportName: 'default',
         cwd: this.baseDir,

--- a/packages/transforms/resolvers-composition/yaml-config.graphql
+++ b/packages/transforms/resolvers-composition/yaml-config.graphql
@@ -2,10 +2,23 @@ extend type Transform {
   """
   Transformer to apply composition to resolvers
   """
-  resolversComposition: [ResolversCompositionTransformObject!]
+  resolversComposition: ResolversCompositionTransformConfig
 }
 
-type ResolversCompositionTransformObject @md {
+union ResolversCompositionTransformConfig = ResolversCompositionTransform | Any
+
+type ResolversCompositionTransform @md {
+  """
+  Specify to apply resolvers-composition transforms to bare schema or by wrapping original schema
+  """
+  mode: ResolversCompositionTransformMode
+  """
+  Array of resolver/composer to apply
+  """
+  compositions: [ResolversCompositionTransformObject!]!
+}
+
+type ResolversCompositionTransformObject {
   """
   The GraphQL Resolver path
   Example: Query.users
@@ -16,4 +29,9 @@ type ResolversCompositionTransformObject @md {
   Example: ./src/auth.js#authComposer
   """
   composer: Any!
+}
+
+enum ResolversCompositionTransformMode {
+  bare
+  wrap
 }

--- a/packages/types/src/config-schema.json
+++ b/packages/types/src/config-schema.json
@@ -410,12 +410,27 @@
           ]
         },
         "resolversComposition": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/ResolversCompositionTransformObject"
-          },
-          "additionalItems": false,
-          "description": "Transformer to apply composition to resolvers"
+          "description": "Transformer to apply composition to resolvers (Any of: ResolversCompositionTransform, Any)",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/ResolversCompositionTransform"
+            },
+            {
+              "anyOf": [
+                {
+                  "type": "object",
+                  "additionalProperties": true
+                },
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "array",
+                  "additionalItems": true
+                }
+              ]
+            }
+          ]
         },
         "snapshot": {
           "$ref": "#/definitions/SnapshotTransformConfig",
@@ -2232,6 +2247,27 @@
           "type": "string"
         }
       }
+    },
+    "ResolversCompositionTransform": {
+      "additionalProperties": false,
+      "type": "object",
+      "title": "ResolversCompositionTransform",
+      "properties": {
+        "mode": {
+          "type": "string",
+          "enum": ["bare", "wrap"],
+          "description": "Specify to apply resolvers-composition transforms to bare schema or by wrapping original schema (Allowed values: bare, wrap)"
+        },
+        "compositions": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ResolversCompositionTransformObject"
+          },
+          "additionalItems": false,
+          "description": "Array of resolver/composer to apply"
+        }
+      },
+      "required": ["compositions"]
     },
     "ResolversCompositionTransformObject": {
       "additionalProperties": false,

--- a/packages/types/src/config.ts
+++ b/packages/types/src/config.ts
@@ -891,9 +891,9 @@ export interface Transform {
    */
   rename?: RenameTransform | any;
   /**
-   * Transformer to apply composition to resolvers
+   * Transformer to apply composition to resolvers (Any of: ResolversCompositionTransform, Any)
    */
-  resolversComposition?: ResolversCompositionTransformObject[];
+  resolversComposition?: ResolversCompositionTransform | any;
   snapshot?: SnapshotTransformConfig;
   [k: string]: any;
 }
@@ -1160,6 +1160,16 @@ export interface RenameConfig {
 export interface RenameConfig1 {
   type?: string;
   field?: string;
+}
+export interface ResolversCompositionTransform {
+  /**
+   * Specify to apply resolvers-composition transforms to bare schema or by wrapping original schema (Allowed values: bare, wrap)
+   */
+  mode?: 'bare' | 'wrap';
+  /**
+   * Array of resolver/composer to apply
+   */
+  compositions: ResolversCompositionTransformObject[];
 }
 export interface ResolversCompositionTransformObject {
   /**

--- a/website/docs/getting-started/mesh-transforms.md
+++ b/website/docs/getting-started/mesh-transforms.md
@@ -186,17 +186,21 @@ transforms:
             field: code
 ```
 
-### Transforms supporting "bare" mode
+### Modes support
 
-Being a recent addition, "bare" mode is not available to all transforms yet.  
-The table below gives you the list of transforms that support "bare" mode. Transforms not listed here do not support "bare", and so only implement default "wrap" mode.  
-If you have use cases where you believe "bare" mode should be added to a transform not listed here, feel free to [open a feature request](https://github.com/Urigo/graphql-mesh/issues/new/choose).
+The table below illustrates how "bare" and "wrap" modes are supported across all transforms.  
+If you have use cases for which you would require to introduce either "bare" or "wrap" mode to one of the transforms, feel free to [open a feature request](https://github.com/Urigo/graphql-mesh/issues/new/choose).
 
 | Transform             | Bare | Wrap |                      Docs                      |
 | --------------------- | :--: | :--: | :--------------------------------------------: |
 | Cache                 |  ✅  |  ❌  | [docs](/docs/transforms/cache)                 |
+| Encapsulate           |  ❌  |  ✅  | [docs](/docs/transforms/encapsulate)           |
 | Extend                |  ✅  |  ❌  | [docs](/docs/transforms/extend)                |
+| Federation            |  ❌  |  ✅  | [docs](/docs/transforms/federation)            |
 | Filter Schema         |  ✅  |  ✅  | [docs](/docs/transforms/filter-schema)         |
+| Mock                  |  ❌  |  ✅  | [docs](/docs/transforms/mock)                  |
+| Naming Convention     |  ❌  |  ✅  | [docs](/docs/transforms/naming-convention)     |
+| Prefix                |  ❌  |  ✅  | [docs](/docs/transforms/prefix)                |
 | Rename                |  ✅  |  ✅  | [docs](/docs/transforms/rename)                |
-| Resolvers Composition |  ✅  |  ❌  | [docs](/docs/transforms/resolvers-composition) |
+| Resolvers Composition |  ✅  |  ✅  | [docs](/docs/transforms/resolvers-composition) |
 | Snapshot              |  ✅  |  ❌  | [docs](/docs/transforms/snapshot)              |

--- a/website/docs/transforms/resolvers-composition.md
+++ b/website/docs/transforms/resolvers-composition.md
@@ -17,6 +17,8 @@ Add the following configuration to your Mesh config file:
 ```yml
 transforms:
   - resolversComposition:
+      mode: bare | wrap
+      compositions:
         - resolver: 'Query.me'
           composer: is-auth#isAuth
         - resolver: 'Mutation.*'
@@ -35,6 +37,7 @@ module.exports = {
 };
 ```
 
+> For information about "bare" and "wrap" modes, please read the [dedicated section](/docs/getting-started/mesh-transforms#two-different-modes).
 
 <iframe
      src="https://codesandbox.io/embed/github/Urigo/graphql-mesh/tree/master/examples/openapi-youtrack?fontsize=14&hidenavigation=1&theme=dark&module=%2F.meshrc.yml"


### PR DESCRIPTION
As per the title, this PR introduces "wrap" mode to the resolvers-composition transform.
This is in order to make this transform work on GraphQL sources.
The PR is related to#1891.

I tested the changes and updated and extended the documentation.

I introduced a new syntax for the transform but also kept backward compatibility with the previous syntax, this is in line with other transforms that support both "bare" and "wrap" modes.
The new syntax is as follow, note the new "mode" property, and the array that is now wrapped under "compositions" property:
```yml
transforms:
  - resolversComposition:
      mode: bare | wrap
      compositions:
        - resolver: 'Query.me'
          composer: is-auth#isAuth
        - resolver: 'Mutation.*'
          composer: is-admin#isAdmin
```

### Important thing to note:
This transform didn't support "wrap" mode prior to this PR. However, the convention established for transforms is to work in "wrap" mode by default.
This means that now that the transform supports "wrap", I made this the default mode; hence if "mode" property is not specified, then "wrap" will be applied by default.

This is consistent with other transforms that support both modes, however, it might have undesired effects for users that are currently using this transform.
Potentially we could make default mode for this transform to be "bare", to avoid a change in behavior for existing users; however, that would become inconsistent with other transforms.

I believe we need to stick to the decision made to operate in "wrap" by default.

Once agreed, I will add the changeset and specify the potentially breaking behavior (not breaking changes in terms of API though).