### PR TITLE
Remove broken self-referential link in "as-mesh" recipe docs.

### DIFF
--- a/website/docs/recipes/as-gateway.md
+++ b/website/docs/recipes/as-gateway.md
@@ -9,7 +9,7 @@ sidebar_label: Mesh as Gateway
   <br/>
 </p>
 
-You can use GraphQL Mesh as an HTTP gateway proxy for your data sources. GraphQL Mesh provides you an HTTP server with [Express](https://expressjs.com/), [GraphQL Helix](https://github.com/contrawork/graphql-helix), [GraphQL-WS](https://github.com/enisdenjo/graphql-ws#readme) and [GraphiQL Explorer](https://github.com/OneGraph/graphiql-explorer) with the bunch of configurable features out-of-box.
+You can use GraphQL Mesh as an HTTP gateway proxy for your data sources. GraphQL Mesh provides you an HTTP server with [Express](https://expressjs.com/), [GraphQL Helix](https://github.com/contrawork/graphql-helix), [GraphQL-WS](https://github.com/enisdenjo/graphql-ws#readme) and [GraphiQL Explorer](https://github.com/OneGraph/graphiql-explorer) with a bunch of configurable features out-of-box.
 
 There are two commands for GraphQL Mesh's HTTP Server;
 

--- a/website/docs/recipes/as-gateway.md
+++ b/website/docs/recipes/as-gateway.md
@@ -9,7 +9,7 @@ sidebar_label: Mesh as Gateway
   <br/>
 </p>
 
-You can use GraphQL Mesh as an HTTP gateway proxy for your data sources. GraphQL Mesh provides you an HTTP server with [Express](https://expressjs.com/), [GraphQL Helix](https://github.com/contrawork/graphql-helix), [GraphQL-WS](https://github.com/enisdenjo/graphql-ws#readme) and [GraphiQL Explorer](https://github.com/OneGraph/graphiql-explorer) with the bunch of configurable features out-of-box which can be seen [here](/docs/recipes/mesh-as-gateway).
+You can use GraphQL Mesh as an HTTP gateway proxy for your data sources. GraphQL Mesh provides you an HTTP server with [Express](https://expressjs.com/), [GraphQL Helix](https://github.com/contrawork/graphql-helix), [GraphQL-WS](https://github.com/enisdenjo/graphql-ws#readme) and [GraphiQL Explorer](https://github.com/OneGraph/graphiql-explorer) with the bunch of configurable features out-of-box.
 
 There are two commands for GraphQL Mesh's HTTP Server;
 


### PR DESCRIPTION
## Description

Removed broken link and fixed grammar in "as-mesh" recipe docs.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Visually.

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
