### PR TITLE
chore(renovate): use common renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,11 +1,5 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:base"],
-  "postUpdateOptions": ["yarnDedupeFewer"],
-  "automerge": true,
-  "major": {
-    "automerge": false
-  },
-  "labels": ["dependencies"],
+  "extends": ["github>the-guild-org/shared-config:renovate"],
   "ignoreDeps": ["typedoc", "typedoc-plugin-markdown", "typedoc-plugin-rename-defaults"]
 }


### PR DESCRIPTION

This The Guild preset configures:
- extend `config:base`
- automerges unless major
- add `dependencies` label to PR
- group all non-major updates into a single PR
- Higher priority to `@the-guild/*` and `@guild-docs/*` package (website related)
- + GraphQL mesh specific config (`ignoredDeps`)