### PR TITLE
Fix serialization of array values in query parameters

### DIFF
--- a/.changeset/fifty-moles-work.md
+++ b/.changeset/fifty-moles-work.md
@@ -1,0 +1,5 @@
+---
+"@graphql-mesh/openapi": patch
+---
+
+Fix serialization of array values in query parameters

--- a/packages/handlers/openapi/src/openapi-to-graphql/resolver_builder.ts
+++ b/packages/handlers/openapi/src/openapi-to-graphql/resolver_builder.ts
@@ -477,7 +477,12 @@ export function getResolver<TSource, TContext, TArgs>(
 
     for (const paramName in query) {
       const val = query[paramName];
-      if (val !== undefined) {
+
+      if (Array.isArray(val)) {
+        for (let index = 0; index < val.length; index++) {
+          urlObject.searchParams.append(paramName, val[index]);
+        }
+      } else if (val !== undefined) {
         urlObject.searchParams.set(paramName, val);
       }
     }


### PR DESCRIPTION
## Description

Currently, the OpenApi handler concatenates array values in query params like so:
`http://myRestapi/endpoint?foo=bar,qux`

Whilst this serialization might be supported by some APIs, it is not the default behaviour for OpenApi, which is instead to generate separate parameters for each array item, like so:
`http://myRestapi/endpoint?foo=bar&foo=qux`

This PR address this issue in order to obtain separate parameters per array item as per default OpenApi behaviour.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests and linter rules pass locally with my changes