### PR TITLE
Ensure cache transform respects subfield arguments.

### DIFF
--- a/.changeset/tricky-eyes-sneeze.md
+++ b/.changeset/tricky-eyes-sneeze.md
@@ -1,0 +1,5 @@
+---
+'@graphql-mesh/transform-cache': patch
+---
+
+Ensure cache transform respects subfield arguments.

--- a/packages/transforms/cache/src/compute-cache-key.ts
+++ b/packages/transforms/cache/src/compute-cache-key.ts
@@ -9,7 +9,7 @@ export function computeCacheKey(options: {
   info: GraphQLResolveInfo;
 }): string {
   const argsHash = options.args ? objectHash(options.args, { ignoreUnknown: true }) : '';
-  const fieldsObj = graphqlFields(options.info);
+  const fieldsObj = graphqlFields(options.info, {}, { processArguments: true });
   const fieldNamesHash = objectHash(fieldsObj, { ignoreUnknown: true });
 
   if (!options.keyStr) {

--- a/packages/transforms/cache/test/cache.spec.ts
+++ b/packages/transforms/cache/test/cache.spec.ts
@@ -100,6 +100,11 @@ const spies = {
       });
     }),
   },
+  User: {
+    friend: jest.fn().mockImplementation((_, { id }) => {
+      return MOCK_DATA.find(u => u.id.toString() === id.toString());
+    }),
+  },
 };
 
 describe('cache', () => {
@@ -132,6 +137,7 @@ describe('cache', () => {
         username: String!
         email: String!
         profile: Profile!
+        friend(id: ID!): User
       }
 
       type Profile {
@@ -475,6 +481,59 @@ describe('cache', () => {
       await execute(executeOptions);
       expect(await cache.get(expectedCacheKey)).toBeDefined();
       expect(spies.Query.user.mock.calls.length).toBe(2);
+    });
+
+    describe('Subfields', () => {
+      it('Should cache queries including subfield arguments', async () => {
+        const transform = new CacheTransform({
+          config: [{ field: 'Query.user' }],
+          cache,
+          pubsub,
+          baseDir,
+        });
+        const schemaWithCache = transform.transformSchema(schema);
+
+        // First query should call resolver and fill cache
+        const executeOptions1 = {
+          schema: schemaWithCache,
+          document: parse(/* GraphQL */ `
+            query {
+              user(id: 1) {
+                friend(id: 2) {
+                  id
+                }
+              }
+            }
+          `),
+        };
+        const { data: actual1 } = await execute(executeOptions1);
+        expect(spies.Query.user.mock.calls.length).toBe(1);
+        expect(actual1.user.friend.id).toBe('2');
+
+        // Second query should call resolver and also fill cache
+        const executeOptions2 = {
+          schema: schemaWithCache,
+          document: parse(/* GraphQL */ `
+            query {
+              user(id: 1) {
+                friend(id: 3) {
+                  id
+                }
+              }
+            }
+          `),
+        };
+        const { data: actual2 } = await execute(executeOptions2);
+        expect(spies.Query.user.mock.calls.length).toBe(2);
+        expect(actual2.user.friend.id).toBe('3');
+
+        // Repeat both queries, no new calls for resolver
+        const { data: repeat1 } = await execute(executeOptions1);
+        const { data: repeat2 } = await execute(executeOptions2);
+        expect(spies.Query.user.mock.calls.length).toBe(2);
+        expect(repeat1.user.friend.id).toBe('2');
+        expect(repeat2.user.friend.id).toBe('3');
+      });
     });
   });
 });


### PR DESCRIPTION
## Description

Cache transform does not respect subfield arguments.

Related #1976 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Unit test
- [x] Private project (confirmed resolved)

**Test Environment**:

- OS: macOS Big Sur
- @graphql-mesh/transform-cache: v0.8.39
- NodeJS: v15.11.0

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests and linter rules pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
