### PR TITLE
Remove to lower case converter

### DIFF
--- a/packages/utils/src/resolver-data-factory.ts
+++ b/packages/utils/src/resolver-data-factory.ts
@@ -47,7 +47,7 @@ export function getInterpolatedHeadersFactory(
     for (const headerName in nonInterpolatedHeaders) {
       const headerValue = nonInterpolatedHeaders[headerName];
       if (headerValue) {
-        headers[headerName.toLowerCase()] = stringInterpolator.parse(headerValue, resolverData);
+        headers[headerName] = stringInterpolator.parse(headerValue, resolverData);
       }
     }
     return headers;


### PR DESCRIPTION
Unsure why the header value converts to lower case when interpolating headers from the .meshrc file, we can't assume header information will always be lowercase only. In fact, an example from Stripe's documentation requires capitalization. 'Authorization: Bearer YOUR_SECRET_KEY'. See https://stripe.com/docs/api#authentication for details.