### PR TITLE
[1909] Extend the mock test cases - draft 1

### DIFF
--- a/packages/transforms/mock/test/mocks.ts
+++ b/packages/transforms/mock/test/mocks.ts
@@ -1,0 +1,4 @@
+export default {
+  id: 'sample-id',
+  fullName: 'John Snow',
+};


### PR DESCRIPTION
This is a draft pull request addressing the issue https://github.com/Urigo/graphql-mesh/issues/1909.
There should also be a documentation update, which I'll see to hopefully soon.


## Description
Tests have been adjusted to better match expectations, as well as to provide test coverage for already supported use case - the `custom` property.

In the feature, no where it is defined the amount of items that should be returned, yet 2 items get returned and they are both looking the same. To me, this looks like a bug, so I've updated the existing test to match this expectation.

## Type of change

Please delete options that are not relevant.

- [x] Updates test cases


## How Has This Been Tested?

**Test Environment**:
- OS: Windows 10
- "@graphql-mesh/types": "0.39.0",
- "@graphql-mesh/utils": "0.10.0",
- "@graphql-tools/utils": "7.7.3",
- "@graphql-tools/mock": "8.1.1",
- NodeJS: 14.15.5

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests and linter rules pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

## Further comments
At the moment there is only one test covering mocking's one happy path.
The use case test that I've added of handling the custom property is just one, and I have to say, I am surprised of such a simple test coverage. Coupled with the not complete documentation, it really doesn't give a good picture about the tool.