### PR TITLE
Introduce input object field filtering to "bare" mode of filter-schem…

### DIFF
--- a/.changeset/moody-badgers-jam.md
+++ b/.changeset/moody-badgers-jam.md
@@ -1,0 +1,5 @@
+---
+'@graphql-mesh/transform-filter-schema': minor
+---
+
+Introduce input object field filtering to "bare" mode of filter-schema transform

--- a/packages/transforms/filter-schema/src/bareFilter.ts
+++ b/packages/transforms/filter-schema/src/bareFilter.ts
@@ -37,7 +37,7 @@ export default class BareFilter implements MeshTransform {
       }
 
       const mapName = argsGlob ? 'argsMap' : 'fieldsMap';
-      const mapKey = argsGlob ? `${typeName}_${fieldNameOrGlob}` : typeName;
+      const mapKey = argsGlob ? `${typeName}.${fieldNameOrGlob}` : typeName;
       const currentRules = this[mapName].get(mapKey) || [];
 
       this[mapName].set(mapKey, [...currentRules, polishedGlob]);
@@ -60,8 +60,8 @@ export default class BareFilter implements MeshTransform {
       ...((this.fieldsMap.size || this.argsMap.size) && {
         [MapperKind.COMPOSITE_FIELD]: (fieldConfig, fieldName, typeName) => {
           const fieldRules = this.fieldsMap.get(typeName);
-          const wildcardArgRules = this.argsMap.get(`${typeName}_*`) || [];
-          const fieldArgRules = this.argsMap.get(`${typeName}_${fieldName}`) || [];
+          const wildcardArgRules = this.argsMap.get(`${typeName}.*`) || [];
+          const fieldArgRules = this.argsMap.get(`${typeName}.${fieldName}`) || [];
           const argRules = wildcardArgRules.concat(fieldArgRules);
           const hasFieldRules = Boolean(fieldRules && fieldRules.length);
           const hasArgRules = Boolean(argRules && argRules.length);
@@ -76,6 +76,16 @@ export default class BareFilter implements MeshTransform {
           );
 
           return { ...fieldConfig, args: fieldArgs };
+        },
+      }),
+      ...(this.fieldsMap.size && {
+        [MapperKind.INPUT_OBJECT_FIELD]: (_, fieldName, typeName) => {
+          const fieldRules = this.fieldsMap.get(typeName);
+          const hasFieldRules = Boolean(fieldRules && fieldRules.length);
+
+          if (hasFieldRules && this.matchInArray(fieldRules, fieldName) === null) return null;
+
+          return undefined;
         },
       }),
     });


### PR DESCRIPTION
## Description

Currently, the "bare" mode of filter-schema transform does not allow to filter Input Object Fields, whilst the wrap version does.
This PR extends the "bare" mode to also filter Input Object Fields.

Syntax is same as usual, an input object like this:
```graphql
input BookRequestBody {
  id: String!
  isAvailable: Boolean
}
```

Can be filtered this way:
```yaml
- filterSchema:
    mode: bare
    filters:
      - BookRequestBody.!isAvailable
```

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests and linter rules pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules