### PR TITLE
fix(build): use correct path for relative imports of external modules + bracket notation

### DIFF
--- a/packages/cli/src/commands/ts-artifacts.ts
+++ b/packages/cli/src/commands/ts-artifacts.ts
@@ -191,10 +191,12 @@ export async function generateTsArtifacts({
             if (importPath.startsWith('.')) {
               importPath = join(baseDir, importPath);
             }
+
             if (isAbsolute(importPath)) {
               moduleMapProp = relative(baseDir, importPath).split('\\').join('/');
               importPath = `./${relative(artifactsDir, importPath).split('\\').join('/')}`;
             }
+
             const importedModuleVariable = pascalCase(`ExternalModule$${i}`);
             importCodes.push(`import ${importedModuleVariable} from '${importPath}';`);
             return `  // @ts-ignore\n  [${JSON.stringify(moduleMapProp)}]: ${importedModuleVariable}`;

--- a/packages/cli/src/commands/ts-artifacts.ts
+++ b/packages/cli/src/commands/ts-artifacts.ts
@@ -192,8 +192,8 @@ export async function generateTsArtifacts({
               importPath = join(baseDir, importPath);
             }
             if (isAbsolute(importPath)) {
-              moduleMapProp = relative(baseDir, importedModuleName).split('\\').join('/');
-              importPath = `./${relative(artifactsDir, importedModuleName).split('\\').join('/')}`;
+              moduleMapProp = relative(baseDir, importPath).split('\\').join('/');
+              importPath = `./${relative(artifactsDir, importPath).split('\\').join('/')}`;
             }
             const importedModuleVariable = pascalCase(`ExternalModule$${i}`);
             importCodes.push(`import ${importedModuleVariable} from '${importPath}';`);

--- a/packages/config/src/process.ts
+++ b/packages/config/src/process.ts
@@ -294,7 +294,7 @@ export async function processConfig(
         )}';`
       );
       codes.push(
-        `additionalResolversRawConfig.push(additionalResolvers$${additionalResolverDefinitionIndex}.resolvers || additionalResolvers$${additionalResolverDefinitionIndex}.default || additionalResolvers$${additionalResolverDefinitionIndex})`
+        `additionalResolversRawConfig.push(additionalResolvers$${additionalResolverDefinitionIndex}['resolvers'] || additionalResolvers$${additionalResolverDefinitionIndex}['default'] || additionalResolvers$${additionalResolverDefinitionIndex})`
       );
     } else {
       codes.push(


### PR DESCRIPTION
## Description

Rolled up two issues as they both only required minor fixes:

Issue 1
Currently using build with external modules that are specified by relative path only work when the `--dir` equals root of the workspace. Any relative import is always expressed in relation to the root workspace directory instead of in relation to the `baseDir`.

Issue 2
When using a built mesh with additional resolvers from within a typescript project the compiler was complaining about either missing `.resolvers` or  `.default`. This was easily mitigated by using bracket notation.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests and linter rules pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

## Further comments
I have tested this locally as we were trying to get mesh build up and running in the context of an nx workspace.


Let me know if I should create a change set or wait for #2970 to create a single PR + changeset.
