### PR TITLE
OData handler: fix handling of bound functions with arguments

### DIFF
--- a/.changeset/slow-carrots-relax.md
+++ b/.changeset/slow-carrots-relax.md
@@ -1,0 +1,5 @@
+---
+'@graphql-mesh/odata': patch
+---
+
+fix(odata): fix handling of bound functions with arguments

--- a/examples/odata-trippin/tests/__snapshots__/odata-trippin.test.js.snap
+++ b/examples/odata-trippin/tests/__snapshots__/odata-trippin.test.js.snap
@@ -789,7 +789,19 @@ Object {
             },
           },
           Object {
-            "args": Array [],
+            "args": Array [
+              Object {
+                "defaultValue": null,
+                "deprecationReason": null,
+                "isDeprecated": false,
+                "name": "person",
+                "type": Object {
+                  "kind": "INPUT_OBJECT",
+                  "name": "PersonInput",
+                  "ofType": null,
+                },
+              },
+            ],
             "deprecationReason": null,
             "isDeprecated": false,
             "name": "GetFavoriteAirline",
@@ -800,7 +812,34 @@ Object {
             },
           },
           Object {
-            "args": Array [],
+            "args": Array [
+              Object {
+                "defaultValue": null,
+                "deprecationReason": null,
+                "isDeprecated": false,
+                "name": "person",
+                "type": Object {
+                  "kind": "INPUT_OBJECT",
+                  "name": "PersonInput",
+                  "ofType": null,
+                },
+              },
+              Object {
+                "defaultValue": null,
+                "deprecationReason": null,
+                "isDeprecated": false,
+                "name": "userName",
+                "type": Object {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": Object {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null,
+                  },
+                },
+              },
+            ],
             "deprecationReason": null,
             "isDeprecated": false,
             "name": "GetFriendsTrips",
@@ -1650,7 +1689,19 @@ Object {
             },
           },
           Object {
-            "args": Array [],
+            "args": Array [
+              Object {
+                "defaultValue": null,
+                "deprecationReason": null,
+                "isDeprecated": false,
+                "name": "person",
+                "type": Object {
+                  "kind": "INPUT_OBJECT",
+                  "name": "PersonInput",
+                  "ofType": null,
+                },
+              },
+            ],
             "deprecationReason": null,
             "isDeprecated": false,
             "name": "GetFavoriteAirline",
@@ -1661,7 +1712,34 @@ Object {
             },
           },
           Object {
-            "args": Array [],
+            "args": Array [
+              Object {
+                "defaultValue": null,
+                "deprecationReason": null,
+                "isDeprecated": false,
+                "name": "person",
+                "type": Object {
+                  "kind": "INPUT_OBJECT",
+                  "name": "PersonInput",
+                  "ofType": null,
+                },
+              },
+              Object {
+                "defaultValue": null,
+                "deprecationReason": null,
+                "isDeprecated": false,
+                "name": "userName",
+                "type": Object {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": Object {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null,
+                  },
+                },
+              },
+            ],
             "deprecationReason": null,
             "isDeprecated": false,
             "name": "GetFriendsTrips",
@@ -2459,7 +2537,19 @@ Object {
             },
           },
           Object {
-            "args": Array [],
+            "args": Array [
+              Object {
+                "defaultValue": null,
+                "deprecationReason": null,
+                "isDeprecated": false,
+                "name": "person",
+                "type": Object {
+                  "kind": "INPUT_OBJECT",
+                  "name": "PersonInput",
+                  "ofType": null,
+                },
+              },
+            ],
             "deprecationReason": null,
             "isDeprecated": false,
             "name": "GetFavoriteAirline",
@@ -2470,7 +2560,34 @@ Object {
             },
           },
           Object {
-            "args": Array [],
+            "args": Array [
+              Object {
+                "defaultValue": null,
+                "deprecationReason": null,
+                "isDeprecated": false,
+                "name": "person",
+                "type": Object {
+                  "kind": "INPUT_OBJECT",
+                  "name": "PersonInput",
+                  "ofType": null,
+                },
+              },
+              Object {
+                "defaultValue": null,
+                "deprecationReason": null,
+                "isDeprecated": false,
+                "name": "userName",
+                "type": Object {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": Object {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null,
+                  },
+                },
+              },
+            ],
             "deprecationReason": null,
             "isDeprecated": false,
             "name": "GetFriendsTrips",
@@ -3305,7 +3422,19 @@ Object {
             },
           },
           Object {
-            "args": Array [],
+            "args": Array [
+              Object {
+                "defaultValue": null,
+                "deprecationReason": null,
+                "isDeprecated": false,
+                "name": "person",
+                "type": Object {
+                  "kind": "INPUT_OBJECT",
+                  "name": "PersonInput",
+                  "ofType": null,
+                },
+              },
+            ],
             "deprecationReason": null,
             "isDeprecated": false,
             "name": "GetFavoriteAirline",
@@ -3316,7 +3445,34 @@ Object {
             },
           },
           Object {
-            "args": Array [],
+            "args": Array [
+              Object {
+                "defaultValue": null,
+                "deprecationReason": null,
+                "isDeprecated": false,
+                "name": "person",
+                "type": Object {
+                  "kind": "INPUT_OBJECT",
+                  "name": "PersonInput",
+                  "ofType": null,
+                },
+              },
+              Object {
+                "defaultValue": null,
+                "deprecationReason": null,
+                "isDeprecated": false,
+                "name": "userName",
+                "type": Object {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": Object {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null,
+                  },
+                },
+              },
+            ],
             "deprecationReason": null,
             "isDeprecated": false,
             "name": "GetFriendsTrips",
@@ -4497,7 +4653,19 @@ Object {
             },
           },
           Object {
-            "args": Array [],
+            "args": Array [
+              Object {
+                "defaultValue": null,
+                "deprecationReason": null,
+                "isDeprecated": false,
+                "name": "trip",
+                "type": Object {
+                  "kind": "INPUT_OBJECT",
+                  "name": "TripInput",
+                  "ofType": null,
+                },
+              },
+            ],
             "deprecationReason": null,
             "isDeprecated": false,
             "name": "GetInvolvedPeople",
@@ -4637,6 +4805,129 @@ Object {
         "interfaces": Array [],
         "kind": "OBJECT",
         "name": "Trip",
+        "possibleTypes": null,
+        "specifiedByUrl": null,
+      },
+      Object {
+        "enumValues": null,
+        "fields": null,
+        "inputFields": Array [
+          Object {
+            "defaultValue": null,
+            "deprecationReason": null,
+            "isDeprecated": false,
+            "name": "Budget",
+            "type": Object {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": Object {
+                "kind": "SCALAR",
+                "name": "Float",
+                "ofType": null,
+              },
+            },
+          },
+          Object {
+            "defaultValue": null,
+            "deprecationReason": null,
+            "isDeprecated": false,
+            "name": "Description",
+            "type": Object {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null,
+            },
+          },
+          Object {
+            "defaultValue": null,
+            "deprecationReason": null,
+            "isDeprecated": false,
+            "name": "EndsAt",
+            "type": Object {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": Object {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null,
+              },
+            },
+          },
+          Object {
+            "defaultValue": null,
+            "deprecationReason": null,
+            "isDeprecated": false,
+            "name": "Name",
+            "type": Object {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null,
+            },
+          },
+          Object {
+            "defaultValue": null,
+            "deprecationReason": null,
+            "isDeprecated": false,
+            "name": "ShareId",
+            "type": Object {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": Object {
+                "kind": "SCALAR",
+                "name": "GUID",
+                "ofType": null,
+              },
+            },
+          },
+          Object {
+            "defaultValue": null,
+            "deprecationReason": null,
+            "isDeprecated": false,
+            "name": "StartsAt",
+            "type": Object {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": Object {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null,
+              },
+            },
+          },
+          Object {
+            "defaultValue": null,
+            "deprecationReason": null,
+            "isDeprecated": false,
+            "name": "Tags",
+            "type": Object {
+              "kind": "LIST",
+              "name": null,
+              "ofType": Object {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null,
+              },
+            },
+          },
+          Object {
+            "defaultValue": null,
+            "deprecationReason": null,
+            "isDeprecated": false,
+            "name": "TripId",
+            "type": Object {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": Object {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null,
+              },
+            },
+          },
+        ],
+        "interfaces": null,
+        "kind": "INPUT_OBJECT",
+        "name": "TripInput",
         "possibleTypes": null,
         "specifiedByUrl": null,
       },

--- a/packages/handlers/odata/test/__snapshots__/handler.spec.ts.snap
+++ b/packages/handlers/odata/test/__snapshots__/handler.spec.ts.snap
@@ -18,9 +18,9 @@ exports[`odata should create a GraphQL schema from a simple OData endpoint 1`] =
   BestFriend: Person
   Trips(queryOptions: QueryOptions): [Trip]
   TripsById(id: ID): Trip
-  GetFavoriteAirline: Airline
-  GetFriendsTrips: [Trip]
-  UpdatePersonLastName: Boolean
+  GetFavoriteAirline(person: PersonInput): Airline
+  GetFriendsTrips(person: PersonInput, userName: String!): [Trip]
+  UpdatePersonLastName(person: PersonInput, lastName: String!): Boolean
   ShareTrip(personInstance: PersonInput, userName: String!, tripId: Int!): JSON
 }
 
@@ -41,9 +41,9 @@ interface IPerson {
   BestFriend: Person
   Trips(queryOptions: QueryOptions): [Trip]
   TripsById(id: ID): Trip
-  GetFavoriteAirline: Airline
-  GetFriendsTrips: [Trip]
-  UpdatePersonLastName: Boolean
+  GetFavoriteAirline(person: PersonInput): Airline
+  GetFriendsTrips(person: PersonInput, userName: String!): [Trip]
+  UpdatePersonLastName(person: PersonInput, lastName: String!): Boolean
   ShareTrip(personInstance: PersonInput, userName: String!, tripId: Int!): JSON
 }
 
@@ -105,11 +105,6 @@ enum InlineCount {
   none
 }
 
-\\"\\"\\"
-The \`JSON\` scalar type represents JSON values as specified by [ECMA-404](http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf).
-\\"\\"\\"
-scalar JSON @specifiedBy(url: \\"http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf\\")
-
 input PersonInput {
   UserName: String!
   FirstName: String!
@@ -135,6 +130,11 @@ input CityInput {
   Region: String
 }
 
+\\"\\"\\"
+The \`JSON\` scalar type represents JSON values as specified by [ECMA-404](http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf).
+\\"\\"\\"
+scalar JSON @specifiedBy(url: \\"http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf\\")
+
 type Airline {
   AirlineCode: String!
   Name: String
@@ -158,7 +158,7 @@ type Trip implements ITrip {
   EndsAt: DateTime!
   PlanItems(queryOptions: QueryOptions): [PlanItem]
   PlanItemsById(id: ID): PlanItem
-  GetInvolvedPeople: [Person]
+  GetInvolvedPeople(trip: TripInput): [Person]
 }
 
 interface ITrip {
@@ -172,7 +172,7 @@ interface ITrip {
   EndsAt: DateTime!
   PlanItems(queryOptions: QueryOptions): [PlanItem]
   PlanItemsById(id: ID): PlanItem
-  GetInvolvedPeople: [Person]
+  GetInvolvedPeople(trip: TripInput): [Person]
 }
 
 \\"\\"\\"
@@ -184,6 +184,17 @@ scalar GUID
 A date-time string at UTC, such as 2007-12-03T10:15:30Z, compliant with the \`date-time\` format outlined in section 5.6 of the RFC 3339 profile of the ISO 8601 standard for representation of dates and times using the Gregorian calendar.
 \\"\\"\\"
 scalar DateTime
+
+input TripInput {
+  TripId: Int!
+  ShareId: GUID!
+  Name: String
+  Budget: Float!
+  Description: String
+  Tags: [String]
+  StartsAt: DateTime!
+  EndsAt: DateTime!
+}
 
 type PlanItem implements IPlanItem {
   PlanItemId: Int!
@@ -284,9 +295,9 @@ type Employee implements IPerson {
   BestFriend: Person
   Trips(queryOptions: QueryOptions): [Trip]
   TripsById(id: ID): Trip
-  GetFavoriteAirline: Airline
-  GetFriendsTrips: [Trip]
-  UpdatePersonLastName: Boolean
+  GetFavoriteAirline(person: PersonInput): Airline
+  GetFriendsTrips(person: PersonInput, userName: String!): [Trip]
+  UpdatePersonLastName(person: PersonInput, lastName: String!): Boolean
   ShareTrip(personInstance: PersonInput, userName: String!, tripId: Int!): JSON
 }
 
@@ -311,9 +322,9 @@ type Manager implements IPerson {
   BestFriend: Person
   Trips(queryOptions: QueryOptions): [Trip]
   TripsById(id: ID): Trip
-  GetFavoriteAirline: Airline
-  GetFriendsTrips: [Trip]
-  UpdatePersonLastName: Boolean
+  GetFavoriteAirline(person: PersonInput): Airline
+  GetFriendsTrips(person: PersonInput, userName: String!): [Trip]
+  UpdatePersonLastName(person: PersonInput, lastName: String!): Boolean
   ShareTrip(personInstance: PersonInput, userName: String!, tripId: Int!): JSON
 }
 

--- a/packages/handlers/odata/test/handler.spec.ts
+++ b/packages/handlers/odata/test/handler.spec.ts
@@ -552,7 +552,7 @@ describe('odata', () => {
 
     expect(graphqlResult.errors).toBeFalsy();
     expect(sentRequest!.method).toBe(correctMethod);
-    expect(sentRequest!.url).toBe(correctUrl);
+    expect(sentRequest!.url).toBe(correctUrl.replace(/'/g, '%27',  ));// apostrophe gets percent-encoded
   });
   it('should generate correct HTTP request for invoking unbound actions', async () => {
     addMock('https://services.odata.org/TripPinRESTierService/$metadata', async () => new Response(TripPinMetadata));


### PR DESCRIPTION
🚨 **IMPORTANT: Please do not create a Pull Request without creating an issue first.**

*Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request.*

## Description

I added test cases in the OData handler to verify that fields generated for bound functions have arguments corresponding to the function parameters and that requests that include functions generate OData urls with the appropriate arguments passed.

I've also fixed the issue by making the following changes:
- register the bound field corresponding to the function on the GraphQL schema only after adding all the parameters to to the arg. The old code has bug here, it was registering the arguments outside the loop that processes the arguments, and it was registering the function field inside the loop that processes the function arguments.
- In the field resolver, I appended the arguments to the function URL. I wrapped string arguments with a single quotes as per the standard (otherwise you might get an error).

Fixes #2476 

## Type of change

- New test cases.
- Bug fix

## Screenshots/Sandbox (if appropriate/relevant):

![image](https://user-images.githubusercontent.com/8460169/126509291-4e46265c-f999-4dc6-bd4d-4af20f43ed4f.png)


## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

I ran `yarn test odata` which runs the OData Handler test suite as well as the OData Trippin example test. Note that the OData Trippin test fails (even before my changes).

- [x] `yarn test odata`

**Test Environment**:
- OS: Windows 10
- `@graphql-mesh/odata`: 0.11.18
- NodeJS: 14.0

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests and linter rules pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

## Further comments
