### PR TITLE
Experiment: Mesh Declarative Plugin System

### DIFF
--- a/.changeset/sour-tables-kick.md
+++ b/.changeset/sour-tables-kick.md
@@ -2,7 +2,7 @@
 '@graphql-mesh/config': minor
 '@graphql-mesh/runtime': minor
 '@graphql-mesh/types': minor
-'@graphql-mesh/plugin-live-query': minor
+'@graphql-mesh/plugin-live-query': patch
 ---
 
 POC: Mesh Declarative Plugin System

--- a/.changeset/sour-tables-kick.md
+++ b/.changeset/sour-tables-kick.md
@@ -1,0 +1,8 @@
+---
+'@graphql-mesh/config': minor
+'@graphql-mesh/runtime': minor
+'@graphql-mesh/types': minor
+'@graphql-mesh/plugin-live-query': minor
+---
+
+POC: Mesh Declarative Plugin System

--- a/examples/json-schema-subscriptions/.meshrc.yml
+++ b/examples/json-schema-subscriptions/.meshrc.yml
@@ -35,7 +35,9 @@ documents:
 additionalTypeDefs: |
   directive @live on QUERY
 
-liveQueryInvalidations:
-  - field: Mutation.addTodo
-    invalidate:
-      - Query.todos
+plugins:
+  - liveQuery:
+      liveQueryInvalidations:
+        - field: Mutation.addTodo
+          invalidate:
+            - Query.todos

--- a/examples/json-schema-subscriptions/package.json
+++ b/examples/json-schema-subscriptions/package.json
@@ -10,6 +10,7 @@
   "dependencies": {
     "@graphql-mesh/cli": "0.70.4",
     "@graphql-mesh/json-schema": "0.28.11",
+    "@graphql-mesh/plugin-live-query": "0.0.0",
     "graphql": "16.0.1",
     "body-parser": "1.19.0",
     "express": "4.17.1",

--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
       "./packages/handlers/*",
       "./packages/transforms/*",
       "./packages/mergers/*",
+      "./packages/plugins/*",
       "./examples/*",
       "./examples/federation-example/*",
       "./examples/graphql-file-upload-example/frontend",

--- a/packages/config/yaml-config.graphql
+++ b/packages/config/yaml-config.graphql
@@ -29,10 +29,6 @@ type Query {
   """
   pubsub: PubSub
   """
-  Live Query Invalidations
-  """
-  liveQueryInvalidations: [LiveQueryInvalidation]
-  """
   Provide a query or queries for GraphQL Playground, validation and SDK Generation
   The value can be the file path, glob expression for the file paths or the SDL.
   (.js, .jsx, .graphql, .gql, .ts and .tsx files are supported.
@@ -50,6 +46,7 @@ type Query {
   You can provide Envelop plugins
   """
   additionalEnvelopPlugins: String
+  plugins: [Plugin]
 }
 
 scalar JSON
@@ -74,6 +71,14 @@ type Source {
 type Transform @withAdditionalProperties
 type Handler @withAdditionalProperties
 type Cache @withAdditionalProperties
+type Plugin @withAdditionalProperties {
+  maskedErrors: MaskedErrorsPluginConfig
+  immediateIntrospection: Any
+}
+
+type MaskedErrorsPluginConfig {
+  errorMessage: String
+}
 
 union AdditionalResolver =
     String
@@ -136,9 +141,4 @@ union PubSub = String | PubSubConfig
 type PubSubConfig {
   name: String!
   config: Any
-}
-
-type LiveQueryInvalidation {
-  field: String!
-  invalidate: [String!]!
 }

--- a/packages/plugins/live-query/package.json
+++ b/packages/plugins/live-query/package.json
@@ -1,0 +1,42 @@
+{
+  "name": "@graphql-mesh/plugin-live-query",
+  "version": "0.0.0",
+  "sideEffects": false,
+  "main": "dist/index.js",
+  "module": "dist/index.mjs",
+  "typings": "dist/index.d.ts",
+  "typescript": {
+    "definition": "dist/index.d.ts"
+  },
+  "exports": {
+    ".": {
+      "require": "./dist/index.js",
+      "import": "./dist/index.mjs"
+    },
+    "./*": {
+      "require": "./dist/*.js",
+      "import": "./dist/*.mjs"
+    }
+  },
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "Urigo/graphql-mesh",
+    "directory": "packages/plugins/live-query"
+  },
+  "peerDependencies": {
+    "graphql": "*"
+  },
+  "dependencies": {
+    "@envelop/live-query": "3.3.2",
+    "@n1ru4l/in-memory-live-query-store": "0.9.0",
+    "@graphql-mesh/types": "0.72.4",
+    "@graphql-mesh/utils": "0.34.9",
+    "@envelop/core": "^2.3.2",
+    "tslib": "^2.3.1"
+  },
+  "publishConfig": {
+    "access": "public",
+    "directory": "dist"
+  }
+}

--- a/packages/plugins/live-query/src/index.ts
+++ b/packages/plugins/live-query/src/index.ts
@@ -1,0 +1,72 @@
+import { useLiveQuery } from '@envelop/live-query';
+import { MeshPluginOptions, YamlConfig } from '@graphql-mesh/types';
+import { getInterpolatedStringFactory, ResolverDataBasedFactory } from '@graphql-mesh/utils';
+import { InMemoryLiveQueryStore } from '@n1ru4l/in-memory-live-query-store';
+import { useEnvelop, envelop, Plugin } from '@envelop/core';
+import { getOperationAST, TypeInfo, visit, visitWithTypeInfo } from 'graphql';
+
+export default function useMeshLiveQuery(options: MeshPluginOptions<YamlConfig.LiveQueryConfig>): Plugin {
+  const liveQueryInvalidationFactoryMap = new Map<string, ResolverDataBasedFactory<string>[]>();
+  options.logger.debug(() => `Creating Live Query Store`);
+  const liveQueryStore = new InMemoryLiveQueryStore({
+    includeIdentifierExtension: true,
+  });
+  options.liveQueryInvalidations?.forEach(liveQueryInvalidation => {
+    const rawInvalidationPaths = liveQueryInvalidation.invalidate;
+    const factories = rawInvalidationPaths.map(rawInvalidationPath =>
+      getInterpolatedStringFactory(rawInvalidationPath)
+    );
+    liveQueryInvalidationFactoryMap.set(liveQueryInvalidation.field, factories);
+  });
+  return useEnvelop(
+    envelop({
+      plugins: [
+        useLiveQuery({ liveQueryStore }),
+        {
+          onExecute(onExecuteParams) {
+            if (!onExecuteParams.args.schema.getDirective('live')) {
+              options.logger.warn(`You have to add @live directive to additionalTypeDefs to enable Live Queries
+See more at https://www.graphql-mesh.com/docs/recipes/live-queries`);
+            }
+            return {
+              onExecuteDone({ args: executionArgs, result }) {
+                queueMicrotask(() => {
+                  const { schema, document, operationName, rootValue, contextValue } = executionArgs;
+                  const operationAST = getOperationAST(document, operationName);
+                  if (!operationAST) {
+                    throw new Error(`Operation couldn't be found`);
+                  }
+                  const typeInfo = new TypeInfo(schema);
+                  visit(
+                    operationAST,
+                    visitWithTypeInfo(typeInfo, {
+                      Field: () => {
+                        const parentType = typeInfo.getParentType();
+                        const fieldDef = typeInfo.getFieldDef();
+                        const path = `${parentType.name}.${fieldDef.name}`;
+                        if (liveQueryInvalidationFactoryMap.has(path)) {
+                          const invalidationPathFactories = liveQueryInvalidationFactoryMap.get(path);
+                          const invalidationPaths = invalidationPathFactories.map(invalidationPathFactory =>
+                            invalidationPathFactory({
+                              root: rootValue,
+                              context: contextValue,
+                              env: process.env,
+                              result,
+                            })
+                          );
+                          liveQueryStore
+                            .invalidate(invalidationPaths)
+                            .catch((e: Error) => options.logger.warn(`Invalidation failed for ${path}: ${e.message}`));
+                        }
+                      },
+                    })
+                  );
+                });
+              },
+            };
+          },
+        },
+      ],
+    })
+  );
+}

--- a/packages/plugins/live-query/yaml-config.graphql
+++ b/packages/plugins/live-query/yaml-config.graphql
@@ -1,0 +1,15 @@
+extend type Plugin {
+  liveQuery: LiveQueryConfig
+}
+
+type LiveQueryConfig {
+  """
+  Live Query Invalidations
+  """
+  liveQueryInvalidations: [LiveQueryInvalidation]
+}
+
+type LiveQueryInvalidation {
+  field: String!
+  invalidate: [String!]!
+}

--- a/packages/runtime/src/types.ts
+++ b/packages/runtime/src/types.ts
@@ -25,7 +25,6 @@ export type GetMeshOptions = {
   pubsub: MeshPubSub;
   merger: MeshMerger;
   logger?: Logger;
-  liveQueryInvalidations?: YamlConfig.LiveQueryInvalidation[];
   additionalEnvelopPlugins?: Parameters<typeof envelop>[0]['plugins'];
   documents?: Source[];
 };

--- a/packages/transforms/rename/src/wrapRename.ts
+++ b/packages/transforms/rename/src/wrapRename.ts
@@ -82,20 +82,24 @@ export default class WrapRename implements MeshTransform {
         let replaceArgNameFn: (typeName: string, fieldName: string, argName: string) => string;
 
         const fieldNameMatch = (fieldName: string) =>
-          fieldName === (useRegExpForFields ? fieldName.replace((new RegExp(fromFieldName, regExpFlags)), toFieldName) : toFieldName)
+          fieldName ===
+          (useRegExpForFields ? fieldName.replace(new RegExp(fromFieldName, regExpFlags), toFieldName) : toFieldName);
 
         const typeNameMatch = (typeName: string) =>
-          typeName === (useRegExpForTypes ? typeName.replace((new RegExp(fromTypeName, regExpFlags)), toTypeName) : toTypeName)
+          typeName ===
+          (useRegExpForTypes ? typeName.replace(new RegExp(fromTypeName, regExpFlags), toTypeName) : toTypeName);
 
         if (useRegExpForArguments) {
           const argNameRegExp = new RegExp(fromArgumentName, regExpFlags);
-          replaceArgNameFn = (typeName, fieldName, argName) => typeNameMatch(typeName) && fieldNameMatch(fieldName)
-            ? argName.replace(argNameRegExp, toArgumentName)
-            : argName;
+          replaceArgNameFn = (typeName, fieldName, argName) =>
+            typeNameMatch(typeName) && fieldNameMatch(fieldName)
+              ? argName.replace(argNameRegExp, toArgumentName)
+              : argName;
         } else {
-          replaceArgNameFn = (typeName, fieldName, argName) => typeNameMatch(typeName) && fieldNameMatch(fieldName) && argName === fromArgumentName
-            ? toArgumentName
-            : argName;
+          replaceArgNameFn = (typeName, fieldName, argName) =>
+            typeNameMatch(typeName) && fieldNameMatch(fieldName) && argName === fromArgumentName
+              ? toArgumentName
+              : argName;
         }
 
         this.transforms.push(new RenameObjectFieldArguments(replaceArgNameFn) as any);

--- a/packages/transforms/rename/test/wrapRename.spec.ts
+++ b/packages/transforms/rename/test/wrapRename.spec.ts
@@ -560,7 +560,7 @@ describe('rename', () => {
                   field: 'profile',
                   argument: '$1Id',
                 },
-                useRegExpForArguments: true
+                useRegExpForArguments: true,
               },
             ],
           },

--- a/packages/types/src/config-schema.json
+++ b/packages/types/src/config-schema.json
@@ -537,6 +537,16 @@
         }
       }
     },
+    "Plugin": {
+      "additionalProperties": true,
+      "type": "object",
+      "title": "Plugin",
+      "properties": {
+        "liveQuery": {
+          "$ref": "#/definitions/LiveQueryConfig"
+        }
+      }
+    },
     "AdditionalStitchingResolverObject": {
       "additionalProperties": false,
       "type": "object",
@@ -681,24 +691,6 @@
         }
       },
       "required": ["name"]
-    },
-    "LiveQueryInvalidation": {
-      "additionalProperties": false,
-      "type": "object",
-      "title": "LiveQueryInvalidation",
-      "properties": {
-        "field": {
-          "type": "string"
-        },
-        "invalidate": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "additionalItems": false
-        }
-      },
-      "required": ["field", "invalidate"]
     },
     "GraphQLHandlerMultipleHTTPConfiguration": {
       "additionalProperties": false,
@@ -2032,6 +2024,39 @@
           "description": "Which method is used for this operation"
         }
       }
+    },
+    "LiveQueryConfig": {
+      "additionalProperties": false,
+      "type": "object",
+      "title": "LiveQueryConfig",
+      "properties": {
+        "liveQueryInvalidations": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/LiveQueryInvalidation"
+          },
+          "additionalItems": false,
+          "description": "Live Query Invalidations"
+        }
+      }
+    },
+    "LiveQueryInvalidation": {
+      "additionalProperties": false,
+      "type": "object",
+      "title": "LiveQueryInvalidation",
+      "properties": {
+        "field": {
+          "type": "string"
+        },
+        "invalidate": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "additionalItems": false
+        }
+      },
+      "required": ["field", "invalidate"]
     },
     "PostGraphileHandler": {
       "additionalProperties": false,
@@ -3439,14 +3464,6 @@
         }
       ]
     },
-    "liveQueryInvalidations": {
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/LiveQueryInvalidation"
-      },
-      "additionalItems": false,
-      "description": "Live Query Invalidations"
-    },
     "documents": {
       "type": "array",
       "items": {
@@ -3478,6 +3495,13 @@
     "additionalEnvelopPlugins": {
       "type": "string",
       "description": "You can provide Envelop plugins"
+    },
+    "plugins": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/Plugin"
+      },
+      "additionalItems": false
     }
   },
   "additionalProperties": false

--- a/packages/types/src/config.ts
+++ b/packages/types/src/config.ts
@@ -44,10 +44,6 @@ export interface Config {
    */
   pubsub?: string | PubSubConfig;
   /**
-   * Live Query Invalidations
-   */
-  liveQueryInvalidations?: LiveQueryInvalidation[];
-  /**
    * Provide a query or queries for GraphQL Playground, validation and SDK Generation
    * The value can be the file path, glob expression for the file paths or the SDL.
    * (.js, .jsx, .graphql, .gql, .ts and .tsx files are supported.
@@ -65,6 +61,7 @@ export interface Config {
    * You can provide Envelop plugins
    */
   additionalEnvelopPlugins?: string;
+  plugins?: Plugin[];
 }
 /**
  * Configuration for `mesh start` or `mesh dev` command.
@@ -1780,6 +1777,16 @@ export interface RedisConfig {
 export interface PubSubConfig {
   name: string;
   config?: any;
+}
+export interface Plugin {
+  liveQuery?: LiveQueryConfig;
+  [k: string]: any;
+}
+export interface LiveQueryConfig {
+  /**
+   * Live Query Invalidations
+   */
+  liveQueryInvalidations?: LiveQueryInvalidation[];
 }
 export interface LiveQueryInvalidation {
   field: string;

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -7,6 +7,7 @@ import { Transform, MergedTypeConfig } from '@graphql-tools/delegate';
 import { TypedDocumentNode } from '@graphql-typed-document-node/core';
 import { MeshStore } from '@graphql-mesh/store';
 import configSchema from './config-schema.json';
+import type { Plugin } from '@envelop/core';
 
 export const jsonSchema: any = configSchema;
 
@@ -109,6 +110,12 @@ export interface MeshMerger {
   name: string;
   getUnifiedSchema(mergerContext: MeshMergerContext): GraphQLSchema | Promise<GraphQLSchema>;
 }
+
+export type MeshPluginOptions<TConfig> = TConfig & {
+  logger: Logger;
+};
+
+export type MeshPluginFactory<TConfig> = (options: MeshPluginOptions<TConfig>) => Plugin;
 
 export type RawSourceOutput = {
   name: string;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -34,6 +34,7 @@
       "@graphql-mesh/cache-*": ["packages/cache/*/src/index.ts"],
       "@graphql-mesh/transform-*": ["packages/transforms/*/src/index.ts"],
       "@graphql-mesh/merger-*": ["packages/mergers/*/src/index.ts"],
+      "@graphql-mesh/plugin-*": ["packages/plugins/*/src/index.ts"],
       "@graphql-mesh/cross-helpers": ["packages/cross-helpers/index"],
       "@graphql-mesh/string-interpolation": ["packages/string-interpolation/src/index"],
       "@graphql-mesh/*": ["packages/handlers/*/src/index.ts"],

--- a/website/docs/guides/error-handling.mdx
+++ b/website/docs/guides/error-handling.mdx
@@ -125,12 +125,12 @@ const resolvers: Resolvers = {
         if (!result) {
           throw new GraphQLError({
             message: `Author with id '${root.authorId}' not found.`,
-            extensions:  {
+            extensions: {
               code: 'AUTHOR_NOT_FOUND',
               // complex values
               bookId: root.id,
-              authorId: root.authorId,
-            },
+              authorId: root.authorId
+            }
           })
         } else {
           return result

--- a/website/docs/guides/error-handling.mdx
+++ b/website/docs/guides/error-handling.mdx
@@ -94,12 +94,12 @@ All errors will be hidden from the end-user when error masking is enabled.
 
 However, some might want to throw specific visible errors.
 
-To make an error visible, leverage the `GraphQLYogaError` Yoga error class as follows:
+To make an error visible, leverage the `GraphQLError` error class as follows:
 
 **`additionalResolvers.ts`**
 
 ```ts
-import { GraphQLYogaError } from '@graphql-yoga/node'
+import { GraphQLError } from 'graphql'
 
 import { Resolvers } from './.mesh'
 
@@ -123,16 +123,15 @@ const resolvers: Resolvers = {
           info
         })
         if (!result) {
-          throw new GraphQLYogaError(
-            `Author with id '${root.authorId}' not found.`,
-            // error extensions
-            {
+          throw new GraphQLError({
+            message: `Author with id '${root.authorId}' not found.`,
+            extensions:  {
               code: 'AUTHOR_NOT_FOUND',
               // complex values
               bookId: root.id,
-              authorId: root.authorId
-            }
-          )
+              authorId: root.authorId,
+            },
+          })
         } else {
           return result
         }

--- a/website/docs/guides/live-queries.mdx
+++ b/website/docs/guides/live-queries.mdx
@@ -7,6 +7,8 @@ type: Guide
 
 GraphQL Live Query implementation from [Laurin Quast](https://github.com/n1ru4l) can be used in GraphQL Mesh with a few additions in the configuration.
 
+<PackageInstall packages="@graphql-mesh/plugin-live-query" />
+
 ### Basic Usage
 
 You have a `Query` root field that returns all `Todo` entities from your data source like below.
@@ -26,11 +28,13 @@ You only need to add the following to your existing configuration.
 
 ```yaml
 additionalTypeDefs: |
-  directive @live on QUERY
-liveQueryInvalidations:
-  - field: Mutation.addTodo
-    invalidate:
-      - Query.todos
+    directive @live on QUERY
+plugins:
+    - liveQuery:
+        liveQueryInvalidations:
+            - field: Mutation.addTodo
+            invalidate:
+                - Query.todos
 ```
 
 Then you can send a live query with `@live` directive.


### PR DESCRIPTION
Declarative Based Plugin System;
We can create Mesh specific plugins which still follow Envelop's Plugin signature like we do for Tools transforms or we can use the existing plugins like below;
```yaml
plugins:
  - liveQuery: # This will load @graphql-mesh/plugin-live-query
      liveQueryInvalidations:
        - field: Mutation.addTodo
          invalidate:
            - Query.todos
   - sentry: # This will load @envelop/sentry
        includeRawResult: true
   - graphqlJit: # This will load @envelop/graphql-jit
       disableLeafSerialization: false
```

And in the future we can introduce more hooks besides Yoga's and Envelop's to control phases of Mesh. It can be kind of presets including different transforms and envelop plugins maybe???