### PR TITLE
Fix Json parse error for successful responses that have no content Eg…

### DIFF
--- a/.changeset/nine-cars-walk.md
+++ b/.changeset/nine-cars-walk.md
@@ -1,0 +1,5 @@
+---
+'@graphql-mesh/openapi': patch
+---
+
+Fixed open api to graph ql mesh to handle successful responses that have no content. For Example 204-No Content.

--- a/packages/handlers/openapi/src/openapi-to-graphql/resolver_builder.ts
+++ b/packages/handlers/openapi/src/openapi-to-graphql/resolver_builder.ts
@@ -617,7 +617,7 @@ export function getResolver<TSource, TContext, TArgs>(
         if (response.headers.get('content-type').includes('json')) {
           let responseBody;
           try {
-            responseBody = JSON.parse(body);
+            responseBody = body ? JSON.parse(body) : {};
           } catch (e) {
             const errorString =
               `Cannot JSON parse response body of ` +


### PR DESCRIPTION
## Description

GQL-mesh crashes when receiving a successful API response that has no content. For example when receiving a response of type 204-No Content. 

Fixes # 1860

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests and linter rules pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

