### PR TITLE
Add support to require local modules as an addition to installed pack…

### DIFF
--- a/.changeset/neat-zoos-tie.md
+++ b/.changeset/neat-zoos-tie.md
@@ -1,0 +1,5 @@
+---
+'@graphql-mesh/cli': minor
+---
+
+Add support to require local modules as an addition to installed packages


### PR DESCRIPTION
## Description

When running CLI commands it might be necessary to require local modules, that are, then, relative to the working directory.
Normally using `-r` argument with node cli would correctly load installed/external modules (from node_modules folder) as well as local modules when passing the path to a local js file.
However, currently Mesh CLI does not support this, and so, passing the path to a local module, like `-r ./scripts/myCustomModule.js` doesn’t work.

The issue is caused by the fact that the import is requested within the mesh cli package, which is in `myProject/node_modules/@graphql-mesh/cli/`.
In this case, the following require doesn't work:
`-r ./scripts/myCustomModule.js`
but this does work:
`-r ../../../scripts/myCustomModule.js`

This PR addresses this by checking if the passed argument value (module name or local path) can be found in a local file relative to the working directory; if so it will import the local path, otherwise continue with the existing behavior which is to import the passed argument value directory (most likely the name of an installed package/module)

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
Added 2 require arguments on a CLI command, one using the path to a local module and one using the name of an installed module; both are working as expected.

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests and linter rules pass locally with my changes