### PR TITLE
fix(store): prevent non-spec compliant schemas to breaking the build

### DIFF
--- a/.changeset/thick-bikes-fold.md
+++ b/.changeset/thick-bikes-fold.md
@@ -1,0 +1,5 @@
+---
+"@graphql-mesh/store": patch
+---
+
+fix(store): prevent non-spec compliant schemas to breaking the build

--- a/packages/store/src/index.ts
+++ b/packages/store/src/index.ts
@@ -101,7 +101,9 @@ export enum PredefinedProxyOptionsName {
   GraphQLSchemaWithDiffing = 'GraphQLSchemaWithDiffing',
 }
 
-const escapeForTemplateLiteral = (str: string) => str.split('`').join('\\`').split('$').join('\\$');
+// Note: escape unsafe \n and \" from string (strings and block strings)
+const escapeForTemplateLiteral = (str: string) =>
+  str.split('`').join('\\`').split('$').join('\\$').split('\\n').join('').split('\\"').join('');
 
 export const PredefinedProxyOptions: Record<PredefinedProxyOptionsName, ProxyOptions<any>> = {
   JsonWithoutValidation: {


### PR DESCRIPTION
Fix issue with Shopify GraphQL Schema that contains illegals characters in GraphQL _StringValue_ (repro: https://github.com/Drew-Garratt/mesh-test)


Example invalid GraphQL definition:

```graphql

"""An article in an online store blog."""
type Article implements HasMetafields & Node & OnlineStorePublishable {
  # ...
  ): MetafieldConnection! @deprecated(reason: "The `metafields` field will be removed in the future in favor of using [aliases](https://graphql.org/learn/queries/#aliases) with the `metafield` field.\n")
```

The `\n` in `@deprecated` `reason` argument value is not properly escaped and illegal in `StringValue`: https://spec.graphql.org/June2018/#StringValue