### PR TITLE
Enhances renaming for arguments

### DIFF
--- a/.changeset/stupid-chicken-guess.md
+++ b/.changeset/stupid-chicken-guess.md
@@ -1,0 +1,5 @@
+---
+'@graphql-mesh/transform-rename': patch
+---
+
+Regex now supported for Types and Fields on arguments renaming

--- a/packages/transforms/rename/src/wrapRename.ts
+++ b/packages/transforms/rename/src/wrapRename.ts
@@ -73,25 +73,29 @@ export default class WrapRename implements MeshTransform {
 
       if (
         fromTypeName &&
-        fromTypeName === toTypeName &&
+        (fromTypeName === toTypeName || useRegExpForTypes) &&
         toFieldName &&
-        fromFieldName === toFieldName &&
+        (fromFieldName === toFieldName || useRegExpForFields) &&
         fromArgumentName &&
         fromArgumentName !== toArgumentName
       ) {
         let replaceArgNameFn: (typeName: string, fieldName: string, argName: string) => string;
 
+        const fieldNameMatch = (fieldName) =>
+          fieldName === useRegExpForFields ? fieldName.replace((new RegExp(fromFieldName, regExpFlags)), toFieldName) : toFieldName
+
+        const typeNameMatch = (typeName) =>
+          typeName === useRegExpForTypes ? typeName.replace((new RegExp(fromTypeName, regExpFlags)), toTypeName) : toTypeName
+
         if (useRegExpForArguments) {
           const argNameRegExp = new RegExp(fromArgumentName, regExpFlags);
-          replaceArgNameFn = (typeName, fieldName, argName) =>
-            typeName === toTypeName && fieldName === toFieldName
-              ? fieldName.replace(argNameRegExp, toArgumentName)
-              : argName;
+          replaceArgNameFn = (typeName, fieldName, argName) => typeNameMatch(typeName) && fieldNameMatch(fieldName)
+            ? argName.replace(argNameRegExp, toArgumentName)
+            : argName;
         } else {
-          replaceArgNameFn = (typeName, fieldName, argName) =>
-            typeName === toTypeName && fieldName === fromFieldName && argName === fromArgumentName
-              ? toArgumentName
-              : argName;
+          replaceArgNameFn = (typeName, fieldName, argName) => typeNameMatch(typeName) && fieldNameMatch(fieldName) && argName === fromArgumentName
+            ? toArgumentName
+            : argName;
         }
 
         this.transforms.push(new RenameObjectFieldArguments(replaceArgNameFn) as any);

--- a/packages/transforms/rename/src/wrapRename.ts
+++ b/packages/transforms/rename/src/wrapRename.ts
@@ -81,10 +81,10 @@ export default class WrapRename implements MeshTransform {
       ) {
         let replaceArgNameFn: (typeName: string, fieldName: string, argName: string) => string;
 
-        const fieldNameMatch = (fieldName) =>
+        const fieldNameMatch = (fieldName: string) =>
           fieldName === useRegExpForFields ? fieldName.replace((new RegExp(fromFieldName, regExpFlags)), toFieldName) : toFieldName
 
-        const typeNameMatch = (typeName) =>
+        const typeNameMatch = (typeName: string) =>
           typeName === useRegExpForTypes ? typeName.replace((new RegExp(fromTypeName, regExpFlags)), toTypeName) : toTypeName
 
         if (useRegExpForArguments) {

--- a/packages/transforms/rename/src/wrapRename.ts
+++ b/packages/transforms/rename/src/wrapRename.ts
@@ -82,10 +82,10 @@ export default class WrapRename implements MeshTransform {
         let replaceArgNameFn: (typeName: string, fieldName: string, argName: string) => string;
 
         const fieldNameMatch = (fieldName: string) =>
-          fieldName === useRegExpForFields ? fieldName.replace((new RegExp(fromFieldName, regExpFlags)), toFieldName) : toFieldName
+          fieldName === (useRegExpForFields ? fieldName.replace((new RegExp(fromFieldName, regExpFlags)), toFieldName) : toFieldName)
 
         const typeNameMatch = (typeName: string) =>
-          typeName === useRegExpForTypes ? typeName.replace((new RegExp(fromTypeName, regExpFlags)), toTypeName) : toTypeName
+          typeName === (useRegExpForTypes ? typeName.replace((new RegExp(fromTypeName, regExpFlags)), toTypeName) : toTypeName)
 
         if (useRegExpForArguments) {
           const argNameRegExp = new RegExp(fromArgumentName, regExpFlags);

--- a/packages/transforms/rename/test/__snapshots__/wrapRename.spec.ts.snap
+++ b/packages/transforms/rename/test/__snapshots__/wrapRename.spec.ts.snap
@@ -120,6 +120,26 @@ type MyBook {
 }"
 `;
 
+exports[`rename should only affect specified field match argument 1`] = `
+"type Query {
+  my_user: MyUser!
+  my_book: MyBook!
+  profile(profileId: ID!, role: String, some_argument: String, another_argument: Int): Profile
+}
+
+type MyUser {
+  id: ID!
+}
+
+type Profile {
+  id: ID!
+}
+
+type MyBook {
+  id: ID!
+}"
+`;
+
 exports[`rename should only affect specified match type and match field argument 1`] = `
 "type Query {
   my_user: MyUser!

--- a/packages/transforms/rename/test/__snapshots__/wrapRename.spec.ts.snap
+++ b/packages/transforms/rename/test/__snapshots__/wrapRename.spec.ts.snap
@@ -120,6 +120,26 @@ type MyBook {
 }"
 `;
 
+exports[`rename should only affect specified match type and match field argument 1`] = `
+"type Query {
+  my_user: MyUser!
+  my_book: MyBook!
+  profile(profileId: ID!, role: String, some_argument: String, another_argument: Int): Profile
+}
+
+type MyUser {
+  id: ID!
+}
+
+type Profile {
+  id: ID!
+}
+
+type MyBook {
+  id: ID!
+}"
+`;
+
 exports[`rename should only affect specified type 1`] = `
 "type Query {
   my_user: MyUser!

--- a/packages/transforms/rename/test/wrapRename.spec.ts
+++ b/packages/transforms/rename/test/wrapRename.spec.ts
@@ -539,6 +539,53 @@ describe('rename', () => {
     expect(printSchema(newSchema)).toMatchSnapshot();
   });
 
+  it('should only affect specified match type and match field argument', () => {
+    const newSchema = wrapSchema({
+      schema,
+      transforms: [
+        new RenameTransform({
+          apiName: '',
+          importFn: m => import(m),
+          config: {
+            mode: 'wrap',
+            renames: [
+              {
+                from: {
+                  type: '(.uer.)',
+                  field: '(.rofil.)',
+                  argument: 'profile_id',
+                },
+                to: {
+                  type: '$1',
+                  field: '$1',
+                  argument: 'profileId',
+                },
+                useRegExpForTypes: true,
+                useRegExpForFields: true,
+              },
+            ],
+          },
+          cache,
+          pubsub,
+          baseDir,
+        }),
+      ],
+    });
+
+    const queryType = newSchema.getType('Query') as GraphQLObjectType;
+    const fieldMap = queryType.getFields();
+
+    // TODO: uncomment following line once #3778 is fixed
+    // expect(fieldMap.profile.args.find(a => a.name === 'role')).toBeDefined();
+    expect(fieldMap.profile.args.find(a => a.name === 'profile_id')).toBeUndefined();
+    expect(fieldMap.profile.args.find(a => a.name === 'profileId')).toBeDefined();
+
+    expect(fieldMap.profile.args.find(a => a.name === 'another_argument')).toBeDefined();
+    expect(fieldMap.profile.args.find(a => a.name === 'some_argument')).toBeDefined();
+
+    expect(printSchema(newSchema)).toMatchSnapshot();
+  });
+
   it('should resolve correctly field with renamed argument', async () => {
     const newSchema = wrapSchema({
       schema,

--- a/packages/transforms/rename/test/wrapRename.spec.ts
+++ b/packages/transforms/rename/test/wrapRename.spec.ts
@@ -539,6 +539,52 @@ describe('rename', () => {
     expect(printSchema(newSchema)).toMatchSnapshot();
   });
 
+  it('should only affect specified field match argument', () => {
+    const newSchema = wrapSchema({
+      schema,
+      transforms: [
+        new RenameTransform({
+          apiName: '',
+          importFn: m => import(m),
+          config: {
+            mode: 'wrap',
+            renames: [
+              {
+                from: {
+                  type: 'Query',
+                  field: 'profile',
+                  argument: '(profile)_(id)',
+                },
+                to: {
+                  type: 'Query',
+                  field: 'profile',
+                  argument: '$1Id',
+                },
+                useRegExpForArguments: true
+              },
+            ],
+          },
+          cache,
+          pubsub,
+          baseDir,
+        }),
+      ],
+    });
+
+    const queryType = newSchema.getType('Query') as GraphQLObjectType;
+    const fieldMap = queryType.getFields();
+
+    // TODO: uncomment following line once #3778 is fixed
+    // expect(fieldMap.profile.args.find(a => a.name === 'role')).toBeDefined();
+    expect(fieldMap.profile.args.find(a => a.name === 'profile_id')).toBeUndefined();
+    expect(fieldMap.profile.args.find(a => a.name === 'profileId')).toBeDefined();
+
+    expect(fieldMap.profile.args.find(a => a.name === 'another_argument')).toBeDefined();
+    expect(fieldMap.profile.args.find(a => a.name === 'some_argument')).toBeDefined();
+
+    expect(printSchema(newSchema)).toMatchSnapshot();
+  });
+
   it('should only affect specified match type and match field argument', () => {
     const newSchema = wrapSchema({
       schema,


### PR DESCRIPTION
## Description

The Rename transform allows regex for types and field renaming. However it doesnt support the ability to use type and field regex for arguments renames. So If I'd wanted to rename the arguments of a bunch of types or fields, I'd have to add an argument rename for each of them.

The solution is quite simple really, it allows arguments renaming actions to support regex values for types and fields.

Additionally it fixes an issue in `wrapRename.ts:L88`, where the argument regex is being applied to the `fieldName` instead of to the argName.

```typescript
if (useRegExpForArguments) {
  const argNameRegExp = new RegExp(fromArgumentName, regExpFlags);
  replaceArgNameFn = (typeName, fieldName, argName) =>
    typeName === toTypeName && fieldName === toFieldName
      ? fieldName.replace(argNameRegExp, toArgumentName)  //   <--------- should be argName.replace(...)
      : argName;
}
```

Fixes https://github.com/Urigo/graphql-mesh/issues/3957

## Type of change

Bug fix (non-breaking change which fixes an issue)
New feature (non-breaking change which adds functionality)


## How Has This Been Tested?

Missing tests...

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests and linter rules pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
