### PR TITLE
Fix code generation failure on Windows

### DIFF
--- a/.changeset/mean-experts-argue.md
+++ b/.changeset/mean-experts-argue.md
@@ -1,0 +1,5 @@
+---
+'@graphql-mesh/cli': patch
+---
+
+Fixed a regression causing code generation using mesh build to fail on Windows

--- a/packages/cli/src/commands/ts-artifacts.ts
+++ b/packages/cli/src/commands/ts-artifacts.ts
@@ -8,7 +8,7 @@ import { pascalCase } from 'pascal-case';
 import { Source } from '@graphql-tools/utils';
 import * as tsOperationsPlugin from '@graphql-codegen/typescript-operations';
 import * as tsGenericSdkPlugin from '@graphql-codegen/typescript-generic-sdk';
-import { isAbsolute, relative, join } from 'path';
+import { isAbsolute, relative, join, normalize } from 'path';
 import ts from 'typescript';
 import { writeFile } from '@graphql-mesh/utils';
 import { cwd } from 'process';
@@ -293,7 +293,7 @@ export async function getMeshSDK() {
   await unlink(tsFilePath);
 }
 
-function compileTS(tsFilePath: string, module: ts.ModuleKind, outputFilePaths: string[]) {
+export function compileTS(tsFilePath: string, module: ts.ModuleKind, outputFilePaths: string[]) {
   const options: ts.CompilerOptions = {
     target: ts.ScriptTarget.ESNext,
     module,
@@ -308,7 +308,7 @@ function compileTS(tsFilePath: string, module: ts.ModuleKind, outputFilePaths: s
 
   const hostWriteFile = host.writeFile.bind(host);
   host.writeFile = (fileName, ...rest) => {
-    if (outputFilePaths.includes(fileName)) {
+    if (outputFilePaths.some(f => normalize(f) === normalize(fileName))) {
       return hostWriteFile(fileName, ...rest);
     }
   };

--- a/packages/cli/test/commands/fixtures/simple-compilation/.gitignore
+++ b/packages/cli/test/commands/fixtures/simple-compilation/.gitignore
@@ -1,0 +1,5 @@
+# These directories are generated (and deleted) by the test code
+# in case they're not auto-delete (due to some error), they should be excluded
+# from version control
+commonjs
+esm

--- a/packages/cli/test/commands/fixtures/simple-compilation/index.ts
+++ b/packages/cli/test/commands/fixtures/simple-compilation/index.ts
@@ -1,0 +1,3 @@
+export function square(x: number): number {
+  return x * x;
+}

--- a/packages/cli/test/commands/ts-artifacts.spec.ts
+++ b/packages/cli/test/commands/ts-artifacts.spec.ts
@@ -1,5 +1,5 @@
 import { join } from "path";
-import { existsSync, readFileSync, mkdirSync, copyFileSync, rmSync } from "fs";
+import { existsSync, readFileSync, mkdirSync, copyFileSync, rmdirSync } from "fs";
 import ts from "typescript";
 import { compileTS } from "../../src/commands/ts-artifacts";
 
@@ -11,8 +11,8 @@ describe('cli ts-artifacts', () => {
     const esmDir = join(baseDir, "esm");
 
     function cleanUp() {
-      rmSync(cjsDir, { recursive: true, force: true });
-      rmSync(esmDir, { recursive: true, force: true });
+      rmdirSync(cjsDir, { recursive: true });
+      rmdirSync(esmDir, { recursive: true });
     }
 
     beforeAll(() => {

--- a/packages/cli/test/commands/ts-artifacts.spec.ts
+++ b/packages/cli/test/commands/ts-artifacts.spec.ts
@@ -1,5 +1,5 @@
 import { join } from "path";
-import { existsSync, readFileSync, mkdirSync, rmdirSync, copyFileSync, rmSync } from "fs";
+import { existsSync, readFileSync, mkdirSync, copyFileSync, rmSync } from "fs";
 import ts from "typescript";
 import { compileTS } from "../../src/commands/ts-artifacts";
 

--- a/packages/cli/test/commands/ts-artifacts.spec.ts
+++ b/packages/cli/test/commands/ts-artifacts.spec.ts
@@ -1,5 +1,6 @@
 import { join } from "path";
-import { existsSync, readFileSync, mkdirSync, copyFileSync, rmdirSync } from "fs";
+import { existsSync, readFileSync, mkdirSync, copyFileSync } from "fs";
+import rimraf from "rimraf";
 import ts from "typescript";
 import { compileTS } from "../../src/commands/ts-artifacts";
 
@@ -10,13 +11,20 @@ describe('cli ts-artifacts', () => {
     const cjsDir = join(baseDir, "commonjs");
     const esmDir = join(baseDir, "esm");
 
-    function cleanUp() {
-      rmdirSync(cjsDir, { recursive: true });
-      rmdirSync(esmDir, { recursive: true });
+    async function cleanUp() {
+      return new Promise<void>((resolve, reject) => {
+        rimraf(cjsDir, (cjsErr) => {
+          if (cjsErr) return reject(cjsErr);
+          rimraf(esmDir, (esmErr) => {
+            if (esmErr) return reject(esmErr);
+            resolve();
+          })
+        });
+      });
     }
 
-    beforeAll(() => {
-      cleanUp();
+    beforeAll(async () => {
+      await cleanUp();
       const tsFilePath = join(baseDir, "index.ts");
       mkdirSync(cjsDir, { recursive: true });
       copyFileSync(tsFilePath, join(cjsDir, "index.ts"));
@@ -24,8 +32,8 @@ describe('cli ts-artifacts', () => {
       copyFileSync(tsFilePath, join(esmDir, "index.ts"));
     });
 
-    afterAll(() => {
-      cleanUp();
+    afterAll(async () => {
+      await cleanUp();
     });
 
 

--- a/packages/cli/test/commands/ts-artifacts.spec.ts
+++ b/packages/cli/test/commands/ts-artifacts.spec.ts
@@ -1,0 +1,54 @@
+import { join } from "path";
+import { existsSync, readFileSync, mkdirSync, rmdirSync, copyFileSync, rmSync } from "fs";
+import ts from "typescript";
+import { compileTS } from "../../src/commands/ts-artifacts";
+
+describe('cli ts-artifacts', () => {
+
+  describe("compileTS", () => {
+    const baseDir = join(__dirname, "fixtures", "simple-compilation");
+    const cjsDir = join(baseDir, "commonjs");
+    const esmDir = join(baseDir, "esm");
+
+    function cleanUp() {
+      rmSync(cjsDir, { recursive: true, force: true });
+      rmSync(esmDir, { recursive: true, force: true });
+    }
+
+    beforeAll(() => {
+      cleanUp();
+      const tsFilePath = join(baseDir, "index.ts");
+      mkdirSync(cjsDir, { recursive: true });
+      copyFileSync(tsFilePath, join(cjsDir, "index.ts"));
+      mkdirSync(esmDir, { recursive: true })
+      copyFileSync(tsFilePath, join(esmDir, "index.ts"));
+    });
+
+    afterAll(() => {
+      cleanUp();
+    });
+
+
+    it('should compile ts code to js code with CommonJS module', () => {
+      const tsFilePath = join(cjsDir, "index.ts");
+      const jsFilePath = join(cjsDir, "index.js");
+      const dtsFilePath = join(cjsDir, "index.d.ts");
+      compileTS(tsFilePath, ts.ModuleKind.CommonJS, [jsFilePath, dtsFilePath]);
+      expect(existsSync(jsFilePath)).toBe(true);
+      expect(existsSync(dtsFilePath)).toBe(true);
+      const js = readFileSync(jsFilePath, { encoding: "utf8" });
+      expect(js.includes("exports.square")).toBe(true);
+    });
+
+    it('should compile ts code to js code with ESM module', () => {
+      const tsFilePath = join(esmDir, "index.ts");
+      const jsFilePath = join(esmDir, "index.js");
+      const dtsFilePath = join(esmDir, "index.d.ts");
+      compileTS(tsFilePath, ts.ModuleKind.ESNext, [jsFilePath, dtsFilePath]);
+      expect(existsSync(jsFilePath)).toBe(true);
+      expect(existsSync(dtsFilePath)).toBe(true);
+      const js = readFileSync(jsFilePath, { encoding: "utf8" });
+      expect(js.includes("export function square")).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
🚨 **IMPORTANT: Please do not create a Pull Request without creating an issue first.**

*Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request.*

## Description

Adds new test cases to demonstrate the bug causing code generation to fail on Windows. The bug is caused by comparing paths with different path separators (`/` and `\`).

Fixes the issue by normalizing paths before comparing them.

Fixes #2650 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots/Sandbox (if appropriate/relevant):

### Running tests **before** the fix

![image](https://user-images.githubusercontent.com/8460169/129753753-cb06094b-3805-4b43-8468-02619e05bdd1.png)

### Running tests **after** the fix

![image](https://user-images.githubusercontent.com/8460169/129755811-4ec51731-143d-4af6-a618-92402b42d761.png)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] `npm test cli`

**Test Environment**:
- OS: Windows 10
- `@graphql-mesh/cli`: 0.34.2
- NodeJS: 14.7.3

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests and linter rules pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
