### PR TITLE
Extend documentation to for the usage of the `initializeStore` property

### DIFF
--- a/website/docs/transforms/mock.md
+++ b/website/docs/transforms/mock.md
@@ -159,13 +159,11 @@ Initially populating the list of users can be done by utilizing the `initializeS
 
 In this case there is no need to provide special array mocking definition, like `length`. It will automatically be taken based on the mock data.
 
-**Note:**
-If you are using the `mesh serve --dir=some-path` to set your root, at the moment the `initializeStore` will not be affected by it, so the absolute path will be needed.
 
 ```yml
 transforms:
   - mock:
-      initializeStore: absolute-path-to-file/myMock#initializeStore
+      initializeStore: ./myMock#initializeStore
 ```
 
 In the `./myMock.js`:


### PR DESCRIPTION
Also, adjust the rest of the mock documentation to be more coherent.


Fixes https://github.com/Urigo/graphql-mesh/issues/2014

## Type of change
- [x] This change requires a documentation update

## Checklist:

- [X] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have made changes to the documentation
- [X] My changes generate no new warnings
- [X] New and existing unit tests and linter rules pass locally with my changes


## Further comments

It would be nice if the typescript documentation would become a first-class citizen.

Also, I believe the graphql-mesh should be treated as the primary library, not just a collection of other libraries, meaning the documentation should be complete for the use cases that graphql-mesh handles without the need to decipher the API of the lower-level libraries. (e.g. graphql-tools)