### PR TITLE
fix(cli/serve): Spread WebSocket `connectionParams` to upgrade request headers

### DIFF
--- a/.changeset/happy-lions-play.md
+++ b/.changeset/happy-lions-play.md
@@ -1,0 +1,5 @@
+---
+'@graphql-mesh/cli': patch
+---
+
+Spread WebSocket `connectionParams` to upgrade request headers

--- a/packages/cli/src/commands/serve/serve.ts
+++ b/packages/cli/src/commands/serve/serve.ts
@@ -116,7 +116,7 @@ export async function serveMesh({ baseDir, argsPort, getBuiltMesh, logger, rawCo
           ),
         context: async ({ connectionParams, extra: { request } }) => {
           // spread connectionParams.headers to upgrade request headers.
-          // we dont completely ignore the root connectionParams because
+          // we completely ignore the root connectionParams because
           // [@graphql-tools/url-loader adds the headers there](https://github.com/ardatan/graphql-tools/blob/9a13357c4be98038c645f6efb26f0584828177cf/packages/loaders/url/src/index.ts#L597)
           for (const [key, value] of Object.entries(connectionParams.headers ?? {})) {
             // dont overwrite existing upgrade headers due to security reasons

--- a/packages/cli/src/commands/serve/serve.ts
+++ b/packages/cli/src/commands/serve/serve.ts
@@ -114,9 +114,19 @@ export async function serveMesh({ baseDir, argsPort, getBuiltMesh, logger, rawCo
           mesh$.then(({ subscribe }) =>
             subscribe(args.document, args.variableValues, args.contextValue, args.rootValue)
           ),
-        context: async ctx => {
+        context: async ({ connectionParams, extra: { request } }) => {
+          // spread connectionParams.headers to upgrade request headers.
+          // we dont completely ignore the root connectionParams because
+          // [@graphql-tools/url-loader adds the headers there](https://github.com/ardatan/graphql-tools/blob/9a13357c4be98038c645f6efb26f0584828177cf/packages/loaders/url/src/index.ts#L597)
+          for (const [key, value] of Object.entries(connectionParams.headers ?? {})) {
+            // dont overwrite existing upgrade headers due to security reasons
+            if (!(key in request.headers)) {
+              request.headers[key.toLowerCase()] = value;
+            }
+          }
+
           const { contextBuilder } = await mesh$;
-          return contextBuilder(ctx.extra.request);
+          return contextBuilder(request);
         },
       },
       wsServer

--- a/packages/cli/src/commands/serve/serve.ts
+++ b/packages/cli/src/commands/serve/serve.ts
@@ -117,7 +117,7 @@ export async function serveMesh({ baseDir, argsPort, getBuiltMesh, logger, rawCo
         context: async ({ connectionParams, extra: { request } }) => {
           // spread connectionParams.headers to upgrade request headers.
           // we completely ignore the root connectionParams because
-          // [@graphql-tools/url-loader adds the headers there](https://github.com/ardatan/graphql-tools/blob/9a13357c4be98038c645f6efb26f0584828177cf/packages/loaders/url/src/index.ts#L597)
+          // [@graphql-tools/url-loader adds the headers inside the "headers" field](https://github.com/ardatan/graphql-tools/blob/9a13357c4be98038c645f6efb26f0584828177cf/packages/loaders/url/src/index.ts#L597)
           for (const [key, value] of Object.entries(connectionParams.headers ?? {})) {
             // dont overwrite existing upgrade headers due to security reasons
             if (!(key in request.headers)) {

--- a/packages/cli/src/commands/serve/serve.ts
+++ b/packages/cli/src/commands/serve/serve.ts
@@ -120,7 +120,7 @@ export async function serveMesh({ baseDir, argsPort, getBuiltMesh, logger, rawCo
           // [@graphql-tools/url-loader adds the headers inside the "headers" field](https://github.com/ardatan/graphql-tools/blob/9a13357c4be98038c645f6efb26f0584828177cf/packages/loaders/url/src/index.ts#L597)
           for (const [key, value] of Object.entries(connectionParams.headers ?? {})) {
             // dont overwrite existing upgrade headers due to security reasons
-            if (!(key in request.headers)) {
+            if (!(key.toLowerCase() in request.headers)) {
               request.headers[key.toLowerCase()] = value;
             }
           }


### PR DESCRIPTION
## Description

Spread the [`ConnectionInit.payload` (aka `connectionParams`)](https://github.com/enisdenjo/graphql-ws/blob/master/PROTOCOL.md#connectioninit) values in the WebSocket [HTTP Upgrade request](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Upgrade) headers for a non-breaking fix of lacking authentication requirements.

Even through tampering with original request's headers feels illegal, it should be considered safe in this case since browsers dont allow specifying custom upgrade request header values when initialising a WebSocket connection. Because of this, passing along necessary header-like information is recommended to be done through the first WebSocket message inside an established connection, making the `connectionParams` synonymous to the upgrade request headers.

**Note:** Only the `connectionParams.headers` field is spread. Two reasons behind it:
1. Explicitness of where the values would end up. Using the `headers` field as an indicator of where the values would end up.
1. [`@graphql-tools/url-loader` adds the headers inside the `connectionParams.headers`](https://github.com/ardatan/graphql-tools/blob/9a13357c4be98038c645f6efb26f0584828177cf/packages/loaders/url/src/index.ts#L597)

Fixes #2638 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] ~New feature (non-breaking change which adds functionality)~
- [ ] ~Breaking change (fix or feature that would cause existing functionality to not work as expected)~
- [ ] ~This change requires a documentation update~

## How Has This Been Tested?

@jgoux monkey patched the `node_modules` following the relevant changes and achieved the desired results.

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests and linter rules pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules