### PR TITLE
fix(encapsulate): follow up fix #2021

### DIFF
--- a/.changeset/tidy-mangos-cheat.md
+++ b/.changeset/tidy-mangos-cheat.md
@@ -1,0 +1,5 @@
+---
+'@graphql-mesh/transform-encapsulate': patch
+---
+
+Fix encapsulate transform mismatch with schema on request/result


### PR DESCRIPTION
## Description

#2021 introduce a new bug because request/result transforms were missed.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Further comments

I'm not sure this is a good implementation.. this quite rely on lifecycle to get schema. But I don't know how can we get originalWrapSchema from transformRequest/transformResult without them...