### PR TITLE
feat(naming-convention): ignore fields needed by Federation spec

### DIFF
--- a/.changeset/real-icons-lie.md
+++ b/.changeset/real-icons-lie.md
@@ -1,0 +1,5 @@
+---
+'@graphql-mesh/transform-naming-convention': minor
+---
+
+feat(naming-convention): ignore fields of Federation spec

--- a/packages/transforms/naming-convention/src/index.ts
+++ b/packages/transforms/naming-convention/src/index.ts
@@ -3,8 +3,6 @@ import { MeshTransform, YamlConfig, MeshTransformOptions } from '@graphql-mesh/t
 import {
   RenameTypes,
   RenameObjectFields,
-  RenameRootFields,
-  RenameRootTypes,
   RenameInputObjectFields,
   TransformEnumValues,
   RenameInterfaceFields,
@@ -49,22 +47,23 @@ const NAMING_CONVENTIONS: Record<NamingConventionType, NamingConventionFn> = {
   lowerCase,
 };
 
+// Ignore fields needed by Federation spec
+const IGNORED_ROOT_FIELD_NAMES = ['_service', '_entities'];
+
 export default class NamingConventionTransform implements MeshTransform {
   private transforms: Transform[] = [];
 
   constructor(options: MeshTransformOptions<YamlConfig.NamingConventionTransformConfig>) {
     if (options.config.typeNames) {
       const namingConventionFn = NAMING_CONVENTIONS[options.config.typeNames];
-      this.transforms.push(
-        new RenameTypes(typeName => namingConventionFn(typeName) || typeName),
-        new RenameRootTypes(typeName => namingConventionFn(typeName) || typeName)
-      );
+      this.transforms.push(new RenameTypes(typeName => namingConventionFn(typeName) || typeName));
     }
     if (options.config.fieldNames) {
       const namingConventionFn = NAMING_CONVENTIONS[options.config.fieldNames];
       this.transforms.push(
-        new RenameObjectFields((_, fieldName) => namingConventionFn(fieldName) || fieldName),
-        new RenameRootFields((_, fieldName) => namingConventionFn(fieldName) || fieldName),
+        new RenameObjectFields((_, fieldName) =>
+          IGNORED_ROOT_FIELD_NAMES.includes(fieldName) ? fieldName : namingConventionFn(fieldName) || fieldName
+        ),
         new RenameInputObjectFields((_, fieldName) => namingConventionFn(fieldName) || fieldName),
         new RenameInterfaceFields((_, fieldName) => namingConventionFn(fieldName) || fieldName)
       );

--- a/packages/transforms/naming-convention/test/naming-convention.spec.ts
+++ b/packages/transforms/naming-convention/test/naming-convention.spec.ts
@@ -176,4 +176,27 @@ describe('namingConvention', () => {
     });
     expect(data?._).toEqual('test');
   });
+  it('should skip fields of Federation spec', async () => {
+    const typeDefs = /* GraphQL */ `
+type Query {
+  _service: String!
+  _entities: [String!]!
+}`.trim();
+    const schema = wrapSchema({
+      schema: buildSchema(typeDefs),
+      transforms: [
+        new NamingConventionTransform({
+          apiName: '',
+          importFn,
+          cache,
+          pubsub,
+          config: {
+            fieldNames: 'snakeCase',
+          },
+          baseDir,
+        }),
+      ],
+    });
+    expect(printSchema(schema)).toBe(typeDefs);
+  });
 });


### PR DESCRIPTION
Related #3430