### PR TITLE
Add support for fields wildcard when filtering for arguments

### DIFF
--- a/.changeset/thirty-masks-cheer.md
+++ b/.changeset/thirty-masks-cheer.md
@@ -1,0 +1,5 @@
+---
+'@graphql-mesh/transform-filter-schema': minor
+---
+
+Add support for wildcard matching of fields when filtering arguments

--- a/packages/transforms/filter-schema/src/bareFilter.ts
+++ b/packages/transforms/filter-schema/src/bareFilter.ts
@@ -60,7 +60,9 @@ export default class BareFilter implements MeshTransform {
       ...((this.fieldsMap.size || this.argsMap.size) && {
         [MapperKind.COMPOSITE_FIELD]: (fieldConfig, fieldName, typeName) => {
           const fieldRules = this.fieldsMap.get(typeName);
-          const argRules = this.argsMap.get(`${typeName}_${fieldName}`);
+          const wildcardArgRules = this.argsMap.get(`${typeName}_*`) || [];
+          const fieldArgRules = this.argsMap.get(`${typeName}_${fieldName}`) || [];
+          const argRules = wildcardArgRules.concat(fieldArgRules);
           const hasFieldRules = Boolean(fieldRules && fieldRules.length);
           const hasArgRules = Boolean(argRules && argRules.length);
 

--- a/packages/transforms/filter-schema/test/transform.spec.ts
+++ b/packages/transforms/filter-schema/test/transform.spec.ts
@@ -40,9 +40,11 @@ describe('filter', () => {
       transforms: [
         FilterSchemaTransform({
           config: ['!Comment', 'User.posts.{message, author}', 'Query.user.!pk'],
+          apiName: '',
           cache,
           pubsub,
           baseDir,
+          syncImportFn: require,
         }),
       ],
     });
@@ -99,9 +101,11 @@ type Query {
       transforms: [
         FilterSchemaTransform({
           config: { filters: ['!Comment', 'User.posts.{message, author}', 'Query.user.!pk'] },
+          apiName: '',
           cache,
           pubsub,
           baseDir,
+          syncImportFn: require,
         }),
       ],
     });
@@ -185,9 +189,11 @@ type Query {
               'Query.user.!pk',
             ],
           },
+          apiName: '',
           cache,
           pubsub,
           baseDir,
+          syncImportFn: require,
         }),
       ],
     });
@@ -209,6 +215,190 @@ type Post {
 
 type Query {
   user(name: String, age: Int): User
+}
+`.trim()
+    );
+  });
+
+  it("filters correctly arguments on all fields in Type, with 'bare' mode", async () => {
+    let schema = buildSchema(/* GraphQL */ `
+      type User {
+        id: ID
+        name: String
+        username: String
+      }
+
+      type Query {
+        userOne(pk: ID!, name: String, age: Int): User
+        userTwo(pk: ID!, name: String, age: Int): User
+      }
+    `);
+    schema = wrapSchema({
+      schema,
+      transforms: [
+        FilterSchemaTransform({
+          config: {
+            mode: 'bare',
+            filters: ['Query.*.!pk'],
+          },
+          apiName: '',
+          cache,
+          pubsub,
+          baseDir,
+          syncImportFn: require,
+        }),
+      ],
+    });
+
+    expect(printSchema(schema).trim()).toBe(
+      /* GraphQL */ `
+type User {
+  id: ID
+  name: String
+  username: String
+}
+
+type Query {
+  userOne(name: String, age: Int): User
+  userTwo(name: String, age: Int): User
+}
+`.trim()
+    );
+  });
+
+  it("filters correctly arguments on all fields in Type, plus specific field arguments; with 'bare' mode", async () => {
+    let schema = buildSchema(/* GraphQL */ `
+      type User {
+        id: ID
+        name: String
+        username: String
+      }
+
+      type Query {
+        userOne(pk: ID!, name: String, age: Int): User
+        userTwo(pk: ID!, name: String, age: Int): User
+      }
+    `);
+    schema = wrapSchema({
+      schema,
+      transforms: [
+        FilterSchemaTransform({
+          config: {
+            mode: 'bare',
+            filters: ['Query.*.!pk', 'Query.userOne.!age'],
+          },
+          apiName: '',
+          cache,
+          pubsub,
+          baseDir,
+          syncImportFn: require,
+        }),
+      ],
+    });
+
+    expect(printSchema(schema).trim()).toBe(
+      /* GraphQL */ `
+type User {
+  id: ID
+  name: String
+  username: String
+}
+
+type Query {
+  userOne(name: String): User
+  userTwo(name: String, age: Int): User
+}
+`.trim()
+    );
+  });
+
+  it("filters correctly arguments on all fields in Type, with 'wrap' mode", async () => {
+    let schema = buildSchema(/* GraphQL */ `
+      type User {
+        id: ID
+        name: String
+        username: String
+      }
+
+      type Query {
+        userOne(pk: ID!, name: String, age: Int): User
+        userTwo(pk: ID!, name: String, age: Int): User
+      }
+    `);
+    schema = wrapSchema({
+      schema,
+      transforms: [
+        FilterSchemaTransform({
+          config: {
+            mode: 'wrap',
+            filters: ['Query.*.!pk'],
+          },
+          apiName: '',
+          cache,
+          pubsub,
+          baseDir,
+          syncImportFn: require,
+        }),
+      ],
+    });
+
+    expect(printSchema(schema).trim()).toBe(
+      /* GraphQL */ `
+type User {
+  id: ID
+  name: String
+  username: String
+}
+
+type Query {
+  userOne(name: String, age: Int): User
+  userTwo(name: String, age: Int): User
+}
+`.trim()
+    );
+  });
+
+  it("filters correctly arguments on all fields in Type, plus specific field arguments; with 'wrap' mode", async () => {
+    let schema = buildSchema(/* GraphQL */ `
+      type User {
+        id: ID
+        name: String
+        username: String
+      }
+
+      type Query {
+        userOne(pk: ID!, name: String, age: Int): User
+        userTwo(pk: ID!, name: String, age: Int): User
+      }
+    `);
+    schema = wrapSchema({
+      schema,
+      transforms: [
+        FilterSchemaTransform({
+          config: {
+            mode: 'wrap',
+            filters: ['Query.*.!pk', 'Query.userOne.!age'],
+          },
+          apiName: '',
+          cache,
+          pubsub,
+          baseDir,
+          syncImportFn: require,
+        }),
+      ],
+    });
+
+    expect(printSchema(schema).trim()).toBe(
+      /* GraphQL */ `
+type User {
+  id: ID
+  name: String
+  username: String
+}
+
+type Query {
+  userOne(name: String): User
+  userTwo(name: String, age: Int): User
 }
 `.trim()
     );
@@ -244,9 +434,11 @@ type Query {
       transforms: [
         FilterSchemaTransform({
           config: ['User.!{a,b,c,d,e}', 'Query.!admin', 'Book.{id,name,author}'],
+          apiName: '',
           cache,
           pubsub,
           baseDir,
+          syncImportFn: require,
         }),
       ],
     });
@@ -289,9 +481,11 @@ type Query {
       transforms: [
         FilterSchemaTransform({
           config: ['Mutation.!*'],
+          apiName: '',
           cache,
           pubsub,
           baseDir,
+          syncImportFn: require,
         }),
       ],
     });
@@ -334,9 +528,11 @@ type Query {
       transforms: [
         FilterSchemaTransform({
           config: ['User.{id, username}', 'Query.!{admin}', 'Book.{id}'],
+          apiName: '',
           cache,
           pubsub,
           baseDir,
+          syncImportFn: require,
         }),
       ],
     });
@@ -389,9 +585,11 @@ type Query {
       transforms: [
         FilterSchemaTransform({
           config: ['!Book'],
+          apiName: '',
           cache,
           pubsub,
           baseDir,
+          syncImportFn: require,
         }),
       ],
     });
@@ -456,9 +654,11 @@ type Query {
       transforms: [
         FilterSchemaTransform({
           config: { mode: 'bare', filters: ['Type.!Comment', 'Type.!{Notification, Mention}'] },
+          apiName: '',
           cache,
           pubsub,
           baseDir,
+          syncImportFn: require,
         }),
       ],
     });
@@ -525,9 +725,11 @@ type Query {
         FilterSchemaTransform({
           // bizarre case, but logic should still work
           config: { mode: 'bare', filters: ['Type.{Query, User, Post, String, ID}'] },
+          apiName: '',
           cache,
           pubsub,
           baseDir,
+          syncImportFn: require,
         }),
       ],
     });
@@ -585,9 +787,11 @@ type Query {
       transforms: [
         FilterSchemaTransform({
           config: ['!User'],
+          apiName: '',
           cache,
           pubsub,
           baseDir,
+          syncImportFn: require,
         }),
       ],
     });
@@ -647,9 +851,11 @@ type Query {
       transforms: [
         FilterSchemaTransform({
           config: ['!AuthRule'],
+          apiName: '',
           cache,
           pubsub,
           baseDir,
+          syncImportFn: require,
         }),
       ],
     });
@@ -708,9 +914,11 @@ type Query {
       transforms: [
         FilterSchemaTransform({
           config: ['Query.user.!{pk, age}', 'Query.book.title'],
+          apiName: '',
           cache,
           pubsub,
           baseDir,
+          syncImportFn: require,
         }),
       ],
     });

--- a/website/docs/transforms/filter-schema.md
+++ b/website/docs/transforms/filter-schema.md
@@ -27,9 +27,14 @@ transforms:
         - User.{id, username, name, age} # <-- This will remove all fields, from User type, except `id`, `username`, `name` and `age`
 
         - Query.user.id # <-- This will remove all args from field `user`, in Query type, except `id` only
-        - Query.user.!name # <-- This will remove argument `id` from field `user`, in Query type
+        - Query.user.!name # <-- This will remove argument `name` from field `user`, in Query type
         - Query.user.{id, name} # <-- This will remove all args for field `user`, in Query type, except `id` and `name`
         - Query.user.!{id, name} # <-- This will remove args `id` and `name` from field `user`, in Query type
+
+        - Query.*.id # <-- This will remove all args from all fields in Query type, except `id` only
+        - Query.*.!name # <-- This will remove argument `name` from all fields in Query type
+        - Query.*.{id, name} # <-- This will remove all args from all fields in Query type, except `id` and `name`
+        - Query.*.!{id, name} # <-- This will remove args `id` and `name` from all fields in Query type
 ```
 
 Let's assume you have the following schema,


### PR DESCRIPTION
## Description

With this PR I want to add support for the following syntax on the filter transform:
`Query.*.!{id, name}`, `Query.*.{id, name}` and similar.

You can also see updated docs for other examples of supported syntax, but the key point is to target all fields in Type with `Type.*.`

This seems to be working for free with `wrap` mode, but it currently doesn't work with `bare` mode.
This PR intentionally adds support for this syntax and also provides relevant examples in the documentation.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

4 new unit tests have been introduced.
Also, all tests for the filter transform have been fixed as they had TS errors.

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests and linter rules pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules