### PR TITLE
Update openapi.md

### DIFF
--- a/website/docs/handlers/openapi.md
+++ b/website/docs/handlers/openapi.md
@@ -63,9 +63,9 @@ sources:
         source: ./my-schema.json
         operationHeaders:
           # Please do not use capital letters while getting the headers
-          Authorization: Bearer {context.headers['x-my-api-token']}
+          Authorization: Bearer {context.req.headers['x-my-api-token']}
           # You can also access to the cookies like below;
-          # Authorization: Bearer {context.cookies.myApiToken}
+          # Authorization: Bearer {context.req.cookies.myApiToken}
 ```
 
 And for `mesh dev` or `mesh start`, you can pass the value using `x-my-graphql-api-token` HTTP header.
@@ -102,8 +102,8 @@ sources:
         source: ./openapi.yaml
         baseUrl: "{env.REST_URL}/api/"
         operationHeaders:
-          Authorization-Header: "{context.headers['authorization']}"
-          Authorization-Cookie: Bearer {context.cookies.accessToken}
+          Authorization-Header: "{context.req.headers['authorization']}"
+          Authorization-Cookie: Bearer {context.req.cookies.accessToken}
         customFetch: ./src/custom-fetch.js
 ```
 


### PR DESCRIPTION

## Description
Was following the documentation on how to parse the authorization header forward and it didn't seem to work unless taking it directly from the req. When investigating the issue it seems like `context.headers` is always undefined suggesting that it was a typo in the documentation.

Fixes # (issue)
Could potentially fix the issue in #1459 however I haven't looked at the graphql handler implementation.

## Type of change
Documentation only
