### PR TITLE
Fix the typo referencing to the generated SDK in the docs

### DIFF
--- a/examples/grpc-example/start-server.js
+++ b/examples/grpc-example/start-server.js
@@ -1,6 +1,3 @@
-const {
-  promises: { readFile },
-} = require('fs');
 const { Server, loadPackageDefinition, ServerCredentials } = require('@grpc/grpc-js');
 const { load } = require('@grpc/proto-loader');
 const { join } = require('path');
@@ -94,11 +91,6 @@ module.exports = function startServer(subscriptionInterval = 1000, debug = false
           }, subscriptionInterval * (Movies.length + 1));
         },
       });
-      const [rootCA, cert_chain, private_key] = await Promise.all([
-        readFile(join(__dirname, './certs/ca.crt')),
-        readFile(join(__dirname, './certs/server.crt')),
-        readFile(join(__dirname, './certs/server.key')),
-      ]);
       server.bindAsync('0.0.0.0:50051', ServerCredentials.createInsecure(), (error, port) => {
         if (error) {
           reject(error);

--- a/website/docs/guides/graphql-code-generator.mdx
+++ b/website/docs/guides/graphql-code-generator.mdx
@@ -15,11 +15,11 @@ Mesh relies on [GraphQL Code Generator](https://www.graphql-code-generator.com/)
 The generated typed Mesh SDK can also be accessed directly, as shown below:
 
 ```ts
-import { getMeshSdk } from './.mesh'
+import { getMeshSDK } from './.mesh'
 
 async function test() {
   // Load mesh config and get the sdkClient from it
-  const sdk = getMeshSdk()
+  const sdk = getMeshSDK()
 
   // Execute `myQuery` and get a type-safe result
   // Variables and result are typed: { getSomething: { fieldA: string, fieldB: number }, errors?: GraphQLError[] }

--- a/website/docs/recipes/as-sdk.mdx
+++ b/website/docs/recipes/as-sdk.mdx
@@ -61,11 +61,11 @@ yarn mesh build
 Now, instead of using `execute` manually, you can use the generated `getSdk` method with your GraphQL Mesh client, and use the functions that are generated based on your operations:
 
 ```ts
-import { getMeshSdk } from './.mesh'
+import { getMeshSDK } from './.mesh'
 
 async function test() {
   // Load mesh config and get the sdkClient from it
-  const sdk = getMeshSdk()
+  const sdk = getMeshSDK()
 
   // Execute `myQuery` and get a type-safe result
   // Variables and result are typed: { getSomething: { fieldA: string, fieldB: number }, errors?: GraphQLError[] }


### PR DESCRIPTION
The generated SDK should be called with `getMeshSDK` not `getMeshSdk`.
Related https://github.com/Urigo/graphql-mesh/issues/4050