### PR TITLE
fix(encapsulate): ignore type not defined

### DIFF
--- a/.changeset/hip-flies-visit.md
+++ b/.changeset/hip-flies-visit.md
@@ -1,0 +1,5 @@
+---
+'@graphql-mesh/transform-encapsulate': patch
+---
+
+Ignore not-defined/empty root type on encapsulate transform


### PR DESCRIPTION
Sorry for skipping issue.

## Description

encapsulated schema fails to introspect if applyTo.{type} is true but {type} does not exist.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Screenshots/Sandbox (if appropriate/relevant):

![image](https://user-images.githubusercontent.com/9696352/116091002-66f23800-a6df-11eb-8322-4ffe532ff282.png)

## How Has This Been Tested?

I had this problem in production and fixed it through patching node_modules. Commiting here a failing test first.

**Test Environment**:
- OS: MacOS 11.2.3
- `@graphql-mesh/*`: master
- NodeJS: v14.16.0

## Checklist:

- [ ] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests and linter rules pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules