### PR TITLE
Enable flags for regular expressions in rename transform

### DIFF
--- a/.changeset/itchy-bulldogs-joke.md
+++ b/.changeset/itchy-bulldogs-joke.md
@@ -1,0 +1,6 @@
+---
+'@graphql-mesh/transform-rename': patch
+'@graphql-mesh/types': patch
+---
+
+Enable flags for regular expressions in rename transform

--- a/packages/transforms/rename/src/bareRename.ts
+++ b/packages/transforms/rename/src/bareRename.ts
@@ -21,11 +21,14 @@ export default class BareRename implements MeshTransform {
         useRegExpForTypes,
         useRegExpForFields,
       } = rename;
+
+      const regExpFlags = rename.regExpFlags || undefined;
+
       if (fromTypeName && !fromFieldName && toTypeName && !toFieldName && fromTypeName !== toTypeName) {
-        this.typesMap.set(useRegExpForTypes ? new RegExp(fromTypeName) : fromTypeName, toTypeName);
+        this.typesMap.set(useRegExpForTypes ? new RegExp(fromTypeName, regExpFlags) : fromTypeName, toTypeName);
       }
       if (fromTypeName && fromFieldName && toTypeName && toFieldName && fromFieldName !== toFieldName) {
-        const fromName = useRegExpForFields ? new RegExp(fromFieldName) : fromFieldName;
+        const fromName = useRegExpForFields ? new RegExp(fromFieldName, regExpFlags) : fromFieldName;
         const typeMap = this.fieldsMap.get(fromTypeName) || new Map();
         this.fieldsMap.set(fromTypeName, typeMap.set(fromName, toFieldName));
       }

--- a/packages/transforms/rename/src/wrapRename.ts
+++ b/packages/transforms/rename/src/wrapRename.ts
@@ -1,12 +1,6 @@
 import { GraphQLSchema } from 'graphql';
 import { MeshTransform, YamlConfig, MeshTransformOptions } from '@graphql-mesh/types';
-import {
-  RenameTypes,
-  RenameObjectFields,
-  RenameRootFields,
-  RenameRootTypes,
-  RenameInputObjectFields,
-} from '@graphql-tools/wrap';
+import { RenameTypes, RenameObjectFields, RenameRootTypes, RenameInputObjectFields } from '@graphql-tools/wrap';
 import { ExecutionResult, ExecutionRequest } from '@graphql-tools/utils';
 import { Transform, SubschemaConfig, DelegationContext } from '@graphql-tools/delegate';
 import { applyRequestTransforms, applyResultTransforms, applySchemaTransforms } from '@graphql-mesh/utils';

--- a/packages/transforms/rename/src/wrapRename.ts
+++ b/packages/transforms/rename/src/wrapRename.ts
@@ -49,7 +49,6 @@ export default class WrapRename implements MeshTransform {
           replaceFieldNameFn = (typeName, fieldName) =>
             typeName === toTypeName && fieldName === fromFieldName ? toFieldName : fieldName;
         }
-        this.transforms.push(new RenameRootFields(replaceFieldNameFn));
         this.transforms.push(new RenameObjectFields(replaceFieldNameFn));
         this.transforms.push(new RenameInputObjectFields(replaceFieldNameFn));
       }

--- a/packages/transforms/rename/src/wrapRename.ts
+++ b/packages/transforms/rename/src/wrapRename.ts
@@ -24,10 +24,12 @@ export default class WrapRename implements MeshTransform {
         useRegExpForFields,
       } = change;
 
+      const regExpFlags = change.regExpFlags || undefined;
+
       if (fromTypeName !== toTypeName) {
         let replaceTypeNameFn: (t: string) => string;
         if (useRegExpForTypes) {
-          const typeNameRegExp = new RegExp(fromTypeName);
+          const typeNameRegExp = new RegExp(fromTypeName, regExpFlags);
           replaceTypeNameFn = (t: string) => t.replace(typeNameRegExp, toTypeName);
         } else {
           replaceTypeNameFn = t => (t === fromTypeName ? toTypeName : t);
@@ -40,7 +42,7 @@ export default class WrapRename implements MeshTransform {
         let replaceFieldNameFn: (typeName: string, fieldName: string) => string;
 
         if (useRegExpForFields) {
-          const fieldNameRegExp = new RegExp(fromFieldName);
+          const fieldNameRegExp = new RegExp(fromFieldName, regExpFlags);
           replaceFieldNameFn = (typeName, fieldName) =>
             typeName === toTypeName && fieldName.replace(fieldNameRegExp, toFieldName);
         } else {

--- a/packages/transforms/rename/test/__snapshots__/wrapRename.spec.ts.snap
+++ b/packages/transforms/rename/test/__snapshots__/wrapRename.spec.ts.snap
@@ -107,3 +107,19 @@ type User {
 }
 "
 `;
+
+exports[`rename should replace the first occurrence of a substring in a field 1`] = `
+"type Query {
+  my_user: MyUser!
+  my_bok: MyBook!
+}
+
+type MyUser {
+  false: ID!
+}
+
+type MyBook {
+  false: ID!
+}
+"
+`;

--- a/packages/transforms/rename/test/__snapshots__/wrapRename.spec.ts.snap
+++ b/packages/transforms/rename/test/__snapshots__/wrapRename.spec.ts.snap
@@ -63,3 +63,47 @@ type Book {
 }
 "
 `;
+
+exports[`rename should replace all occurrences of a substring in a field 1`] = `
+"type Query {
+  user_v1: ApiUserV1Api!
+}
+
+type ApiUserV1Api {
+  false: ID!
+}
+"
+`;
+
+exports[`rename should replace all occurrences of a substring in a type 1`] = `
+"type Query {
+  api_user_v1_api: UserV1!
+}
+
+type UserV1 {
+  id: ID!
+}
+"
+`;
+
+exports[`rename should replace all occurrences of multiple substrings in a field 1`] = `
+"type Query {
+  user: ApiUserV1Api!
+}
+
+type ApiUserV1Api {
+  false: ID!
+}
+"
+`;
+
+exports[`rename should replace all occurrences of multiple substrings in a type 1`] = `
+"type Query {
+  api_user_v1_api: User!
+}
+
+type User {
+  id: ID!
+}
+"
+`;

--- a/packages/transforms/rename/test/wrapRename.spec.ts
+++ b/packages/transforms/rename/test/wrapRename.spec.ts
@@ -161,6 +161,42 @@ describe('rename', () => {
     expect(printSchema(newSchema)).toMatchSnapshot();
   });
 
+  it('should replace the first occurrence of a substring in a field', () => {
+    const newSchema = wrapSchema({
+      schema,
+      transforms: [
+        RenameTransform({
+          config: {
+            mode: 'wrap',
+            renames: [
+              {
+                from: {
+                  type: 'Query',
+                  field: 'o(.*)',
+                },
+                to: {
+                  type: 'Query',
+                  field: '$1',
+                },
+                useRegExpForFields: true,
+              },
+            ],
+          },
+          cache,
+          pubsub,
+          baseDir,
+        }),
+      ],
+    });
+
+    const queryType = newSchema.getType('Query') as GraphQLObjectType;
+    const fieldMap = queryType.getFields();
+
+    expect(fieldMap.my_book).toBeUndefined();
+    expect(fieldMap.my_bok).toBeDefined();
+    expect(printSchema(newSchema)).toMatchSnapshot();
+  });
+
   it('should replace all occurrences of a substring in a type', () => {
     const schema = buildSchema(/* GraphQL */ `
       type Query {

--- a/packages/transforms/rename/test/wrapRename.spec.ts
+++ b/packages/transforms/rename/test/wrapRename.spec.ts
@@ -160,4 +160,178 @@ describe('rename', () => {
     expect(fieldMap.book).toBeDefined();
     expect(printSchema(newSchema)).toMatchSnapshot();
   });
+
+  it('should replace all occurrences of a substring in a type', () => {
+    const schema = buildSchema(/* GraphQL */ `
+      type Query {
+        api_user_v1_api: ApiUserV1Api!
+      }
+
+      type ApiUserV1Api {
+        id: ID!
+      }
+    `);
+
+    const newSchema = wrapSchema({
+      schema,
+      transforms: [
+        RenameTransform({
+          config: {
+            renames: [
+              {
+                from: {
+                  type: 'Api(.*?)',
+                },
+                to: {
+                  type: '$1',
+                },
+                useRegExpForTypes: true,
+                regExpFlags: 'g',
+              },
+            ],
+          },
+          cache,
+          pubsub,
+          baseDir,
+        }),
+      ],
+    });
+
+    expect(newSchema.getType('ApiUserV1Api')).toBeUndefined();
+    expect(newSchema.getType('UserV1')).toBeDefined();
+    expect(printSchema(newSchema)).toMatchSnapshot();
+  });
+
+  it('should replace all occurrences of multiple substrings in a type', () => {
+    const schema = buildSchema(/* GraphQL */ `
+      type Query {
+        api_user_v1_api: ApiUserV1Api!
+      }
+
+      type ApiUserV1Api {
+        id: ID!
+      }
+    `);
+
+    const newSchema = wrapSchema({
+      schema,
+      transforms: [
+        RenameTransform({
+          config: {
+            renames: [
+              {
+                from: {
+                  type: 'Api|V1(.*?)',
+                },
+                to: {
+                  type: '$1',
+                },
+                useRegExpForTypes: true,
+                regExpFlags: 'g',
+              },
+            ],
+          },
+          cache,
+          pubsub,
+          baseDir,
+        }),
+      ],
+    });
+
+    expect(newSchema.getType('ApiUserV1Api')).toBeUndefined();
+    expect(newSchema.getType('User')).toBeDefined();
+    expect(printSchema(newSchema)).toMatchSnapshot();
+  });
+
+  it('should replace all occurrences of a substring in a field', () => {
+    const schema = buildSchema(/* GraphQL */ `
+      type Query {
+        api_user_v1_api: ApiUserV1Api!
+      }
+
+      type ApiUserV1Api {
+        id: ID!
+      }
+    `);
+
+    const newSchema = wrapSchema({
+      schema,
+      transforms: [
+        RenameTransform({
+          config: {
+            renames: [
+              {
+                from: {
+                  type: 'Query',
+                  field: 'api_|_api(.*?)',
+                },
+                to: {
+                  type: 'Query',
+                  field: '$1',
+                },
+                useRegExpForFields: true,
+                regExpFlags: 'g',
+              },
+            ],
+          },
+          cache,
+          pubsub,
+          baseDir,
+        }),
+      ],
+    });
+
+    const queryType = newSchema.getType('Query') as GraphQLObjectType;
+    const fieldMap = queryType.getFields();
+
+    expect(fieldMap.api_user_v1_api).toBeUndefined();
+    expect(fieldMap.user_v1).toBeDefined();
+    expect(printSchema(newSchema)).toMatchSnapshot();
+  });
+
+  it('should replace all occurrences of multiple substrings in a field', () => {
+    const schema = buildSchema(/* GraphQL */ `
+      type Query {
+        api_user_v1_api: ApiUserV1Api!
+      }
+
+      type ApiUserV1Api {
+        id: ID!
+      }
+    `);
+
+    const newSchema = wrapSchema({
+      schema,
+      transforms: [
+        RenameTransform({
+          config: {
+            renames: [
+              {
+                from: {
+                  type: 'Query',
+                  field: 'api_|_api|v1_|_v1(.*?)',
+                },
+                to: {
+                  type: 'Query',
+                  field: '$1',
+                },
+                useRegExpForFields: true,
+                regExpFlags: 'g',
+              },
+            ],
+          },
+          cache,
+          pubsub,
+          baseDir,
+        }),
+      ],
+    });
+
+    const queryType = newSchema.getType('Query') as GraphQLObjectType;
+    const fieldMap = queryType.getFields();
+
+    expect(fieldMap.api_user_v1_api).toBeUndefined();
+    expect(fieldMap.user).toBeDefined();
+    expect(printSchema(newSchema)).toMatchSnapshot();
+  });
 });

--- a/packages/transforms/rename/yaml-config.graphql
+++ b/packages/transforms/rename/yaml-config.graphql
@@ -29,6 +29,10 @@ type RenameTransformObject @md {
   Use Regular Expression for field names
   """
   useRegExpForFields: Boolean
+  """
+  Flags to use in the Regular Expression
+  """
+  regExpFlags: String
 }
 
 type RenameConfig {

--- a/packages/types/src/config-schema.json
+++ b/packages/types/src/config-schema.json
@@ -2304,6 +2304,10 @@
         "useRegExpForFields": {
           "type": "boolean",
           "description": "Use Regular Expression for field names"
+        },
+        "regExpFlags": {
+          "type": "string",
+          "description": "Flags to use in the Regular Expression"
         }
       },
       "required": ["from", "to"]

--- a/packages/types/src/config.ts
+++ b/packages/types/src/config.ts
@@ -1179,6 +1179,10 @@ export interface RenameTransformObject {
    * Use Regular Expression for field names
    */
   useRegExpForFields?: boolean;
+  /**
+   * Flags to use in the Regular Expression
+   */
+  regExpFlags?: string;
 }
 export interface RenameConfig {
   type?: string;


### PR DESCRIPTION
## Description

In order to enhance pattern matching when renaming types and fields as mentioned in #2469, @ntziolis and I discussed the issue and want to introduce an optional config option `regExpFlags` in which the flags to use for a pattern can be specified.
Like:

```yaml
- rename:
    mode: wrap
    renames:
      - from:
          type: Api(.*)
        to:
          type: $1
        useRegExpForTypes: true
        # new option
        regExpFlags: g
```

Example use cases:

- Eliminating a certain substring (or even a bunch) from type and field names:

```yaml
- rename:
    mode: wrap
    renames:
      # eliminate Api, This, That
      - from:
          # non-greedy
          type: Api|This|That(.*?)
        to:
          type: $1
        useRegExpForTypes: true
        # globally, so not just the first occurrence
        regExpFlags: g
```

- Dropping suffixes:

```yaml
- rename:
    mode: wrap
    renames:
      # drop suffixes v1, V1, v2, V2, ...
      - from:
          type: (.*)v\d+$
        to:
          type: $1
        useRegExpForTypes: true
        # ignore case
        regExpFlags: i
```

Since `regExpFlags` is optional, nothing will break. Instead, the developer has a little more control over their patterns.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- [x] `yarn run test`, where some tests failed before my changes, and still do after my changes
- [x] Just the `rename` suite via [Jest Runner](https://marketplace.visualstudio.com/items?itemName=firsttris.vscode-jest-runner) extension for vscode, all fine

**Test Environment**:
- OS: 4.19.104-microsoft-standard x86_64
- `@graphql-mesh/transform-rename: 0.8.19`
- `@graphql-mesh/types: 0.42.0`
- NodeJS: v12.19.0

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests and linter rules pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

This PR also includes a bug fix:
Renames were applied twice when changing fields on root types via regex. Probably, because the transform is applied on both, root types and object types.
See test `'rename should replace the first occurrence of a substring in a field'` in [packages/transforms/rename/test/wrapRename.spec.ts](packages/transforms/rename/test/wrapRename.spec.ts) at [6739ca5](6739ca54b5fabb991e8c7b7021a8962d174ec1e6).

Schema (simplified):
```graphql
type Query {
  my_book: MyBook!
}

type MyBook {
  id: ID!
}
```

Config:
```yaml
- rename:
    mode: wrap
    renames:
      - from:
         type: Query
         field: o(.*)
        to:
          type: Query
          field: $1
        useRegExpForFields: true
```

Expected output:
- the first `o` of field `my_book` on `Query` is dropped
- so `my_book` becomes `my_bok`

Actual result:
- `my_book`  becomes `my_bk`

Without the changes in [packages/transforms/rename/src/wrapRename.ts](packages/transforms/rename/src/wrapRename.ts), the transform seems to be applied twice, so the field is falsely renamed to `my_bk`.