### PR TITLE
feat(cli): add ts files as search place for config

### DIFF
--- a/.changeset/friendly-numbers-carry.md
+++ b/.changeset/friendly-numbers-carry.md
@@ -1,0 +1,5 @@
+---
+'@graphql-mesh/cli': patch
+---
+
+support `.meshrc.ts` config files

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -20,6 +20,18 @@ export async function findAndParseConfig(options?: ConfigProcessOptions) {
   const { configName = 'mesh', dir: configDir = '', ...restOptions } = options || {};
   const dir = path.isAbsolute(configDir) ? configDir : path.join(process.cwd(), configDir);
   const explorer = cosmiconfig(configName, {
+    searchPlaces: [
+      'package.json',
+      `.${configName}rc`,
+      `.${configName}rc.json`,
+      `.${configName}rc.yaml`,
+      `.${configName}rc.yml`,
+      `.${configName}rc.js`,
+      `.${configName}rc.ts`,
+      `.${configName}rc.cjs`,
+      `${configName}.config.js`,
+      `${configName}.config.cjs`,
+    ],
     loaders: {
       '.json': customLoader('json', options?.importFn),
       '.yaml': customLoader('yaml', options?.importFn),


### PR DESCRIPTION
## Description
Adds `.${configName}rc.ts` as a valid search place for cosmiconfig.

Fixes #3587 

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)