### PR TITLE
fix(server): fork=1 should spawn 1 child process

### DIFF
--- a/.changeset/cold-dingos-prove.md
+++ b/.changeset/cold-dingos-prove.md
@@ -1,0 +1,5 @@
+---
+"@graphql-mesh/cli": patch
+---
+
+fix(server): fork=1 should spawn 1 child process

--- a/packages/cli/src/commands/serve/serve.ts
+++ b/packages/cli/src/commands/serve/serve.ts
@@ -69,7 +69,7 @@ export async function serveMesh({ baseDir, argsPort, getBuiltMesh, logger, rawCo
 
   const protocol = sslCredentials ? 'https' : 'http';
   const serverUrl = `${protocol}://${hostname}:${port}`;
-  if (!cluster.isWorker && fork) {
+  if (!cluster.isWorker && Boolean(fork)) {
     const forkNum = fork > 0 && typeof fork === 'number' ? fork : cpus().length;
     for (let i = 0; i < forkNum; i++) {
       const worker = cluster.fork();
@@ -269,7 +269,7 @@ export async function serveMesh({ baseDir, argsPort, getBuiltMesh, logger, rawCo
       .listen(parseInt(port.toString()), hostname, () => {
         const shouldntOpenBrowser = env.NODE_ENV?.toLowerCase() === 'production' || browser === false;
         if (!shouldntOpenBrowser) {
-          open(serverUrl, typeof browser === 'string' ? { app: browser } : undefined).catch(() => {});
+          open(serverUrl, typeof browser === 'string' ? { app: browser } : undefined).catch(() => { });
         }
       })
       .on('error', handleFatalError);

--- a/packages/cli/src/commands/serve/serve.ts
+++ b/packages/cli/src/commands/serve/serve.ts
@@ -70,7 +70,7 @@ export async function serveMesh({ baseDir, argsPort, getBuiltMesh, logger, rawCo
   const protocol = sslCredentials ? 'https' : 'http';
   const serverUrl = `${protocol}://${hostname}:${port}`;
   if (!cluster.isWorker && fork) {
-    const forkNum = fork > 1 ? fork : cpus().length;
+    const forkNum = fork > 0 && typeof fork === 'number' ? fork : cpus().length;
     for (let i = 0; i < forkNum; i++) {
       const worker = cluster.fork();
       registerTerminateHandler(eventName => worker.kill(eventName));


### PR DESCRIPTION
## Description

The following configuration is not spawning the expected 1 child process but [CPU numbers] processes:

```yaml
serve:
  fork: 1
```

Fixes #3470

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


## How Has This Been Tested?

I did a test with my `spotify-graphql` Mesh server using `@graphql-mesh/cli@0.48.1-alpha-d3d7d124f.0` with the following configurations:

- `fork: 1` ✅ 
- `fork: 2` ✅ 
- `fork: true` ✅ 
- `fork: false` ✅ 

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests and linter rules pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
