### PR TITLE
Sdk-only sources

### DIFF
--- a/packages/cli/src/commands/ts-artifacts.ts
+++ b/packages/cli/src/commands/ts-artifacts.ts
@@ -123,7 +123,9 @@ export async function generateTsArtifacts({
   const artifactsDir = join(baseDir, '.mesh');
   logger.info('Generating index file in TypeScript');
   for (const rawSource of rawSources) {
-    const transformedSchema = (unifiedSchema.extensions as any).sourceMap.get(rawSource);
+    const transformedSchema = rawSource.sdkOnly
+      ? rawSource.schema
+      : (unifiedSchema.extensions as any).sourceMap.get(rawSource);
     const sdl = printSchemaWithDirectives(transformedSchema);
     await writeFile(join(artifactsDir, `sources/${rawSource.name}/schema.graphql`), sdl);
   }
@@ -161,7 +163,7 @@ export async function generateTsArtifacts({
           const results = await Promise.all(
             rawSources.map(source => {
               const sourceMap = unifiedSchema.extensions.sourceMap as Map<RawSourceOutput, GraphQLSchema>;
-              const sourceSchema = sourceMap.get(source);
+              const sourceSchema = source.sdkOnly ? source.schema : sourceMap.get(source);
               const item = generateTypesForApi({
                 schema: sourceSchema,
                 name: source.name,

--- a/packages/config/src/process.ts
+++ b/packages/config/src/process.ts
@@ -206,6 +206,7 @@ export async function processConfig(
           name: source.name,
           handler,
           transforms,
+          sdkOnly: source.sdkOnly || false,
         };
       })
     ),

--- a/packages/config/src/process.ts
+++ b/packages/config/src/process.ts
@@ -199,7 +199,8 @@ export async function processConfig(
         codes.push(`sources.push({
           name: '${source.name}',
           handler: ${handlerVariableName},
-          transforms: ${transformsVariableName}
+          transforms: ${transformsVariableName},
+          sdkOnly: ${source.sdkOnly || false}
         })`);
 
         return {

--- a/packages/config/yaml-config.graphql
+++ b/packages/config/yaml-config.graphql
@@ -66,6 +66,10 @@ type Source {
   List of transforms to apply to the current API source, before unifying it with the rest of the sources
   """
   transforms: [Transform]
+  """
+  Whether this source should only generate an SDK, and not participate in schema stitching too.
+  """
+  sdkOnly: Boolean
 }
 
 type Transform @withAdditionalProperties

--- a/packages/runtime/src/get-mesh.ts
+++ b/packages/runtime/src/get-mesh.ts
@@ -89,6 +89,7 @@ export async function getMesh(options: GetMeshOptions): Promise<MeshInstance> {
           handler: apiSource.handler,
           batch: 'batch' in source ? source.batch : true,
           merge: apiSource.merge,
+          sdkOnly: apiSource.sdkOnly,
         });
       } catch (e: any) {
         sourceLogger.error(`Failed to generate schema: ${e.message || e}`);
@@ -108,7 +109,7 @@ export async function getMesh(options: GetMeshOptions): Promise<MeshInstance> {
 
   getMeshLogger.debug(() => `Merging schemas using the defined merging strategy.`);
   let unifiedSchema = await options.merger.getUnifiedSchema({
-    rawSources,
+    rawSources: rawSources.filter(source => !source.sdkOnly),
     typeDefs: options.additionalTypeDefs,
     resolvers: options.additionalResolvers,
     transforms: options.transforms,

--- a/packages/runtime/src/get-mesh.ts
+++ b/packages/runtime/src/get-mesh.ts
@@ -161,7 +161,7 @@ export async function getMesh(options: GetMeshOptions): Promise<MeshInstance> {
         rawSource,
         [MESH_API_CONTEXT_SYMBOL]: true,
       };
-      const transformedSchema = sourceMap.get(rawSource);
+      const transformedSchema = rawSource.sdkOnly ? rawSource.schema : sourceMap.get(rawSource);
       const rootTypes: Record<OperationTypeNode, GraphQLObjectType> = {
         query: transformedSchema.getQueryType(),
         mutation: transformedSchema.getMutationType(),

--- a/packages/runtime/src/types.ts
+++ b/packages/runtime/src/types.ts
@@ -29,6 +29,7 @@ export type GetMeshOptions = {
 export type MeshResolvedSource<TContext = any> = {
   name: string;
   handler: MeshHandler<TContext>;
+  sdkOnly: boolean;
   transforms?: MeshTransform[];
   merge?: Record<string, MergedTypeConfig>;
 };

--- a/packages/types/src/config-schema.json
+++ b/packages/types/src/config-schema.json
@@ -353,6 +353,10 @@
           },
           "additionalItems": false,
           "description": "List of transforms to apply to the current API source, before unifying it with the rest of the sources"
+        },
+        "sdkOnly": {
+          "type": "boolean",
+          "description": "Whether this source should only generate an SDK, and not participate in schema stitching too."
         }
       },
       "required": ["name", "handler"]

--- a/packages/types/src/config.ts
+++ b/packages/types/src/config.ts
@@ -198,6 +198,10 @@ export interface Source {
    * List of transforms to apply to the current API source, before unifying it with the rest of the sources
    */
   transforms?: Transform[];
+  /**
+   * Whether this source should only generate an SDK, and not participate in schema stitching too.
+   */
+  sdkOnly?: boolean;
 }
 /**
  * Point to the handler you wish to use, it can either be a predefined handler, or a custom

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -122,6 +122,7 @@ export type RawSourceOutput = {
   handler: MeshHandler;
   batch: boolean;
   merge?: Record<string, MergedTypeConfig>;
+  sdkOnly: boolean;
 };
 
 export type GraphQLOperation<TData, TVariables> = TypedDocumentNode<TData, TVariables> | string;


### PR DESCRIPTION
## Description

Adds a new `sdkOnly` flag to the sources config, to indicate that the source should generate an SDK but not be unified alongside the other sources.

Fixes #3482 

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Environment**:
- OS:
- `@graphql-mesh/...`:
- NodeJS:

## Checklist:

- [ ] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests and linter rules pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
