### PR TITLE
Fix object nesting for selectQueryOrMutationField option on openAPI handler

### DIFF
--- a/.changeset/twelve-vans-enjoy.md
+++ b/.changeset/twelve-vans-enjoy.md
@@ -1,0 +1,5 @@
+---
+'@graphql-mesh/openapi': patch
+---
+
+Fix object nesting for selectQueryOrMutationField option on openapi-to-graphql

--- a/packages/handlers/openapi/package.json
+++ b/packages/handlers/openapi/package.json
@@ -25,7 +25,6 @@
     "json-ptr": "2.0.0",
     "graphql-scalars": "1.9.0",
     "graphql-subscriptions": "1.2.1",
-    "lodash": "4.17.21",
     "pluralize": "8.0.0",
     "swagger2openapi": "7.0.5",
     "url-join": "4.0.1"

--- a/packages/handlers/openapi/src/index.ts
+++ b/packages/handlers/openapi/src/index.ts
@@ -19,7 +19,6 @@ import {
   KeyValueCache,
   MeshPubSub,
 } from '@graphql-mesh/types';
-import { set } from 'lodash';
 import { OasTitlePathMethodObject } from './openapi-to-graphql/types/options';
 
 interface OpenAPIIntrospectionCache {
@@ -117,8 +116,16 @@ export default class OpenAPIHandler implements MeshHandler {
                   operationType = GraphQLOperationType.Mutation;
                   break;
               }
-              set(acc, `${curr.title}.${curr.path}.${curr.method}`, operationType);
-              return acc;
+              return {
+                ...acc,
+                [curr.title]: {
+                  ...acc[curr.title],
+                  [curr.path]: {
+                    ...((acc[curr.title] && acc[curr.title][curr.path]) || {}),
+                    [curr.method]: operationType,
+                  },
+                },
+              };
             }, {} as OasTitlePathMethodObject<GraphQLOperationType>),
       addLimitArgument: addLimitArgument === undefined ? true : addLimitArgument,
       sendOAuthTokenInQuery: true,


### PR DESCRIPTION
## Description
Currently, the OpenAPI handler uses `loadsh` to build the object for selectQueryOrMutationField option to be passed to `openapi-to-graphql`.

The problem is that `loadsh`'s `set` has a nesting behavior which, for example, nests fields splitting by a “dot” character.

When you have a configuration like this:
```yaml
        selectQueryOrMutationField:
          - title: "Weather Service v1.0"
            path: /weather/current
            method: post
            type: Query
          - title: "Weather Service v1.0"
            path: /weather/forecast
            method: get
            type: Mutation
```
It gets currently parsed by `lodash` like this:
```json
  "selectQueryOrMutationField": {
    "Weather Service v1": [
      {
        "/weather/current": {
          "post": 0
        },
        "/weather/forecast": {
          "get": 1
        }
      }
    ]
  },
```
Whilst it should be parsed as follow:
```json
  "selectQueryOrMutationField": {
    "Weather Service v1.0": {
      "/weather/current": {
        "post": 0
      },
      "/weather/forecast": {
        "get": 1
      }
    }
  },
```

As you can see `loadsh` nests the OAS title into an array of objects, rather than just an object with "paths" as keys.
It does this because the title contains a dot.
As you can also notice the ".0" is also removed from the title.

This means that the config is not passed correctly to `openapi-to-graphql` and so it won't work.

My fix addresses this by removing `lodash` dependency and merging objects in "reduce" with plain javascript, using spread.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] ~I have commented my code, particularly in hard-to-understand areas~
- [ ] ~I have made corresponding changes to the documentation~
- [x] My changes generate no new warnings
- [ ] ~I have added tests that prove my fix is effective or that my feature works~
- [x] New and existing unit tests and linter rules pass locally with my changes
- [ ] ~Any dependent changes have been merged and published in downstream modules~