### PR TITLE
Add example using ${DATABASE_URL} in postgraphile doc

### DIFF
--- a/website/docs/handlers/postgraphile.md
+++ b/website/docs/handlers/postgraphile.md
@@ -21,6 +21,8 @@ sources:
     handler:
       postgraphile:
         connectionString: postgres://postgres:password@localhost/postgres
+        # can also read connection string from env: 
+        # connectionString: ${DATABASE_URL}
 ```
 
 > You can check out our example that uses schema stitching with a PostgreSQL datasource.


### PR DESCRIPTION

## Description

Add an example of a postgraphile config using `${DATABASE_URL}` in `connectionString`.

I spend too much time to find the correct way to use an env variable in the `connectionString` of the `.meshrc.yaml`.

The documentation of the [OpenAPI handler](https://www.graphql-mesh.com/docs/handlers/openapi#from-environmental-variable) confused me a lot because it reading an env with another syntax:
```yaml
sources:
  - name: MyGraphQLApi
    handler:
      openapi:
        source: ./my-schema.json
        operationHeaders:
          Authorization: Bearer {env.MY_API_TOKEN}
```

Thanks to the issue https://github.com/Urigo/graphql-mesh/issues/543, I finally find how to read an env!

I would also suggest you to add a paragraph about the templating system and what variables or functions are available in the `.meshrc.yaml`.

## Type of change

- update documentation

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests and linter rules pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
