### PR TITLE
fix(federation-transform): initialize field name before use

### DIFF
--- a/.changeset/yellow-cobras-peel.md
+++ b/.changeset/yellow-cobras-peel.md
@@ -1,0 +1,5 @@
+---
+'@graphql-mesh/transform-federation': patch
+---
+
+initialize field name before use

--- a/packages/transforms/federation/src/index.ts
+++ b/packages/transforms/federation/src/index.ts
@@ -44,7 +44,7 @@ export default class FederationTransform implements MeshTransform {
         if (type.config?.fields) {
           for (const field of type.config.fields) {
             fields[field.name] = field.config;
-            rawSource.merge[type.name].fields[field.name] = {};
+            rawSource.merge[type.name].fields = { [field.name]: {} };
             if (field.config.requires) {
               rawSource.merge[type.name].fields[field.name].computed = true;
               rawSource.merge[type.name].fields[field.name].selectionSet = `{ ${field.config.requires} }`;

--- a/packages/transforms/federation/src/index.ts
+++ b/packages/transforms/federation/src/index.ts
@@ -44,7 +44,8 @@ export default class FederationTransform implements MeshTransform {
         if (type.config?.fields) {
           for (const field of type.config.fields) {
             fields[field.name] = field.config;
-            rawSource.merge[type.name].fields = { [field.name]: {} };
+            rawSource.merge[type.name].fields = rawSource.merge[type.name].fields || {};
+            rawSource.merge[type.name].fields[field.name] = rawSource.merge[type.name].fields[field.name] || {}
             if (field.config.requires) {
               rawSource.merge[type.name].fields[field.name].computed = true;
               rawSource.merge[type.name].fields[field.name].selectionSet = `{ ${field.config.requires} }`;


### PR DESCRIPTION
## Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

In the transformSchema function we initialize field name before use.
We try to federate two subgraphs which we generate using graphql-mesh. During the process of building the federated schema we encountered the error.

Fixes #3655

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots/Sandbox (if appropriate/relevant):
https://codesandbox.io/s/graphql-mesh-ydfpg3?file=/package.json

## How Has This Been Tested?

We tested it during the development of our federated graph.

**Test Environment**:
- OS: MacOS/Windows/Linux
- `@graphql-mesh/transform-federation: 0.8.19`
- NodeJS: v14.18.3

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests and linter rules pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
