### PR TITLE
fix cli imports

### DIFF
--- a/.changeset/fluffy-years-prove.md
+++ b/.changeset/fluffy-years-prove.md
@@ -1,0 +1,5 @@
+---
+'@graphql-mesh/utils': patch
+---
+
+Fix baseDir imports for cli generated artifacts

--- a/packages/utils/src/load-from-module-export-expression.ts
+++ b/packages/utils/src/load-from-module-export-expression.ts
@@ -1,8 +1,7 @@
 /* eslint-disable @typescript-eslint/return-await */
-import { isAbsolute, join } from 'path';
+import { isAbsolute, join, resolve } from 'path';
 import { createRequire } from 'module';
 import { ImportFn, SyncImportFn } from '@graphql-mesh/types';
-import { statSync } from 'fs';
 
 type LoadFromModuleExportExpressionOptions = {
   defaultExportName: string;
@@ -98,12 +97,8 @@ export function getDefaultImport(from: string): ImportFn {
 }
 
 export function getDefaultSyncImport(from: string): SyncImportFn {
-  const pathStats = statSync(from);
-  if (pathStats.isDirectory()) {
-    from = join(from, 'mesh.config.js');
-  }
-
-  const relativeRequire = createRequire(from);
+  const createRequireConstructor = isAbsolute(from) ? from : resolve(from);
+  const relativeRequire = createRequire(createRequireConstructor);
 
   return (from: string) => relativeRequire(from);
 }


### PR DESCRIPTION
## Description

This PR fixes the cli definition of `syncImportFn`.
This currently uses createRequire to also support ESM.
The problem is that it passes a filename, to construct the require function, that does not exist.
In fact, `join(baseDir, 'mesh.config.js')` will never exist because `mesh.config.js` is not written as an artifact; since the config is printed within the module, both CommonJs (index.js) and ESModule (index.mjs).

`createRequire` does not necessarily need an actual "file" name, but it can also take a path.
This fix will pass the baseDir as the path argument, which will work both js and mjs.

Fixes #2610 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests and linter rules pass locally with my changes