### PR TITLE
fix(transforms/rename): renaming fields should only affect specified `type`

### DIFF
--- a/.changeset/silent-cherries-taste.md
+++ b/.changeset/silent-cherries-taste.md
@@ -1,0 +1,5 @@
+---
+"@graphql-mesh/transform-rename": patch
+---
+
+fix(transforms/rename): renaming fields should only affect specified …

--- a/packages/transforms/rename/src/wrapRename.ts
+++ b/packages/transforms/rename/src/wrapRename.ts
@@ -37,7 +37,7 @@ export default class WrapRename implements MeshTransform {
         if (useRegExpForFields) {
           const fieldNameRegExp = new RegExp(fromFieldName, regExpFlags);
           replaceFieldNameFn = (typeName, fieldName) =>
-            typeName === toTypeName && fieldName.replace(fieldNameRegExp, toFieldName);
+            typeName === toTypeName ? fieldName.replace(fieldNameRegExp, toFieldName) : fieldName;
         } else {
           replaceFieldNameFn = (typeName, fieldName) =>
             typeName === toTypeName && fieldName === fromFieldName ? toFieldName : fieldName;

--- a/packages/transforms/rename/test/__snapshots__/wrapRename.spec.ts.snap
+++ b/packages/transforms/rename/test/__snapshots__/wrapRename.spec.ts.snap
@@ -37,11 +37,11 @@ exports[`rename should change the name of multiple fields 1`] = `
 }
 
 type MyUser {
-  false: ID!
+  id: ID!
 }
 
 type MyBook {
-  false: ID!
+  id: ID!
 }"
 `;
 
@@ -60,13 +60,28 @@ type Book {
 }"
 `;
 
+exports[`rename should only affect specified type 1`] = `
+"type Query {
+  my_user: MyUser!
+  my_bok: MyBook!
+}
+
+type MyUser {
+  id: ID!
+}
+
+type MyBook {
+  id: ID!
+}"
+`;
+
 exports[`rename should replace all occurrences of a substring in a field 1`] = `
 "type Query {
   user_v1: ApiUserV1Api!
 }
 
 type ApiUserV1Api {
-  false: ID!
+  id: ID!
 }"
 `;
 
@@ -86,7 +101,7 @@ exports[`rename should replace all occurrences of multiple substrings in a field
 }
 
 type ApiUserV1Api {
-  false: ID!
+  id: ID!
 }"
 `;
 
@@ -107,10 +122,10 @@ exports[`rename should replace the first occurrence of a substring in a field 1`
 }
 
 type MyUser {
-  false: ID!
+  id: ID!
 }
 
 type MyBook {
-  false: ID!
+  id: ID!
 }"
 `;


### PR DESCRIPTION
## Description

When using `rename` with a `useRegExpForFields` option, the rename transform is applied to all types of the schema (even with `type` specified), making some fields disappear. 🕳️  (cf: https://github.com/Urigo/graphql-mesh/issues/3437#issuecomment-1012199229)

Related #3437

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

A failing unit test has been added.


## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests and linter rules pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
