### PR TITLE
feat(mysql): handle many-to-many relations automatically

### DIFF
--- a/.changeset/serious-mugs-argue.md
+++ b/.changeset/serious-mugs-argue.md
@@ -3,3 +3,6 @@
 ---
 
 feat(mysql): handle many-to-many relations automatically
+
+- Add relation fields other way around.
+- In case of insert, update and so on, respect multiple primary keys.

--- a/.changeset/serious-mugs-argue.md
+++ b/.changeset/serious-mugs-argue.md
@@ -1,0 +1,5 @@
+---
+"@graphql-mesh/mysql": minor
+---
+
+feat(mysql): handle many-to-many relations automatically

--- a/examples/mysql-employees/example-query.graphql
+++ b/examples/mysql-employees/example-query.graphql
@@ -7,5 +7,15 @@ query GetSomeEmployees {
     last_name
     gender
     hire_date
+    dept_emp {
+      emp_no
+      dept_no
+      from_date
+      to_date
+      departments {
+        dept_no
+        dept_name
+      }
+    }
   }
 }

--- a/examples/mysql-employees/tests/__snapshots__/mysql-employees.test.js.snap
+++ b/examples/mysql-employees/tests/__snapshots__/mysql-employees.test.js.snap
@@ -108,6 +108,8 @@ input current_dept_emp_WhereInput {
 }
 
 type departments {
+  dept_emp(limit: Int, offset: Int, orderBy: dept_emp_OrderByInput, where: dept_emp_WhereInput): [dept_emp]
+  dept_manager(limit: Int, offset: Int, orderBy: dept_manager_OrderByInput, where: dept_manager_WhereInput): [dept_manager]
   dept_name: String!
   dept_no: String!
 }
@@ -243,11 +245,15 @@ input dept_manager_WhereInput {
 
 type employees {
   birth_date: Date!
+  dept_emp(limit: Int, offset: Int, orderBy: dept_emp_OrderByInput, where: dept_emp_WhereInput): [dept_emp]
+  dept_manager(limit: Int, offset: Int, orderBy: dept_manager_OrderByInput, where: dept_manager_WhereInput): [dept_manager]
   emp_no: Int!
   first_name: String!
   gender: employees_gender!
   hire_date: Date!
   last_name: String!
+  salaries(limit: Int, offset: Int, orderBy: salaries_OrderByInput, where: salaries_WhereInput): [salaries]
+  titles(limit: Int, offset: Int, orderBy: titles_OrderByInput, where: titles_WhereInput): [titles]
 }
 
 input employees_InsertInput {
@@ -466,6 +472,20 @@ Object {
       Object {
         "__typename": "employees",
         "birth_date": "1953-09-02",
+        "dept_emp": Array [
+          Object {
+            "departments": Array [
+              Object {
+                "dept_name": "Development",
+                "dept_no": "d005",
+              },
+            ],
+            "dept_no": "d005",
+            "emp_no": 10001,
+            "from_date": "1986-06-26",
+            "to_date": "9999-01-01",
+          },
+        ],
         "emp_no": 10001,
         "first_name": "Georgi",
         "gender": "M",
@@ -475,6 +495,20 @@ Object {
       Object {
         "__typename": "employees",
         "birth_date": "1964-06-02",
+        "dept_emp": Array [
+          Object {
+            "departments": Array [
+              Object {
+                "dept_name": "Development",
+                "dept_no": "d005",
+              },
+            ],
+            "dept_no": "d005",
+            "emp_no": 10001,
+            "from_date": "1986-06-26",
+            "to_date": "9999-01-01",
+          },
+        ],
         "emp_no": 10002,
         "first_name": "Bezalel",
         "gender": "F",
@@ -484,6 +518,20 @@ Object {
       Object {
         "__typename": "employees",
         "birth_date": "1959-12-03",
+        "dept_emp": Array [
+          Object {
+            "departments": Array [
+              Object {
+                "dept_name": "Development",
+                "dept_no": "d005",
+              },
+            ],
+            "dept_no": "d005",
+            "emp_no": 10001,
+            "from_date": "1986-06-26",
+            "to_date": "9999-01-01",
+          },
+        ],
         "emp_no": 10003,
         "first_name": "Parto",
         "gender": "M",
@@ -493,6 +541,20 @@ Object {
       Object {
         "__typename": "employees",
         "birth_date": "1954-05-01",
+        "dept_emp": Array [
+          Object {
+            "departments": Array [
+              Object {
+                "dept_name": "Development",
+                "dept_no": "d005",
+              },
+            ],
+            "dept_no": "d005",
+            "emp_no": 10001,
+            "from_date": "1986-06-26",
+            "to_date": "9999-01-01",
+          },
+        ],
         "emp_no": 10004,
         "first_name": "Chirstian",
         "gender": "M",
@@ -502,6 +564,20 @@ Object {
       Object {
         "__typename": "employees",
         "birth_date": "1955-01-21",
+        "dept_emp": Array [
+          Object {
+            "departments": Array [
+              Object {
+                "dept_name": "Development",
+                "dept_no": "d005",
+              },
+            ],
+            "dept_no": "d005",
+            "emp_no": 10001,
+            "from_date": "1986-06-26",
+            "to_date": "9999-01-01",
+          },
+        ],
         "emp_no": 10005,
         "first_name": "Kyoichi",
         "gender": "M",

--- a/examples/mysql-employees/tests/__snapshots__/mysql-employees.test.js.snap
+++ b/examples/mysql-employees/tests/__snapshots__/mysql-employees.test.js.snap
@@ -499,13 +499,13 @@ Object {
           Object {
             "departments": Array [
               Object {
-                "dept_name": "Development",
-                "dept_no": "d005",
+                "dept_name": "Sales",
+                "dept_no": "d007",
               },
             ],
-            "dept_no": "d005",
-            "emp_no": 10001,
-            "from_date": "1986-06-26",
+            "dept_no": "d007",
+            "emp_no": 10002,
+            "from_date": "1996-08-03",
             "to_date": "9999-01-01",
           },
         ],
@@ -522,13 +522,13 @@ Object {
           Object {
             "departments": Array [
               Object {
-                "dept_name": "Development",
-                "dept_no": "d005",
+                "dept_name": "Production",
+                "dept_no": "d004",
               },
             ],
-            "dept_no": "d005",
-            "emp_no": 10001,
-            "from_date": "1986-06-26",
+            "dept_no": "d004",
+            "emp_no": 10003,
+            "from_date": "1995-12-03",
             "to_date": "9999-01-01",
           },
         ],
@@ -545,13 +545,13 @@ Object {
           Object {
             "departments": Array [
               Object {
-                "dept_name": "Development",
-                "dept_no": "d005",
+                "dept_name": "Production",
+                "dept_no": "d004",
               },
             ],
-            "dept_no": "d005",
-            "emp_no": 10001,
-            "from_date": "1986-06-26",
+            "dept_no": "d004",
+            "emp_no": 10004,
+            "from_date": "1986-12-01",
             "to_date": "9999-01-01",
           },
         ],
@@ -568,13 +568,13 @@ Object {
           Object {
             "departments": Array [
               Object {
-                "dept_name": "Development",
-                "dept_no": "d005",
+                "dept_name": "Human Resources",
+                "dept_no": "d003",
               },
             ],
-            "dept_no": "d005",
-            "emp_no": 10001,
-            "from_date": "1986-06-26",
+            "dept_no": "d003",
+            "emp_no": 10005,
+            "from_date": "1989-09-12",
             "to_date": "9999-01-01",
           },
         ],

--- a/packages/handlers/mysql/src/index.ts
+++ b/packages/handlers/mysql/src/index.ts
@@ -407,9 +407,9 @@ export default class MySQLHandler implements MeshHandler {
                   COLUMN_NAME: foreignColumnName,
                 },
                 resolve: (root, args, { mysqlConnection }, info) => {
-                  args.where = {
+                  const where = {
                     [columnName]: root[foreignColumnName],
-                    ...args.where,
+                    ...args?.where,
                   };
                   const fieldMap: Record<string, any> = graphqlFields(info);
                   const fields: string[] = [];
@@ -428,9 +428,9 @@ export default class MySQLHandler implements MeshHandler {
                   // Generate limit statement
                   const limit = [args.limit, args.offset].filter(Boolean);
                   if (limit.length) {
-                    return mysqlConnection.selectLimit(tableName, fields, limit, args.where, args?.orderBy);
+                    return mysqlConnection.selectLimit(tableName, fields, limit, where, args?.orderBy);
                   } else {
-                    return mysqlConnection.select(tableName, fields, args.where, args?.orderBy);
+                    return mysqlConnection.select(tableName, fields, where, args?.orderBy);
                   }
                 },
               },


### PR DESCRIPTION
Add relation fields other way around.
In case of insert, update and so on, respect multiple primary keys.

Instead of the following complex resolver, MySQL handler now handles those relations automatically;
```ts
import { print } from 'graphql'
import { Resolvers} from './.mesh'
export const resolvers: Resolvers = {
    articles: {
        article_categories: {
            selectionSet: /* GraphQL */ `
                {
                    id
                }
            `,
            resolve: ({ id }, args, context, info) => context.relationtest.Query.article_to_categories({
                args: {
                    where: {
                        article_id: id.toString(),
                    }
                },
                context,
                info,
                valuesFromResults: results => results.map(({ article_categories }) => article_categories).flat(),
                selectionSet: selectionSetNode => /* GraphQL */`
                        {
                            article_categories {
                                ${selectionSetNode.selections.map(selectionNode => print(selectionNode)).join('\n')}
                            }
                        }
                    `
            })
        }
    }
}
```