### PR TITLE
fix(playground): enable subscriptions

### DIFF
--- a/packages/cli/src/commands/serve/playground.ts
+++ b/packages/cli/src/commands/serve/playground.ts
@@ -69,6 +69,7 @@ export const playgroundMiddlewareFactory = ({
           renderGraphiQL({
             defaultQuery,
             endpoint: graphqlPath,
+            subscriptionsEndpoint: graphqlPath
           })
       );
     });


### PR DESCRIPTION
It was not possible to run subscriptions in the graphiql interface that is started after a mesh starts since `subscriptionsEndpoint` was not specified.

##
NOT COMPLETE YET. 
AS Of right now the endpoint for subscriptions would be the same as for Queries and Mutations. This is not as desired and I'm looking at ways to switch it to ws:// path without adding additional config options.

## Description

The `subscriptionsEndpoint` is now provided when GraphiQL is launched.

Fixes #2055

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Manually (local) with various sample mesh configs.

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests and linter rules pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
