### PR TITLE
[WIP] Added transfer-field transform

### DIFF
--- a/packages/transforms/transfer-field/package.json
+++ b/packages/transforms/transfer-field/package.json
@@ -1,0 +1,38 @@
+{
+  "name": "@graphql-mesh/transform-transform-field",
+  "version": "0.0.0",
+  "sideEffects": false,
+  "main": "dist/index.js",
+  "module": "dist/index.mjs",
+  "typings": "dist/index.d.ts",
+  "typescript": {
+    "definition": "dist/index.d.ts"
+  },
+  "exports": {
+    ".": {
+      "require": "./dist/index.js",
+      "import": "./dist/index.mjs"
+    },
+    "./*": {
+      "require": "./dist/*.js",
+      "import": "./dist/*.mjs"
+    }
+  },
+  "license": "MIT",
+  "peerDependencies": {
+    "graphql": "*"
+  },
+  "dependencies": {
+    "@graphql-mesh/types": "0.53.0",
+    "@graphql-tools/utils": "8.5.0"
+  },
+  "publishConfig": {
+    "access": "public",
+    "directory": "dist"
+  },
+  "devDependencies": {
+    "@graphql-mesh/cache-inmemory-lru": "^0.5.25",
+    "@graphql-tools/schema": "8.3.0",
+    "graphql-subscriptions": "1.2.1"
+  }
+}

--- a/packages/transforms/transfer-field/src/bareTransferField.ts
+++ b/packages/transforms/transfer-field/src/bareTransferField.ts
@@ -13,15 +13,23 @@ export default class TransferFieldTransform implements MeshTransform {
   }
 
   transformSchema(schema: GraphQLSchema) {
-    const { defaults = {} } = this.config;
+    const {
+      defaults: {
+        useRegExp: useRegExpDefault = false,
+        regExpFlags: regExpFlagsDefault = undefined,
+        action: actionDefault = 'move',
+      } = {},
+      fields: fieldConfigs,
+    } = this.config;
+
     let transformedSchema: GraphQLSchema = schema;
-    for (const fieldConfig of this.config.fields) {
+    for (const fieldConfig of fieldConfigs) {
       const {
         from: { type: fromTypeName, field: fromFieldName },
         to: { type: toTypeName, field: toFieldName },
-        useRegExp = defaults.useRegExp || false,
-        regExpFlags = defaults.regExpFlags || undefined,
-        action = defaults.action || 'move',
+        useRegExp = useRegExpDefault,
+        regExpFlags = regExpFlagsDefault,
+        action = actionDefault,
       } = fieldConfig;
 
       const [schemaWithoutFields, sourceFieldConfigMap] = removeObjectFields(

--- a/packages/transforms/transfer-field/src/bareTransferField.ts
+++ b/packages/transforms/transfer-field/src/bareTransferField.ts
@@ -1,18 +1,19 @@
 import { MeshTransform, MeshTransformOptions, YamlConfig } from '@graphql-mesh/types';
 import { appendObjectFields, pruneSchema, removeObjectFields } from '@graphql-tools/utils';
-import { GraphQLSchema } from 'graphql';
+import { GraphQLFieldConfigMap, GraphQLSchema } from 'graphql';
+
+type FieldConfig = YamlConfig.TransferFieldTransformFieldConfigObject & {
+  removeObjectFieldsTestFn: (fieldName: string) => boolean;
+};
 
 export default class TransferFieldTransform implements MeshTransform {
   noWrap = true;
 
-  private config: YamlConfig.TransferFieldTransformConfig;
+  private transfers: FieldConfig[] = [];
 
   constructor(options: MeshTransformOptions<YamlConfig.TransferFieldTransformConfig>) {
     const { config } = options;
-    this.config = config;
-  }
 
-  transformSchema(schema: GraphQLSchema) {
     const {
       defaults: {
         useRegExp: useRegExpDefault = false,
@@ -20,43 +21,68 @@ export default class TransferFieldTransform implements MeshTransform {
         action: actionDefault = 'move',
       } = {},
       fields: fieldConfigs,
-    } = this.config;
+    } = config;
 
-    let transformedSchema: GraphQLSchema = schema;
     for (const fieldConfig of fieldConfigs) {
       const {
-        from: { type: fromTypeName, field: fromFieldName },
-        to: { type: toTypeName, field: toFieldName },
+        from,
+        to,
         useRegExp = useRegExpDefault,
         regExpFlags = regExpFlagsDefault,
         action = actionDefault,
       } = fieldConfig;
 
+      const fieldConfigWithDefaults: FieldConfig = {
+        from,
+        to,
+        useRegExp,
+        regExpFlags,
+        action,
+        removeObjectFieldsTestFn: useRegExp
+          ? fieldName => new RegExp(from.field, regExpFlags).test(fieldName)
+          : fieldName => fieldName === from.field,
+      };
+
+      this.transfers.push(fieldConfigWithDefaults);
+    }
+  }
+
+  transformSchema(schema: GraphQLSchema) {
+    let transformedSchema = schema;
+
+    for (const fieldConfig of this.transfers) {
+      const {
+        from: { type: fromTypeName, field: fromFieldName },
+        to: { type: toTypeName, field: toFieldName },
+        useRegExp,
+        regExpFlags,
+        action,
+        removeObjectFieldsTestFn,
+      } = fieldConfig;
+
       const [schemaWithoutFields, sourceFieldConfigMap] = removeObjectFields(
         transformedSchema,
         fromTypeName,
-        fieldName => {
-          return useRegExp ? new RegExp(fromFieldName, regExpFlags).test(fieldName) : fieldName === fromFieldName;
-        }
+        removeObjectFieldsTestFn
       );
 
       if (action === 'move') {
         transformedSchema = schemaWithoutFields;
       }
 
-      const sourceFieldName: string = (Object.keys(sourceFieldConfigMap) as string[]).find((fieldName: string) =>
-        useRegExp ? new RegExp(fromFieldName, regExpFlags).test(fieldName) : fieldName === fromFieldName
-      );
+      const sourceFieldNames = Object.keys(sourceFieldConfigMap) as string[];
 
-      const targetFieldName = useRegExp
-        ? sourceFieldName.replace(new RegExp(fromFieldName, regExpFlags), toFieldName)
-        : toFieldName;
+      const appendFieldConfigMap: GraphQLFieldConfigMap<any, any> = {};
+      for (const sourceFieldName of sourceFieldNames) {
+        const targetFieldName = useRegExp
+          ? sourceFieldName.replace(new RegExp(fromFieldName, regExpFlags), toFieldName)
+          : toFieldName;
 
-      const sourceField = sourceFieldConfigMap[sourceFieldName];
+        const sourceField = sourceFieldConfigMap[sourceFieldName];
+        appendFieldConfigMap[targetFieldName] = sourceField;
+      }
 
-      transformedSchema = appendObjectFields(transformedSchema, toTypeName, {
-        [targetFieldName]: sourceField,
-      });
+      transformedSchema = appendObjectFields(transformedSchema, toTypeName, appendFieldConfigMap);
     }
 
     return pruneSchema(transformedSchema);

--- a/packages/transforms/transfer-field/src/bareTransferField.ts
+++ b/packages/transforms/transfer-field/src/bareTransferField.ts
@@ -1,0 +1,56 @@
+import { MeshTransform, MeshTransformOptions, YamlConfig } from '@graphql-mesh/types';
+import { appendObjectFields, pruneSchema, removeObjectFields } from '@graphql-tools/utils';
+import { GraphQLSchema } from 'graphql';
+
+export default class TransferFieldTransform implements MeshTransform {
+  noWrap = true;
+
+  private config: YamlConfig.TransferFieldTransformConfig;
+
+  constructor(options: MeshTransformOptions<YamlConfig.TransferFieldTransformConfig>) {
+    const { config } = options;
+    this.config = config;
+  }
+
+  transformSchema(schema: GraphQLSchema) {
+    const { defaults = {} } = this.config;
+    let transformedSchema: GraphQLSchema = schema;
+    for (const fieldConfig of this.config.fields) {
+      const {
+        from: { type: fromTypeName, field: fromFieldName },
+        to: { type: toTypeName, field: toFieldName },
+        useRegExp = defaults.useRegExp || false,
+        regExpFlags = defaults.regExpFlags || undefined,
+        action = defaults.action || 'move',
+      } = fieldConfig;
+
+      const [schemaWithoutFields, sourceFieldConfigMap] = removeObjectFields(
+        transformedSchema,
+        fromTypeName,
+        fieldName => {
+          return useRegExp ? new RegExp(fromFieldName, regExpFlags).test(fieldName) : fieldName === fromFieldName;
+        }
+      );
+
+      if (action === 'move') {
+        transformedSchema = schemaWithoutFields;
+      }
+
+      const sourceFieldName: string = (Object.keys(sourceFieldConfigMap) as string[]).find((fieldName: string) =>
+        useRegExp ? new RegExp(fromFieldName, regExpFlags).test(fieldName) : fieldName === fromFieldName
+      );
+
+      const targetFieldName = useRegExp
+        ? sourceFieldName.replace(new RegExp(fromFieldName, regExpFlags), toFieldName)
+        : toFieldName;
+
+      const sourceField = sourceFieldConfigMap[sourceFieldName];
+
+      transformedSchema = appendObjectFields(transformedSchema, toTypeName, {
+        [targetFieldName]: sourceField,
+      });
+    }
+
+    return pruneSchema(transformedSchema);
+  }
+}

--- a/packages/transforms/transfer-field/src/index.ts
+++ b/packages/transforms/transfer-field/src/index.ts
@@ -1,0 +1,9 @@
+import { MeshTransform, MeshTransformOptions, YamlConfig } from '@graphql-mesh/types';
+import BareTransferField from './bareTransferField';
+import WrapTransferField from './wrapTransferField';
+
+export default function HoistFieldTransform(
+  options: MeshTransformOptions<YamlConfig.TransferFieldTransformConfig>
+): MeshTransform {
+  return options.config.mode === 'bare' ? new BareTransferField(options) : new WrapTransferField(options);
+}

--- a/packages/transforms/transfer-field/src/wrapTransferField.ts
+++ b/packages/transforms/transfer-field/src/wrapTransferField.ts
@@ -1,5 +1,4 @@
 import { MeshTransform, MeshTransformOptions, YamlConfig } from '@graphql-mesh/types';
-import { renameFieldNode, wrapFieldNode, unwrapValue } from '@graphql-tools/wrap/transforms/HoistField';
 
 export default class WrapTransferField implements MeshTransform {
   noWrap = false;

--- a/packages/transforms/transfer-field/src/wrapTransferField.ts
+++ b/packages/transforms/transfer-field/src/wrapTransferField.ts
@@ -1,0 +1,10 @@
+import { MeshTransform, MeshTransformOptions, YamlConfig } from '@graphql-mesh/types';
+import { renameFieldNode, wrapFieldNode, unwrapValue } from '@graphql-tools/wrap/transforms/HoistField';
+
+export default class WrapTransferField implements MeshTransform {
+  noWrap = false;
+
+  constructor(options: MeshTransformOptions<YamlConfig.TransferFieldTransformConfig>) {
+    throw new Error('Not implemented');
+  }
+}

--- a/packages/transforms/transfer-field/test/__snapshots__/bareTransferField.spec.ts.snap
+++ b/packages/transforms/transfer-field/test/__snapshots__/bareTransferField.spec.ts.snap
@@ -1,0 +1,69 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`transform-field should copy field to different type - regex 1`] = `
+"type Query {
+  dummy: String
+
+  \\"\\"\\"Retrieve a list of Books\\"\\"\\"
+  books(maxResults: Int, orderBy: String): [Book]
+}
+
+type Mutation {
+  \\"\\"\\"Retrieve a list of Books\\"\\"\\"
+  books(maxResults: Int, orderBy: String): [Book]
+}
+
+type Book {
+  title: String!
+  author: Author!
+  code: String
+}
+
+type Author {
+  name: String!
+  age: Int!
+}
+"
+`;
+
+exports[`transform-field should move field to different type - no regex 1`] = `
+"type Query {
+  dummy: String
+
+  \\"\\"\\"Retrieve a list of Books\\"\\"\\"
+  books(maxResults: Int, orderBy: String): [Book]
+}
+
+type Book {
+  title: String!
+  author: Author!
+  code: String
+}
+
+type Author {
+  name: String!
+  age: Int!
+}
+"
+`;
+
+exports[`transform-field should move field to different type - regex 1`] = `
+"type Query {
+  dummy: String
+
+  \\"\\"\\"Retrieve a list of Books\\"\\"\\"
+  books(maxResults: Int, orderBy: String): [Book]
+}
+
+type Book {
+  title: String!
+  author: Author!
+  code: String
+}
+
+type Author {
+  name: String!
+  age: Int!
+}
+"
+`;

--- a/packages/transforms/transfer-field/test/bareTransferField.spec.ts
+++ b/packages/transforms/transfer-field/test/bareTransferField.spec.ts
@@ -1,0 +1,154 @@
+import { join } from 'path';
+import { execute, parse, printSchema, GraphQLObjectType } from 'graphql';
+import InMemoryLRUCache from '@graphql-mesh/cache-inmemory-lru';
+import { MeshPubSub } from '@graphql-mesh/types';
+import { makeExecutableSchema } from '@graphql-tools/schema';
+import { PubSub } from 'graphql-subscriptions';
+
+import TransferFieldTransform from '../src/bareTransferField';
+
+describe('transform-field', () => {
+  const mockQueryBooks = jest.fn().mockImplementation(() => ({ books: [{ title: 'abc' }, { title: 'def' }] }));
+  const mockBooksApiResponseBooks = jest.fn().mockImplementation(() => [{ title: 'ghi' }, { title: 'lmn' }]);
+
+  const schemaDefs = /* GraphQL */ `
+    type Query {
+      dummy: String
+    }
+
+    type Mutation {
+      """
+      Retrieve a list of Books
+      """
+      books(maxResults: Int, orderBy: String): [Book]
+    }
+
+    type Book {
+      title: String!
+      author: Author!
+      code: String
+    }
+
+    type Author {
+      name: String!
+      age: Int!
+    }
+  `;
+  let cache: InMemoryLRUCache;
+  let pubsub: MeshPubSub;
+  const baseDir: string = undefined;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    cache = new InMemoryLRUCache();
+    pubsub = new PubSub();
+  });
+
+  it('should move field to different type - no regex', async () => {
+    const transform = new TransferFieldTransform({
+      config: {
+        mode: 'bare',
+        fields: [
+          {
+            from: {
+              type: 'Mutation',
+              field: 'books',
+            },
+            to: {
+              type: 'Query',
+              field: 'books',
+            },
+          },
+        ],
+      },
+      cache,
+      pubsub,
+      baseDir,
+      apiName: '',
+      syncImportFn: require,
+    });
+    const schema = makeExecutableSchema({
+      typeDefs: schemaDefs,
+    });
+    const transformedSchema = transform.transformSchema(schema);
+
+    expect(transformedSchema.getType('Mutation')).toBeUndefined();
+    expect((transformedSchema.getType('Query') as GraphQLObjectType).getFields().books.type.toString()).toBe('[Book]');
+    expect(printSchema(transformedSchema)).toMatchSnapshot();
+  });
+
+  it('should move field to different type - regex', async () => {
+    const transform = new TransferFieldTransform({
+      config: {
+        mode: 'bare',
+        fields: [
+          {
+            from: {
+              type: 'Mutation',
+              field: '(.*)',
+            },
+            to: {
+              type: 'Query',
+              field: '$1',
+            },
+            useRegExp: true,
+          },
+        ],
+      },
+      cache,
+      pubsub,
+      baseDir,
+      apiName: '',
+      syncImportFn: require,
+    });
+    const schema = makeExecutableSchema({
+      typeDefs: schemaDefs,
+    });
+    const transformedSchema = transform.transformSchema(schema);
+
+    expect(transformedSchema.getType('Mutation')).toBeUndefined();
+    expect((transformedSchema.getType('Query') as GraphQLObjectType).getFields().books.type.toString()).toBe('[Book]');
+    expect(printSchema(transformedSchema)).toMatchSnapshot();
+  });
+
+  it('should copy field to different type - regex', async () => {
+    const transform = new TransferFieldTransform({
+      config: {
+        mode: 'bare',
+        fields: [
+          {
+            from: {
+              type: 'Mutation',
+              field: '(.*)',
+            },
+            to: {
+              type: 'Query',
+              field: '$1',
+            },
+            useRegExp: true,
+            action: 'copy',
+          },
+        ],
+      },
+      cache,
+      pubsub,
+      baseDir,
+      apiName: '',
+      syncImportFn: require,
+    });
+    const schema = makeExecutableSchema({
+      typeDefs: schemaDefs,
+    });
+    const transformedSchema = transform.transformSchema(schema);
+
+    expect(transformedSchema.getType('Mutation')).toBeDefined();
+    expect((transformedSchema.getType('Mutation') as GraphQLObjectType).getFields().books.type.toString()).toBe(
+      '[Book]'
+    );
+    expect((transformedSchema.getType('Query') as GraphQLObjectType).getFields().books.type.toString()).toBe('[Book]');
+    expect(printSchema(transformedSchema)).toMatchSnapshot();
+  });
+});

--- a/packages/transforms/transfer-field/yaml-config.graphql
+++ b/packages/transforms/transfer-field/yaml-config.graphql
@@ -1,0 +1,58 @@
+extend type Transform {
+  """
+  Transformer to replace GraphQL field with partial of full config from a different field
+  """
+  transferField: TransferFieldTransformConfig
+}
+
+type TransferFieldTransformConfig @md {
+  """
+  Specify to apply filter-schema transforms to bare schema or by wrapping original schema
+  """
+  mode: FilterSchemaTransformMode
+  """
+  Array of hoist field configs
+  """
+  fields: [TransferFieldTransformFieldConfigObject!]!
+
+  defaults: TransferFieldTransformConfigDefaults
+}
+
+type TransferFieldTransformConfigDefaults {
+  action: TransferFieldTransformFieldConfigAction
+  """
+  Use Regular Expression for field names
+  """
+  useRegExp: Boolean
+  """
+  Flags to use in the Regular Expression
+  """
+  regExpFlags: String
+}
+
+type TransferFieldTransformFieldConfigObject @md {
+  from: TransferConfig!
+  to: TransferConfig!
+  """
+  Action to perform default is move unless otherwise specified in defaults
+  """
+  action: TransferFieldTransformFieldConfigAction
+  """
+  Use Regular Expression for field names
+  """
+  useRegExp: Boolean
+  """
+  Flags to use in the Regular Expression
+  """
+  regExpFlags: String
+}
+
+type TransferConfig {
+  type: String!
+  field: String!
+}
+
+enum TransferFieldTransformFieldConfigAction {
+  copy
+  move
+}

--- a/packages/types/src/config-schema.json
+++ b/packages/types/src/config-schema.json
@@ -438,10 +438,6 @@
             }
           ]
         },
-        "replaceField": {
-          "$ref": "#/definitions/ReplaceFieldTransformConfig",
-          "description": "Transformer to replace GraphQL field with partial of full config from a different field"
-        },
         "resolversComposition": {
           "description": "Transformer to apply composition to resolvers (Any of: ResolversCompositionTransform, Any)",
           "anyOf": [
@@ -472,6 +468,14 @@
         "typeMerging": {
           "$ref": "#/definitions/TypeMergingConfig",
           "description": "[Type Merging](https://www.graphql-tools.com/docs/stitch-type-merging) Configuration"
+        },
+        "replaceField": {
+          "$ref": "#/definitions/ReplaceFieldTransformConfig",
+          "description": "Transformer to replace GraphQL field with partial of full config from a different field"
+        },
+        "transferField": {
+          "$ref": "#/definitions/TransferFieldTransformConfig",
+          "description": "Transformer to replace GraphQL field with partial of full config from a different field"
         }
       }
     },
@@ -2500,89 +2504,6 @@
         }
       }
     },
-    "ReplaceFieldTransformConfig": {
-      "additionalProperties": false,
-      "type": "object",
-      "title": "ReplaceFieldTransformConfig",
-      "properties": {
-        "typeDefs": {
-          "anyOf": [
-            {
-              "type": "object",
-              "additionalProperties": true
-            },
-            {
-              "type": "string"
-            },
-            {
-              "type": "array",
-              "additionalItems": true
-            }
-          ],
-          "description": "Additional type definition to used to replace field types"
-        },
-        "replacements": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/ReplaceFieldTransformObject"
-          },
-          "additionalItems": false,
-          "description": "Array of rules to replace fields"
-        }
-      },
-      "required": ["replacements"]
-    },
-    "ReplaceFieldTransformObject": {
-      "additionalProperties": false,
-      "type": "object",
-      "title": "ReplaceFieldTransformObject",
-      "properties": {
-        "from": {
-          "$ref": "#/definitions/ReplaceFieldConfig"
-        },
-        "to": {
-          "$ref": "#/definitions/ReplaceFieldConfig"
-        },
-        "scope": {
-          "type": "string",
-          "enum": ["config", "hoistValue"],
-          "description": "Allowed values: config, hoistValue"
-        },
-        "composer": {
-          "anyOf": [
-            {
-              "type": "object",
-              "additionalProperties": true
-            },
-            {
-              "type": "string"
-            },
-            {
-              "type": "array",
-              "additionalItems": true
-            }
-          ]
-        },
-        "name": {
-          "type": "string"
-        }
-      },
-      "required": ["from", "to"]
-    },
-    "ReplaceFieldConfig": {
-      "additionalProperties": false,
-      "type": "object",
-      "title": "ReplaceFieldConfig",
-      "properties": {
-        "type": {
-          "type": "string"
-        },
-        "field": {
-          "type": "string"
-        }
-      },
-      "required": ["type", "field"]
-    },
     "ResolversCompositionTransform": {
       "additionalProperties": false,
       "type": "object",
@@ -2817,6 +2738,174 @@
           "description": "Path to the SQL Dump file if you want to build a in-memory database"
         }
       }
+    },
+    "ReplaceFieldTransformConfig": {
+      "additionalProperties": false,
+      "type": "object",
+      "title": "ReplaceFieldTransformConfig",
+      "properties": {
+        "typeDefs": {
+          "anyOf": [
+            {
+              "type": "object",
+              "additionalProperties": true
+            },
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "additionalItems": true
+            }
+          ],
+          "description": "Additional type definition to used to replace field types"
+        },
+        "replacements": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ReplaceFieldTransformObject"
+          },
+          "additionalItems": false,
+          "description": "Array of rules to replace fields"
+        }
+      },
+      "required": ["replacements"]
+    },
+    "ReplaceFieldTransformObject": {
+      "additionalProperties": false,
+      "type": "object",
+      "title": "ReplaceFieldTransformObject",
+      "properties": {
+        "from": {
+          "$ref": "#/definitions/ReplaceFieldConfig"
+        },
+        "to": {
+          "$ref": "#/definitions/ReplaceFieldConfig"
+        },
+        "scope": {
+          "type": "string",
+          "enum": ["config", "hoistValue"],
+          "description": "Allowed values: config, hoistValue"
+        },
+        "composer": {
+          "anyOf": [
+            {
+              "type": "object",
+              "additionalProperties": true
+            },
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "additionalItems": true
+            }
+          ]
+        },
+        "name": {
+          "type": "string"
+        }
+      },
+      "required": ["from", "to"]
+    },
+    "ReplaceFieldConfig": {
+      "additionalProperties": false,
+      "type": "object",
+      "title": "ReplaceFieldConfig",
+      "properties": {
+        "type": {
+          "type": "string"
+        },
+        "field": {
+          "type": "string"
+        }
+      },
+      "required": ["type", "field"]
+    },
+    "TransferFieldTransformConfig": {
+      "additionalProperties": false,
+      "type": "object",
+      "title": "TransferFieldTransformConfig",
+      "properties": {
+        "mode": {
+          "type": "string",
+          "enum": ["bare", "wrap"],
+          "description": "Specify to apply filter-schema transforms to bare schema or by wrapping original schema (Allowed values: bare, wrap)"
+        },
+        "fields": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/TransferFieldTransformFieldConfigObject"
+          },
+          "additionalItems": false,
+          "description": "Array of hoist field configs"
+        },
+        "defaults": {
+          "$ref": "#/definitions/TransferFieldTransformConfigDefaults"
+        }
+      },
+      "required": ["fields"]
+    },
+    "TransferFieldTransformConfigDefaults": {
+      "additionalProperties": false,
+      "type": "object",
+      "title": "TransferFieldTransformConfigDefaults",
+      "properties": {
+        "action": {
+          "type": "string",
+          "enum": ["copy", "move"],
+          "description": "Allowed values: copy, move"
+        },
+        "useRegExp": {
+          "type": "boolean",
+          "description": "Use Regular Expression for field names"
+        },
+        "regExpFlags": {
+          "type": "string",
+          "description": "Flags to use in the Regular Expression"
+        }
+      }
+    },
+    "TransferFieldTransformFieldConfigObject": {
+      "additionalProperties": false,
+      "type": "object",
+      "title": "TransferFieldTransformFieldConfigObject",
+      "properties": {
+        "from": {
+          "$ref": "#/definitions/TransferConfig"
+        },
+        "to": {
+          "$ref": "#/definitions/TransferConfig"
+        },
+        "action": {
+          "type": "string",
+          "enum": ["copy", "move"],
+          "description": "Action to perform default is move unless otherwise specified in defaults (Allowed values: copy, move)"
+        },
+        "useRegExp": {
+          "type": "boolean",
+          "description": "Use Regular Expression for field names"
+        },
+        "regExpFlags": {
+          "type": "string",
+          "description": "Flags to use in the Regular Expression"
+        }
+      },
+      "required": ["from", "to"]
+    },
+    "TransferConfig": {
+      "additionalProperties": false,
+      "type": "object",
+      "title": "TransferConfig",
+      "properties": {
+        "type": {
+          "type": "string"
+        },
+        "field": {
+          "type": "string"
+        }
+      },
+      "required": ["type", "field"]
     }
   },
   "title": "Config",

--- a/packages/types/src/config.ts
+++ b/packages/types/src/config.ts
@@ -944,13 +944,14 @@ export interface Transform {
    * Transformer to rename GraphQL types and fields (Any of: RenameTransform, Any)
    */
   rename?: RenameTransform | any;
-  replaceField?: ReplaceFieldTransformConfig;
   /**
    * Transformer to apply composition to resolvers (Any of: ResolversCompositionTransform, Any)
    */
   resolversComposition?: ResolversCompositionTransform | any;
   snapshot?: SnapshotTransformConfig;
   typeMerging?: TypeMergingConfig;
+  replaceField?: ReplaceFieldTransformConfig;
+  transferField?: TransferFieldTransformConfig;
   [k: string]: any;
 }
 export interface CacheTransformConfig {
@@ -1252,37 +1253,6 @@ export interface RenameConfig1 {
   type?: string;
   field?: string;
 }
-/**
- * Transformer to replace GraphQL field with partial of full config from a different field
- */
-export interface ReplaceFieldTransformConfig {
-  /**
-   * Additional type definition to used to replace field types
-   */
-  typeDefs?: any;
-  /**
-   * Array of rules to replace fields
-   */
-  replacements: ReplaceFieldTransformObject[];
-}
-export interface ReplaceFieldTransformObject {
-  from: ReplaceFieldConfig;
-  to: ReplaceFieldConfig1;
-  /**
-   * Allowed values: config, hoistValue
-   */
-  scope?: 'config' | 'hoistValue';
-  composer?: any;
-  name?: string;
-}
-export interface ReplaceFieldConfig {
-  type: string;
-  field: string;
-}
-export interface ReplaceFieldConfig1 {
-  type: string;
-  field: string;
-}
 export interface ResolversCompositionTransform {
   /**
    * Specify to apply resolvers-composition transforms to bare schema or by wrapping original schema (Allowed values: bare, wrap)
@@ -1411,6 +1381,89 @@ export interface MergedRootFieldConfig {
    *   - selections from the key can be referenced by using the $ sign and dot notation: `"upcs: [[$key.upc]]"`, so that `$key.upc` refers to the `upc` field of the key.
    */
   argsExpr?: string;
+}
+/**
+ * Transformer to replace GraphQL field with partial of full config from a different field
+ */
+export interface ReplaceFieldTransformConfig {
+  /**
+   * Additional type definition to used to replace field types
+   */
+  typeDefs?: any;
+  /**
+   * Array of rules to replace fields
+   */
+  replacements: ReplaceFieldTransformObject[];
+}
+export interface ReplaceFieldTransformObject {
+  from: ReplaceFieldConfig;
+  to: ReplaceFieldConfig1;
+  /**
+   * Allowed values: config, hoistValue
+   */
+  scope?: 'config' | 'hoistValue';
+  composer?: any;
+  name?: string;
+}
+export interface ReplaceFieldConfig {
+  type: string;
+  field: string;
+}
+export interface ReplaceFieldConfig1 {
+  type: string;
+  field: string;
+}
+/**
+ * Transformer to replace GraphQL field with partial of full config from a different field
+ */
+export interface TransferFieldTransformConfig {
+  /**
+   * Specify to apply filter-schema transforms to bare schema or by wrapping original schema (Allowed values: bare, wrap)
+   */
+  mode?: 'bare' | 'wrap';
+  /**
+   * Array of hoist field configs
+   */
+  fields: TransferFieldTransformFieldConfigObject[];
+  defaults?: TransferFieldTransformConfigDefaults;
+}
+export interface TransferFieldTransformFieldConfigObject {
+  from: TransferConfig;
+  to: TransferConfig1;
+  /**
+   * Action to perform default is move unless otherwise specified in defaults (Allowed values: copy, move)
+   */
+  action?: 'copy' | 'move';
+  /**
+   * Use Regular Expression for field names
+   */
+  useRegExp?: boolean;
+  /**
+   * Flags to use in the Regular Expression
+   */
+  regExpFlags?: string;
+}
+export interface TransferConfig {
+  type: string;
+  field: string;
+}
+export interface TransferConfig1 {
+  type: string;
+  field: string;
+}
+export interface TransferFieldTransformConfigDefaults {
+  /**
+   * Allowed values: copy, move
+   */
+  action?: 'copy' | 'move';
+  /**
+   * Use Regular Expression for field names
+   */
+  useRegExp?: boolean;
+  /**
+   * Flags to use in the Regular Expression
+   */
+  regExpFlags?: string;
 }
 export interface AdditionalStitchingResolverObject {
   sourceName: string;


### PR DESCRIPTION
## Description

This is an initial version of a transfer field transform. 

Thigs left todo:
- bare mode
   - disucss if  we should batch (by type + action) calls to `removeObjectFields` + `appendObjectFields`
     - I already have an implementation for this in my local version
     - However this would introduce hidden reordering of compared to in which order the steps are defined in the config
     - And while I cant think of a used case where the order of executions should matter,
     - I would hate to limit the use of this transform given the limited benefit in performance
   - ~~move as much init logic into ctor as possible~~
   - write more comprehensive unit tests
- wrap mode
   - not implemented yet 
   - that said @santino given how bare works currently `removeObjectFields` + `appendObjectFields`
      - wouldn't this also work for wrap mode? 
      - meaning bare / wrap would have the same implementation in this rare instance?
      - or are those methods already using wrapping of some kind and they shouldn't have been used in bare more?
        - I used the hoist transform as inspiration but given these methods are not in the wrap, but utils package I assumed they are not using wrapping 
- documentation
   - add section on website for transform  
- add changeset

Open questions:
- Should the transform be able to handle adding an output type if it doesn't exist yet
   - For example we have seen many REST APIs that only provide POST 
   - This means that the source will not generate a Query type
   - When trying to move fields from Mutation to Query the transform would then fail

Addresses parts of  #2975

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## How Has This Been Tested?
I have started adding unit tests, but def. will add more before the PR will be merged.

## Checklist:

- [ ] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests and linter rules pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

@santino Please let me know what you think about the general approach. 
