### PR TITLE
Update basic usage example query: docs and example

### DIFF
--- a/examples/openapi-stackexchange/list-questions.query.graphql
+++ b/examples/openapi-stackexchange/list-questions.query.graphql
@@ -1,5 +1,5 @@
 query ListQuestions {
-  listQuestions(site: "stackoverflow") {
+  listUnansweredQuestions(site: "stackoverflow") {
     items {
       title
       tags

--- a/website/docs/getting-started/basic-usage.mdx
+++ b/website/docs/getting-started/basic-usage.mdx
@@ -34,11 +34,11 @@ This will serve a GraphiQL interface with your schema, so you'll be able to test
 
 Open your browser in `http://localhost:4000` to start using it.
 
-For example, this following will fetch all page views for Wikipedia.org on the past month:
+For example, the following query will fetch unanswered questions on StackOverflow:
 
 ```graphql
 query ListQuestions {
-  listQuestions(site: "stackoverflow") {
+  listUnansweredQuestions(site: "stackoverflow") {
     items {
       title
       tags


### PR DESCRIPTION
## Description

This was a little frustrating to be a new user and to see typos in code (probably references to old code), followed directly by an example that didn't work.

I documented the heck out of this minor typo and one-line example change in the issues I opened.  Please let me know if you want me to change anything, or explain further.

Fixes:

1. Fixes  #3536 Updated references from "wikipedia" to "stackoverflow".  
2. Fixes #3537 Updated docs and example queries from "listQuestions", which no longer exists, to
   "listUnansweredQuestions".  

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update

## Screenshots/Sandbox (if appropriate/relevant):

Current Sandbox:
https://codesandbox.io/s/github/Urigo/graphql-mesh/tree/master/examples/openapi-stackexchange

Expected Sandbox (this PR that you are viewing):

https://codesandbox.io/s/github/rot26/graphql-mesh/tree/fix-basic-usage-example/examples/openapi-stackexchange

## How Has This Been Tested?

I have tested this, but please test the query in the sandbox of the Pull Request here:

https://codesandbox.io/s/github/rot26/graphql-mesh/tree/fix-basic-usage-example/examples/openapi-stackexchange

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation


