### PR TITLE
Generate and refer to source schema type declarations

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -42,6 +42,7 @@
     "@graphql-codegen/typescript-jit-sdk": "2.0.0",
     "@graphql-codegen/typescript-operations": "2.2.2",
     "@graphql-mesh/config": "0.27.4",
+    "@graphql-mesh/transform-rename": "0.11.8",
     "@graphql-codegen/typescript-resolvers": "2.4.3",
     "@graphql-mesh/runtime": "0.28.0",
     "@graphql-mesh/utils": "0.26.0",

--- a/packages/cli/src/commands/ts-artifacts.ts
+++ b/packages/cli/src/commands/ts-artifacts.ts
@@ -207,11 +207,13 @@ export async function generateTsArtifacts({
           const contextItems: string[] = [];
           const results = await Promise.all(
             rawSources.map(source => {
+              const sourceMap = unifiedSchema.extensions.sourceMap as Map<RawSourceOutput, GraphQLSchema>;
+              const sourceSchema = sourceMap.get(source);
               const { normalizedSourceName } = sourceTypeDeclarations.find(
                 ({ sourceName }) => sourceName === source.name
               )!;
               const item = generateTypesForApi({
-                schema: source.schema,
+                schema: sourceSchema,
                 name: normalizedSourceName,
               });
 

--- a/packages/cli/src/commands/ts-artifacts.ts
+++ b/packages/cli/src/commands/ts-artifacts.ts
@@ -140,7 +140,9 @@ export async function generateTsArtifacts({
     const codegenOutput = await codegen({
       filename: 'types.ts',
       documents: [],
-      config: {},
+      config: {
+        enumsAsTypes: true,
+      },
       schema: undefined as any,
       schemaAst: source.schema,
       pluginMap: {

--- a/packages/cli/src/commands/ts-artifacts.ts
+++ b/packages/cli/src/commands/ts-artifacts.ts
@@ -198,13 +198,18 @@ export async function generateTsArtifacts({
             if (importPath.startsWith('.')) {
               importPath = join(baseDir, importPath);
             }
+
             if (isAbsolute(importPath)) {
               moduleMapProp = relative(baseDir, importedModuleName).split('\\').join('/');
               importPath = `./${relative(artifactsDir, importedModuleName).split('\\').join('/')}`;
             }
+
             const importedModuleVariable = pascalCase(`ExternalModule$${i}`);
-            importCodes.push(`import ${importedModuleVariable} from '${importPath}';`);
-            return `  // @ts-ignore\n  [${JSON.stringify(moduleMapProp)}]: ${importedModuleVariable}`;
+            importCodes.push(`import * as ${importedModuleVariable} from '${importPath}';`);
+
+            return `  // @ts-ignore\n  [${JSON.stringify(
+              moduleMapProp
+            )}]: ${importedModuleVariable}['default'] || ${importedModuleVariable}`;
           });
 
           const meshMethods = `

--- a/packages/cli/src/commands/ts-artifacts.ts
+++ b/packages/cli/src/commands/ts-artifacts.ts
@@ -207,13 +207,11 @@ export async function generateTsArtifacts({
           const contextItems: string[] = [];
           const results = await Promise.all(
             rawSources.map(source => {
-              const sourceMap = unifiedSchema.extensions.sourceMap as Map<RawSourceOutput, GraphQLSchema>;
-              const sourceSchema = sourceMap.get(source);
               const { normalizedSourceName } = sourceTypeDeclarations.find(
                 ({ sourceName }) => sourceName === source.name
               )!;
               const item = generateTypesForApi({
-                schema: sourceSchema,
+                schema: source.schema,
                 name: normalizedSourceName,
               });
 

--- a/packages/config/src/process.ts
+++ b/packages/config/src/process.ts
@@ -172,7 +172,7 @@ export async function processConfig(
               const transformImportName = pascalCase(transformName + '_Transform');
               importCodes.push(`import ${transformImportName} from '${moduleName}';`);
               codes.push(`${transformsVariableName}.push(
-                new ${transformImportName}({
+                new (${transformImportName}["default"] || ${transformImportName})({
                   apiName: rawConfig.sources[${sourceIndex}].name,
                   config: rawConfig.sources[${sourceIndex}].transforms[${transformIndex}][${JSON.stringify(
                 transformName

--- a/packages/transforms/rename/src/index.ts
+++ b/packages/transforms/rename/src/index.ts
@@ -18,3 +18,5 @@ export default (function RenameTransform(options: MeshTransformOptions<YamlConfi
   }
   return options.config.mode === 'bare' ? new BareRename(options) : new WrapRename(options);
 } as unknown as RenameTransformConstructor);
+
+export { WrapRename };

--- a/packages/transforms/rename/src/wrapRename.ts
+++ b/packages/transforms/rename/src/wrapRename.ts
@@ -10,7 +10,7 @@ type FieldName = string;
 
 export default class WrapRename implements MeshTransform {
   private transforms: Transform[] = [];
-  public reverseFieldNameMapping: Partial<Record<TypeName, Partial<Record<FieldName, FieldName>>>> = {};
+  private reverseFieldNameMapping: Partial<Record<TypeName, Partial<Record<FieldName, FieldName>>>> = {};
 
   constructor(options: MeshTransformOptions<YamlConfig.RenameTransform>) {
     const { config } = options;

--- a/packages/transforms/rename/src/wrapRename.ts
+++ b/packages/transforms/rename/src/wrapRename.ts
@@ -10,7 +10,6 @@ type FieldName = string;
 
 export default class WrapRename implements MeshTransform {
   private transforms: Transform[] = [];
-  public reverseTypeNameMapping: Partial<Record<TypeName, TypeName>> = {};
   public reverseFieldNameMapping: Partial<Record<TypeName, Partial<Record<FieldName, FieldName>>>> = {};
 
   constructor(options: MeshTransformOptions<YamlConfig.RenameTransform>) {
@@ -29,25 +28,9 @@ export default class WrapRename implements MeshTransform {
         let replaceTypeNameFn: (t: string) => string;
         if (useRegExpForTypes) {
           const typeNameRegExp = new RegExp(fromTypeName, regExpFlags);
-          replaceTypeNameFn = (t: string) => {
-            const replaced = t.replace(typeNameRegExp, toTypeName);
-
-            if (t !== replaced) {
-              this.reverseTypeNameMapping[replaced] = t;
-            }
-
-            return replaced;
-          };
+          replaceTypeNameFn = (t: string) => t.replace(typeNameRegExp, toTypeName);
         } else {
-          replaceTypeNameFn = t => {
-            const replaced = t === fromTypeName ? toTypeName : t;
-
-            if (t !== replaced) {
-              this.reverseTypeNameMapping[replaced] = t;
-            }
-
-            return replaced;
-          };
+          replaceTypeNameFn = t => (t === fromTypeName ? toTypeName : t);
         }
         this.transforms.push(new RenameTypes(replaceTypeNameFn));
       }
@@ -103,10 +86,6 @@ export default class WrapRename implements MeshTransform {
 
   transformResult(originalResult: ExecutionResult, delegationContext: DelegationContext, transformationContext: any) {
     return applyResultTransforms(originalResult, delegationContext, transformationContext, this.transforms);
-  }
-
-  getOriginalTypeName(typeName: string): string | undefined {
-    return this.reverseTypeNameMapping[typeName];
   }
 
   getOriginalFieldName(typeName: string, fieldName: string): string | undefined {


### PR DESCRIPTION
## Description

Fixes #3367 

This PR adds an additional step to the build process, before the existing codegen phase occurs. The new step iterates over the source schemas and invokes codegen to produce the minimal step of type definitions for those schemas *untransformed*. These are written into their own files and then imported under an alias into the main codegen output. The alias are used to fully qualify the upstream types. It's easier to demonstrate with an example - it changes this:

```typescript
export type QueryAuthorServiceSdk = {
  author: InContextSdkMethod<Query['author'], QueryauthorArgs, MeshContext>
  // ... other definitions
};
```

to 

```typescript
import * as AuthorService from "./AuthorService";

export type QueryAuthorServiceSdk = {
  author: InContextSdkMethod<AuthorService.Query['author'], AuthorService.QueryAuthorArgs, MeshContext>
  // ... other definitions
};
```

I need to point out that this is a breaking change - the currently released version of mesh is generating sdks based off the upstread schemas *after* applying transformations defined in the `meshrc`. Field renames, filters, etc are all currently visible in the shape of the generated types. This PR changes that choice so codegen emits type definitions against the upstream schema as published. Any users who have code written against those SDKs and have rename transforms (or other shape-altering transforms) applied will get errors from Typescript after regenerating. 

## Type of change

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Screenshots/Sandbox (if appropriate/relevant):

Sandbox links in issue #3367 : https://codesandbox.io/s/condescending-swanson-9n0ux?file=/.mesh/schema.graphql

## How Has This Been Tested?

Tested against a local version of the sandbox.

**Test Environment**:

OS: MacOS 11.6
"@graphql-mesh/cli": "^0.44.4"
"@graphql-mesh/graphql": "^0.20.9"
"@graphql-mesh/transform-filter-schema": "^0.14.5"
NodeJS: 14

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests and linter rules pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
