### PR TITLE
Fix issue with falsy values getting skipped when translated to REST calls.

### DIFF
--- a/packages/handlers/openapi/src/openapi-to-graphql/resolver_builder.ts
+++ b/packages/handlers/openapi/src/openapi-to-graphql/resolver_builder.ts
@@ -476,7 +476,7 @@ export function getResolver<TSource, TContext, TArgs>(
 
     for (const paramName in query) {
       const val = query[paramName];
-      if (val) {
+      if (val !== undefined) {
         urlObject.searchParams.set(paramName, val);
       }
     }


### PR DESCRIPTION
## Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes #2265

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots/Sandbox (if appropriate/relevant):

When logging the internal API call that was called for a query it has falsy values as well.
![image](https://user-images.githubusercontent.com/12209601/125565840-8d4a7008-b6c1-43eb-9f49-a9120ac02d67.png)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] This has been tested against our development server, this change stops ignoring the values that falsy. 

**Test Environment**:
- OS: MacOS 11.4
- `@graphql-mesh/openapi`:
- NodeJS: v16.4.2

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests and linter rules pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

