### PR TITLE
JSNO schema oneOf + SDK error

### DIFF
--- a/examples/json-schema-covid/package.json
+++ b/examples/json-schema-covid/package.json
@@ -9,6 +9,7 @@
   },
   "scripts": {
     "start": "mesh dev",
+    "build": "mesh build",
     "test": "jest"
   },
   "dependencies": {

--- a/examples/json-schema-covid/src/json-schemas/worldPop.json
+++ b/examples/json-schema-covid/src/json-schemas/worldPop.json
@@ -11,18 +11,37 @@
         "description": "Result of API",
         "properties": {
           "fields": {
-            "type": "object",
-            "properties": {
-              "country_name": {
-                "type": "string"
+            "oneOf": [
+              {
+                "type": "object",
+                "required": ["id"],
+                "properties": {
+                  "country_name": {
+                    "type": "string"
+                  },
+                  "value": {
+                    "type": "number"
+                  },
+                  "year": {
+                    "type": "string"
+                  }
+                }
               },
-              "value": {
-                "type": "number"
-              },
-              "year": {
-                "type": "string"
+              {
+                "type": "object",
+                "additionalProperties": false,
+                "description": "Error",
+                "required": ["error"],
+                "properties": {
+                  "errorCode": {
+                    "type": "number"
+                  },
+                  "errorMessage": {
+                    "type": "string"
+                  }
+                }
               }
-            }
+            ]
           }
         }
       }


### PR DESCRIPTION
## Description
Using JSON schema which includes `oneOf`, results in error on `mesh build`.

to reproduce, run `yarn build` on the json-schema-covid example