### PR TITLE
expose provideErrorExtensions config for openapi

### DIFF
--- a/.changeset/gold-points-drive.md
+++ b/.changeset/gold-points-drive.md
@@ -1,0 +1,5 @@
+---
+'@graphql-mesh/openapi': patch
+---
+
+Expose provideErrorExtensions configuration for openapi

--- a/packages/handlers/openapi/src/index.ts
+++ b/packages/handlers/openapi/src/index.ts
@@ -150,6 +150,7 @@ export default class OpenAPIHandler implements MeshHandler {
       operationIdFieldNames: true,
       fillEmptyResponses: true,
       includeHttpDetails: this.config.includeHttpDetails,
+      provideErrorExtensions: this.config.provideErrorExtensions,
       genericPayloadArgName: genericPayloadArgName === undefined ? false : genericPayloadArgName,
       selectQueryOrMutationField:
         selectQueryOrMutationField === undefined

--- a/packages/handlers/openapi/yaml-config.graphql
+++ b/packages/handlers/openapi/yaml-config.graphql
@@ -51,6 +51,10 @@ type OpenapiHandler @md {
   Allows to explicitly override the default operation (Query or Mutation) for any OAS operation
   """
   selectQueryOrMutationField: [SelectQueryOrMutationFieldConfig]
+  """
+  Overwrite automatic wrapping of errors into GraphqlErrors
+  """
+  provideErrorExtensions: Boolean
 }
 
 enum SourceFormat {

--- a/packages/types/src/config.ts
+++ b/packages/types/src/config.ts
@@ -741,6 +741,10 @@ export interface OpenapiHandler {
    * Allows to explicitly override the default operation (Query or Mutation) for any OAS operation
    */
   selectQueryOrMutationField?: SelectQueryOrMutationFieldConfig[];
+  /**
+   * Overwrite automatic wrapping of errors into GraphqlErrors
+   */
+   provideErrorExtensions?: boolean;
 }
 export interface SelectQueryOrMutationFieldConfig {
   /**


### PR DESCRIPTION
## Description

Expose provideErrorExtensions to openapi config to align with the options given to the function `createGraphQLSchema` in /packages/handlers/openapi/src/openapi-to-graphql/index.ts

## Fixes
Allow disabling of automatic wrapping of errors into graphqlError objects