### PR TITLE
Allowing nested key args

### DIFF
--- a/.changeset/cool-mugs-laugh.md
+++ b/.changeset/cool-mugs-laugh.md
@@ -1,0 +1,14 @@
+---
+'@graphql-mesh/config': minor
+'@graphql-mesh/runtime': minor
+'@graphql-mesh/transform-federation': minor
+'@graphql-mesh/types': minor
+'@graphql-mesh/utils': minor
+---
+
+Some improvements on additional resolvers;
+
+- Now you can point to the nested fields in `keyArgs`; e.g. `keysArg: "where.ids"`
+- You don't need `returnType` for abstract types anymore, because it's inferred from the type of `targetFieldName`.
+
+

--- a/examples/postgres-geodb/.meshrc.yaml
+++ b/examples/postgres-geodb/.meshrc.yaml
@@ -39,7 +39,6 @@ additionalResolvers:
       query: location:{root.name}
       first: "{args.limit}"
     result: nodes
-    resultType: GithubUser
 
 documents:
   - ./src/test.query.graphql

--- a/packages/config/yaml-config.graphql
+++ b/packages/config/yaml-config.graphql
@@ -102,12 +102,22 @@ type AdditionalStitchingBatchResolverObject {
   sourceName: String!
   sourceTypeName: String!
   sourceFieldName: String!
+  sourceSelectionSet: String
+  requiredSelectionSet: String
   keyField: String!
   keysArg: String!
   additionalArgs: JSON
-  requiredSelectionSet: String
   targetTypeName: String!
   targetFieldName: String!
+  """
+  Extract specific property from the result
+  """
+  result: String
+  """
+  If return types don't match,
+  you can specify a result type to apply inline fragment
+  """
+  resultType: String
 }
 
 type AdditionalSubscriptionObject {

--- a/packages/runtime/src/get-mesh.ts
+++ b/packages/runtime/src/get-mesh.ts
@@ -187,7 +187,7 @@ export async function getMesh(options: GetMeshOptions): Promise<MeshInstance> {
           for (const fieldName in rootTypeFieldMap) {
             const rootTypeField = rootTypeFieldMap[fieldName];
             const inContextSdkLogger = rawSourceLogger.child(`InContextSDK.${rootType.name}.${fieldName}`);
-            rawSourceContext[rootType.name][fieldName] = ({
+            rawSourceContext[rootType.name][fieldName] = async ({
               root,
               args,
               context,
@@ -195,6 +195,7 @@ export async function getMesh(options: GetMeshOptions): Promise<MeshInstance> {
               selectionSet,
               key,
               argsFromKeys,
+              valuesFromResults,
             }: {
               root: any;
               args: any;
@@ -203,6 +204,7 @@ export async function getMesh(options: GetMeshOptions): Promise<MeshInstance> {
               selectionSet: SelectionSetParamOrFactory;
               key?: string;
               argsFromKeys?: (keys: string[]) => any;
+              valuesFromResults?: (result: any, keys?: string[]) => any;
             }) => {
               inContextSdkLogger.debug(`Called with
 - root: ${inspect(root)}
@@ -223,22 +225,31 @@ export async function getMesh(options: GetMeshOptions): Promise<MeshInstance> {
                   ...commonDelegateOptions,
                   key,
                   argsFromKeys,
+                  valuesFromResults,
                 };
+                if (selectionSet) {
+                  const selectionSetFactory = normalizeSelectionSetParamOrFactory(selectionSet);
+                  const path = [fieldName];
+                  const wrapQueryTransform = new WrapQuery(path, selectionSetFactory, identical);
+                  batchDelegationOptions.transforms = [wrapQueryTransform];
+                }
                 return batchDelegateToSchema(batchDelegationOptions);
-              } else if (selectionSet) {
-                const selectionSetFactory = normalizeSelectionSetParamOrFactory(selectionSet);
-                const path = [fieldName];
-                const wrapQueryTransform = new WrapQuery(path, selectionSetFactory, identical);
-                return delegateToSchema({
-                  ...commonDelegateOptions,
-                  args,
-                  transforms: [wrapQueryTransform],
-                });
               } else {
-                return delegateToSchema({
+                const options: IDelegateToSchemaOptions = {
                   ...commonDelegateOptions,
                   args,
-                });
+                };
+                if (selectionSet) {
+                  const selectionSetFactory = normalizeSelectionSetParamOrFactory(selectionSet);
+                  const path = [fieldName];
+                  const wrapQueryTransform = new WrapQuery(path, selectionSetFactory, identical);
+                  options.transforms = [wrapQueryTransform];
+                }
+                const result = await delegateToSchema(options);
+                if (valuesFromResults) {
+                  return valuesFromResults(result);
+                }
+                return result;
               }
             };
           }

--- a/packages/runtime/src/get-mesh.ts
+++ b/packages/runtime/src/get-mesh.ts
@@ -10,7 +10,6 @@ import {
   GraphQLObjectType,
   getOperationAST,
   print,
-  isListType,
   SelectionSetNode,
   ExecutionResult,
 } from 'graphql';
@@ -219,7 +218,7 @@ export async function getMesh(options: GetMeshOptions): Promise<MeshInstance> {
                 transformedSchema,
                 info,
               };
-              if (isListType(rootTypeField.type) && key && argsFromKeys) {
+              if (key && argsFromKeys) {
                 const batchDelegationOptions: BatchDelegateOptions = {
                   ...commonDelegateOptions,
                   key,

--- a/packages/types/src/config-schema.json
+++ b/packages/types/src/config-schema.json
@@ -579,6 +579,12 @@
         "sourceFieldName": {
           "type": "string"
         },
+        "sourceSelectionSet": {
+          "type": "string"
+        },
+        "requiredSelectionSet": {
+          "type": "string"
+        },
         "keyField": {
           "type": "string"
         },
@@ -589,14 +595,19 @@
           "type": "object",
           "properties": {}
         },
-        "requiredSelectionSet": {
-          "type": "string"
-        },
         "targetTypeName": {
           "type": "string"
         },
         "targetFieldName": {
           "type": "string"
+        },
+        "result": {
+          "type": "string",
+          "description": "Extract specific property from the result"
+        },
+        "resultType": {
+          "type": "string",
+          "description": "If return types don't match,\nyou can specify a result type to apply inline fragment"
         }
       },
       "required": [

--- a/packages/types/src/config.ts
+++ b/packages/types/src/config.ts
@@ -1375,14 +1375,24 @@ export interface AdditionalStitchingBatchResolverObject {
   sourceName: string;
   sourceTypeName: string;
   sourceFieldName: string;
+  sourceSelectionSet?: string;
+  requiredSelectionSet?: string;
   keyField: string;
   keysArg: string;
   additionalArgs?: {
     [k: string]: any;
   };
-  requiredSelectionSet?: string;
   targetTypeName: string;
   targetFieldName: string;
+  /**
+   * Extract specific property from the result
+   */
+  result?: string;
+  /**
+   * If return types don't match,
+   * you can specify a result type to apply inline fragment
+   */
+  resultType?: string;
 }
 export interface AdditionalSubscriptionObject {
   targetTypeName: string;

--- a/packages/utils/src/resolve-additional-resolvers.ts
+++ b/packages/utils/src/resolve-additional-resolvers.ts
@@ -79,7 +79,7 @@ export function resolveAdditionalResolvers(
                   context,
                   info,
                   argsFromKeys: (keys: string[]) => ({
-                    [additionalResolver.keysArg]: keys,
+                    ..._.set({}, additionalResolver.keysArg, keys),
                     ...targetArgs,
                   }),
                   key: _.get(root, additionalResolver.keyField),

--- a/packages/utils/src/resolve-additional-resolvers.ts
+++ b/packages/utils/src/resolve-additional-resolvers.ts
@@ -78,10 +78,12 @@ export function resolveAdditionalResolvers(
                   root,
                   context,
                   info,
-                  argsFromKeys: (keys: string[]) => ({
-                    ..._.set({}, additionalResolver.keysArg, keys),
-                    ...targetArgs,
-                  }),
+                  argsFromKeys: (keys: string[]) => {
+                    const args: any = {};
+                    _.set(args, additionalResolver.keysArg, keys);
+                    Object.assign(args, targetArgs);
+                    return args;
+                  },
                   key: _.get(root, additionalResolver.keyField),
                 });
               },

--- a/packages/utils/src/resolve-additional-resolvers.ts
+++ b/packages/utils/src/resolve-additional-resolvers.ts
@@ -28,6 +28,10 @@ function getTypeByPath(type: GraphQLType, path: string[]): GraphQLType {
   }
   const fieldMap = type.getFields();
   const currentFieldName = path[0];
+  // Might be an index of an array
+  if (!Number.isNaN(parseInt(currentFieldName))) {
+    return getTypeByPath(type, path.slice(1));
+  }
   const field = fieldMap[currentFieldName];
   if (!field?.type) {
     throw new Error(`${type}.${currentFieldName} is not a valid field.`);


### PR DESCRIPTION
## Description

Allows richer use of `keyArgs` for queries other than those that return lists (such as `Collection`s) and for more complex argument structures, such as passing keys to nested fields in an argument object.

Related https://github.com/Urigo/graphql-mesh/issues/2680

## Type of change

Please delete options that are not relevant. **Currently unsure of the nature of this change**

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Screenshots/Sandbox (if appropriate/relevant):

Adding links to sandbox or providing screenshots can help us understand more about this PR and take action on it as appropriate

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Environment**:
- OS:
- `@graphql-mesh/...`:
- NodeJS:

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests and linter rules pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
