### PR TITLE
Pass context as optional 3rd argument to OpenAPI custom fetch function

### DIFF
--- a/.changeset/light-lizards-applaud.md
+++ b/.changeset/light-lizards-applaud.md
@@ -1,0 +1,5 @@
+---
+'@graphql-mesh/openapi': minor
+---
+
+Pass context as third argument to custom fetch function

--- a/packages/handlers/odata/test/custom-fetch.ts
+++ b/packages/handlers/odata/test/custom-fetch.ts
@@ -1,18 +1,18 @@
 export let mocks: Record<string, (req: Request) => Promise<Response>> = {};
 export const Headers = Map;
-export const MockRequest = (function (url: string, config: RequestInit) {
+export const MockRequest = function (url: string, config: RequestInit) {
   return {
     url,
     ...config,
     text: async () => config.body,
   } as Request;
-} as any) as typeof Request;
-export const MockResponse = (function (body: string) {
+} as any as typeof Request;
+export const MockResponse = function (body: string) {
   return {
     text: async () => body,
     json: async () => JSON.parse(body),
   } as Response;
-} as any) as typeof Response;
+} as any as typeof Response;
 
 export function addMock(url: string, responseFn: (request: Request) => Promise<Response>) {
   mocks[url] = responseFn;
@@ -22,7 +22,7 @@ export function resetMocks() {
   mocks = {};
 }
 
-export const mockFetch = (function (...args: Parameters<WindowOrWorkerGlobalScope['fetch']>) {
+export const mockFetch = function (...args: Parameters<WindowOrWorkerGlobalScope['fetch']>) {
   let request: Request;
   if (typeof args[0] === 'string') {
     request = new MockRequest(...args);
@@ -35,4 +35,4 @@ export const mockFetch = (function (...args: Parameters<WindowOrWorkerGlobalScop
     throw new Error(`${url} isn't mocked!`);
   }
   return responseFn(request);
-} as any) as WindowOrWorkerGlobalScope['fetch'];
+} as any as WindowOrWorkerGlobalScope['fetch'];

--- a/packages/handlers/openapi/src/openapi-to-graphql/resolver_builder.ts
+++ b/packages/handlers/openapi/src/openapi-to-graphql/resolver_builder.ts
@@ -45,7 +45,7 @@ type GetResolverParams<TSource, TContext, TArgs> = {
   data: PreprocessingData<TSource, TContext, TArgs>;
   baseUrl?: string;
   requestOptions?: RequestOptions<TSource, TContext, TArgs>;
-  fetch?: (input: RequestInfo, init?: RequestInit) => Promise<Response>;
+  fetch?: (input: RequestInfo, init?: RequestInit, ctx?: TContext) => Promise<Response>;
   qs?: Record<string, string>;
   logger: Logger;
 };
@@ -598,7 +598,7 @@ export function getResolver<TSource, TContext, TArgs>(
 
     let response: Response;
     try {
-      response = await fetchFn(urlObject.href, options);
+      response = await fetchFn(urlObject.href, options, ctx);
     } catch (err) {
       httpLogger.debug(err);
       throw err;

--- a/packages/handlers/openapi/test/example_api.test.ts
+++ b/packages/handlers/openapi/test/example_api.test.ts
@@ -499,8 +499,7 @@ test('Nested links with constants and variables', () => {
               everythingLink: {
                 body: 'http://localhost:3002/api/copier_get_200_123_application/json_close',
                 everythingLink: {
-                  body:
-                    'http://localhost:3002/api/copier_get_200_http://localhost:3002/api/copier_get_200_123_application/json_close_application/json_close',
+                  body: 'http://localhost:3002/api/copier_get_200_http://localhost:3002/api/copier_get_200_123_application/json_close_application/json_close',
                 },
               },
             },
@@ -533,8 +532,7 @@ test('Link parameters as constants and variables with request payload', () => {
         postScanner: {
           body: 'req.body: body, req.query.query: query, req.path.path: path',
           everythingLink2: {
-            body:
-              'http://localhost:3002/api/scanner/path_post_200_body_query_path_application/json_req.body: body, req.query.query: query, req.path.path: path_query_path_close',
+            body: 'http://localhost:3002/api/scanner/path_post_200_body_query_path_application/json_req.body: body, req.query.query: query, req.path.path: path_query_path_close',
           },
         },
       },

--- a/website/docs/handlers/openapi.md
+++ b/website/docs/handlers/openapi.md
@@ -90,9 +90,9 @@ When building a web application, for security reasons, cookies are often used fo
 
 This section shows how to configure GraphQL Mesh to accept either, and also how to use GraphQL Mesh to set / unset cookies on the login & logout mutations.
 
-### Accepting either a cookie or a header
+### Accepting one of cookie, header or context value
 
-We want to accept either a `accessToken` cookie or a `Authorization` header, and transmit it to the Rest API as a `Authorization` header. GraphQL Mesh does not allow dynamic selection in the `meshrc.yaml` file, but that's fine! We can use a bit of trickery.
+We want to accept one of: an `accessToken` cookie, an `Authorization` header, or an authorization value available in context (e.g. set by a GraphQL auth plugin), and transmit it to the Rest API as a `Authorization` header. GraphQL Mesh does not allow dynamic selection in the `meshrc.yaml` file, but that's fine! We can use a bit of trickery.
 
 ```yml
 sources:
@@ -112,9 +112,9 @@ Here in the `meshrc.yaml` configuration we store the cookie in `Authorization-Co
 ```js
 const fetch = require('node-fetch')
 
-module.exports = function (url, args) {
-  // Set Authorization header dynamically to either the input cookie or input header
-  args.headers['authorization'] = args.headers['authorization-cookie'] ?? args.headers['authorization-header'];
+module.exports = function (url, args, context) {
+  // Set Authorization header dynamically to context value, or input cookie, or input header
+  args.headers['authorization'] = context.authorization || args.headers['authorization-cookie'] || args.headers['authorization-header'];
   // Clean up headers forwarded to the Rest API
   delete args.headers['authorization-cookie'];
   delete args.headers['authorization-header'];


### PR DESCRIPTION
## Description

OpenAPI handler allows setting a custom Fetch function.
This currently receives only URL and options.

With this PR I'm extending the arguments to also receive the context object.
Values available in the context can be used by developers to customise their handling in the fetch function.

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests and linter rules pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules