### PR TITLE
feat(json-schema): new exposeResponseMetadata flag to expose the details of the HTTP responses received from the upstream

### DIFF
--- a/.changeset/new-flies-taste.md
+++ b/.changeset/new-flies-taste.md
@@ -1,0 +1,29 @@
+---
+"@omnigraph/json-schema": minor
+---
+
+feat(json-schema): new exposeResponseMetadata flag to expose the details of the HTTP responses received from the upstream
+
+```yml
+responseSchema: ...
+exposeResponseMetadata: true
+```
+
+Now you will have another field called `$response` in the response type;
+
+```graphql
+type MyResponseType {
+  myFooField: String
+  _response: ResponseMetadata
+}
+
+type ResponseMetadata {
+  url: URL
+  status: Int
+  method: String
+  headers: JSON
+  body: String
+}
+```
+
+

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -17,11 +17,11 @@ export function validateConfig(
   const isValid = ajv.validate(jsonSchema, config);
   if (!isValid) {
     const logger = new DefaultLogger(initialLoggerPrefix).child('config');
-    logger.warn(
-      `${filepath} configuration file is not valid:\n${ajv.errorsText(ajv.errors, {
-        separator: '\n',
-      })}\nThis is just a warning! It doesn't have any effects on runtime.`
-    );
+    logger.warn('Configuration file is not valid!');
+    logger.warn("This is just a warning! It doesn't have any effects on runtime.");
+    ajv.errors.forEach(error => {
+      logger.warn(error.message);
+    });
   }
 }
 

--- a/packages/handlers/json-schema/yaml-config.graphql
+++ b/packages/handlers/json-schema/yaml-config.graphql
@@ -60,6 +60,7 @@ interface JsonSchemaBaseOperation {
   responseSchema: Any
   responseSample: Any
   responseTypeName: String
+  exposeResponseMetadata: Boolean
   argTypeMap: JSON
 }
 
@@ -120,6 +121,27 @@ type JsonSchemaHTTPOperation implements JsonSchemaBaseOperation {
       responseTypeName: MyError
   """
   responseByStatusCode: Any
+
+  """
+  Expose response details done to the upstream API
+  When you enable this, you will see a new field in the response type;
+  ```graphql
+  type MyResponseType {
+    myFooField: String
+    _response: ResponseMetadata
+  }
+
+  # And a new type for the response metadata object
+  type ResponseMetadata {
+    url: URL
+    status: Int
+    method: String
+    headers: JSON
+    body: String
+  }
+  ```
+  """
+  exposeResponseMetadata: Boolean
 
   """
   Mapping the JSON Schema and define the arguments of the operation.

--- a/packages/loaders/json-schema/src/addExecutionLogicToComposer.ts
+++ b/packages/loaders/json-schema/src/addExecutionLogicToComposer.ts
@@ -1,4 +1,4 @@
-import { SchemaComposer } from 'graphql-compose';
+import { GraphQLJSON, SchemaComposer } from 'graphql-compose';
 import { Logger, MeshPubSub } from '@graphql-mesh/types';
 import { JSONSchemaOperationConfig } from './types';
 import { getOperationMetadata, isPubSubOperationConfig, isFileUpload, cleanObject } from './utils';
@@ -10,8 +10,11 @@ import {
   getNamedType,
   GraphQLError,
   GraphQLFieldResolver,
+  GraphQLInt,
+  GraphQLObjectType,
   GraphQLOutputType,
   GraphQLResolveInfo,
+  GraphQLString,
   isListType,
   isNonNullType,
   isScalarType,
@@ -64,6 +67,18 @@ function linkResolver(
   }
   return actualResolver(root, args, context, info);
 }
+
+const responseMetadataType = new GraphQLObjectType({
+  name: 'ResponseMetadata',
+  fields: {
+    url: { type: GraphQLString },
+    method: { type: GraphQLString },
+    status: { type: GraphQLInt },
+    statusTest: { type: GraphQLString },
+    headers: { type: GraphQLJSON },
+    body: { type: GraphQLJSON },
+  },
+});
 
 export async function addExecutionLogicToComposer(
   schemaComposer: SchemaComposer,
@@ -314,6 +329,13 @@ export async function addExecutionLogicToComposer(
               method: httpMethod,
               status: response.status,
               statusText: response.statusText,
+              get headers() {
+                const headersObj = {};
+                response.headers.forEach((value, key) => {
+                  headersObj[key] = value;
+                });
+                return headersObj;
+              },
               body: obj,
             },
           };
@@ -343,16 +365,36 @@ export async function addExecutionLogicToComposer(
             },
           });
         }
-      } else if ('responseByStatusCode' in operationConfig) {
+      }
+
+      if ('exposeResponseMetadata' in operationConfig && operationConfig.exposeResponseMetadata) {
+        const typeTC = schemaComposer.getOTC(field.type.getTypeName());
+        typeTC.addFields({
+          _response: {
+            type: responseMetadataType,
+            resolve: root => root.$response,
+          },
+        });
+      }
+
+      if ('responseByStatusCode' in operationConfig) {
         const unionOrSingleTC = schemaComposer.getAnyTC(getNamedType(field.type.getType()));
         const types = 'getTypes' in unionOrSingleTC ? unionOrSingleTC.getTypes() : [unionOrSingleTC];
         const statusCodeOneOfIndexMap =
           (unionOrSingleTC.getExtension('statusCodeOneOfIndexMap') as Record<string, number>) || {};
         for (const statusCode in operationConfig.responseByStatusCode) {
+          const typeTCThunked = types[statusCodeOneOfIndexMap[statusCode] || 0];
           const responseConfig = operationConfig.responseByStatusCode[statusCode];
-          for (const linkName in responseConfig.links) {
-            const typeTCThunked = types[statusCodeOneOfIndexMap[statusCode] || 0];
-            const typeTC = schemaComposer.getOTC(typeTCThunked.getTypeName());
+          const typeTC = schemaComposer.getOTC(typeTCThunked.getTypeName());
+          if (responseConfig.exposeResponseMetadata) {
+            typeTC.addFields({
+              _response: {
+                type: responseMetadataType,
+                resolve: root => root.$response,
+              },
+            });
+          }
+          for (const linkName in responseConfig.links || []) {
             typeTC.addFields({
               [linkName]: () => {
                 const linkObj = responseConfig.links[linkName];

--- a/packages/loaders/json-schema/src/types.ts
+++ b/packages/loaders/json-schema/src/types.ts
@@ -22,6 +22,8 @@ export interface JSONSchemaOperationResponseConfig {
   responseSample?: any;
   responseTypeName?: string;
 
+  exposeResponseMetadata?: boolean;
+
   links?: Record<string, JSONSchemaLinkConfig>;
 }
 

--- a/packages/types/src/config-schema.json
+++ b/packages/types/src/config-schema.json
@@ -1178,6 +1178,10 @@
           ],
           "description": "You can define your response schemas by status codes;\nresponseByStatusCode:\n  200:\n    responseSchema: ./someschema.json#/somepath\n  404:\n    responseSample: ./error-sample.json\n    responseTypeName: MyError"
         },
+        "exposeResponseMetadata": {
+          "type": "boolean",
+          "description": "Expose response details done to the upstream API\nWhen you enable this, you will see a new field in the response type;\n```graphql\ntype MyResponseType {\n  myFooField: String\n  _response: ResponseMetadata\n}\n\n# And a new type for the response metadata object\ntype ResponseMetadata {\n  url: URL\n  status: Int\n  method: String\n  headers: JSON\n  body: String\n}\n```"
+        },
         "argTypeMap": {
           "type": "object",
           "properties": {},

--- a/packages/types/src/config.ts
+++ b/packages/types/src/config.ts
@@ -440,6 +440,26 @@ export interface JsonSchemaHTTPOperation {
    */
   responseByStatusCode?: any;
   /**
+   * Expose response details done to the upstream API
+   * When you enable this, you will see a new field in the response type;
+   * ```graphql
+   * type MyResponseType {
+   *   myFooField: String
+   *   _response: ResponseMetadata
+   * }
+   *
+   * # And a new type for the response metadata object
+   * type ResponseMetadata {
+   *   url: URL
+   *   status: Int
+   *   method: String
+   *   headers: JSON
+   *   body: String
+   * }
+   * ```
+   */
+  exposeResponseMetadata?: boolean;
+  /**
    * Mapping the JSON Schema and define the arguments of the operation.
    * Example: 'argTypeMap: ID: String'
    */

--- a/website/docs/generated-markdown/JsonSchemaHandler.generated.md
+++ b/website/docs/generated-markdown/JsonSchemaHandler.generated.md
@@ -26,6 +26,23 @@ responseByStatusCode:
   404:
     responseSample: ./error-sample.json
     responseTypeName: MyError
+    * `exposeResponseMetadata` (type: `Boolean`) - Expose response details done to the upstream API
+When you enable this, you will see a new field in the response type;
+```graphql
+type MyResponseType \{
+  myFooField: String
+  _response: ResponseMetadata
+}
+
+# And a new type for the response metadata object
+type ResponseMetadata \{
+  url: URL
+  status: Int
+  method: String
+  headers: JSON
+  body: String
+}
+```
     * `argTypeMap` (type: `JSON`) - Mapping the JSON Schema and define the arguments of the operation.
 Example: 'argTypeMap: ID: String'
     * `path` (type: `String`, required)

--- a/website/src/pages/api/covid/json-schema-covid/example-queries/getData_step1.graphql
+++ b/website/src/pages/api/covid/json-schema-covid/example-queries/getData_step1.graphql
@@ -12,5 +12,9 @@ query getData_step1 {
         country_name
       }
     }
+    _response {
+      status
+      body
+    }
   }
 }

--- a/website/src/pages/api/covid/json-schema-covid/sources/WorldPop.yml
+++ b/website/src/pages/api/covid/json-schema-covid/sources/WorldPop.yml
@@ -8,5 +8,6 @@ handler:
         path: /?dataset=world-population&q={args.country}&rows=1&sort=year&facet=year&facet=country_name
         method: GET
         responseSchema: ./src/json-schemas/worldPop.json
+        exposeResponseMetadata: true
         argTypeMap:
           country: String

--- a/website/src/pages/api/covid/json-schema-covid/tests/__snapshots__/json-schema-covid.test.js.snap
+++ b/website/src/pages/api/covid/json-schema-covid/tests/__snapshots__/json-schema-covid.test.js.snap
@@ -5,6 +5,7 @@ exports[`JSON Schema Covid should generate correct schema: json-schema-covid-sch
 
 \\"\\"\\"Desc Api Population\\"\\"\\"
 type ApiPopulation {
+  _response: ResponseMetadata
   records: [Result]
 }
 
@@ -108,6 +109,11 @@ type Daily {
 \\"\\"\\"\\"\\"\\"
 scalar Date
 
+\\"\\"\\"
+The \`JSON\` scalar type represents JSON values as specified by [ECMA-404](http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf).
+\\"\\"\\"
+scalar JSON
+
 \\"\\"\\"\\"\\"\\"
 type Query {
   \\"\\"\\"\\"\\"\\"
@@ -126,6 +132,15 @@ type Query {
 }
 
 scalar ResolveToSourceArgs
+
+type ResponseMetadata {
+  body: JSON
+  headers: JSON
+  method: String
+  status: Int
+  statusTest: String
+  url: String
+}
 
 \\"\\"\\"Result of API\\"\\"\\"
 type Result {
@@ -147,4 +162,123 @@ type query_population_records_items_fields {
   value: Float
   year: String
 }"
+`;
+
+exports[`JSON Schema Covid should give correct response for STEP 1: 2 sources side by side: json-schema-covid-response-metadata 1`] = `
+Object {
+  "body": Object {
+    "facet_groups": Array [
+      Object {
+        "facets": Array [
+          Object {
+            "count": 1,
+            "name": "1990",
+            "path": "1990",
+            "state": "displayed",
+          },
+          Object {
+            "count": 1,
+            "name": "2000",
+            "path": "2000",
+            "state": "displayed",
+          },
+          Object {
+            "count": 1,
+            "name": "2011",
+            "path": "2011",
+            "state": "displayed",
+          },
+          Object {
+            "count": 1,
+            "name": "2012",
+            "path": "2012",
+            "state": "displayed",
+          },
+          Object {
+            "count": 1,
+            "name": "2013",
+            "path": "2013",
+            "state": "displayed",
+          },
+          Object {
+            "count": 1,
+            "name": "2014",
+            "path": "2014",
+            "state": "displayed",
+          },
+          Object {
+            "count": 1,
+            "name": "2015",
+            "path": "2015",
+            "state": "displayed",
+          },
+          Object {
+            "count": 1,
+            "name": "2016",
+            "path": "2016",
+            "state": "displayed",
+          },
+          Object {
+            "count": 1,
+            "name": "2017",
+            "path": "2017",
+            "state": "displayed",
+          },
+          Object {
+            "count": 1,
+            "name": "2018",
+            "path": "2018",
+            "state": "displayed",
+          },
+          Object {
+            "count": 1,
+            "name": "2019",
+            "path": "2019",
+            "state": "displayed",
+          },
+        ],
+        "name": "year",
+      },
+      Object {
+        "facets": Array [
+          Object {
+            "count": 11,
+            "name": "France",
+            "path": "France",
+            "state": "displayed",
+          },
+        ],
+        "name": "country_name",
+      },
+    ],
+    "nhits": 11,
+    "parameters": Object {
+      "dataset": "world-population",
+      "facet": Array [
+        "year",
+        "country_name",
+      ],
+      "format": "json",
+      "q": "France",
+      "rows": 1,
+      "sort": Array [
+        "year",
+      ],
+      "start": 0,
+      "timezone": "UTC",
+    },
+    "records": Array [
+      Object {
+        "datasetid": "world-population",
+        "fields": Object {
+          "country_name": "France",
+          "value": 67059887,
+          "year": "2019",
+        },
+        "recordid": "bd26b46379d53d7f7f52dcbf478c1a6b090e3a94",
+      },
+    ],
+  },
+  "status": 200,
+}
 `;

--- a/website/src/pages/api/covid/json-schema-covid/tests/json-schema-covid.test.js
+++ b/website/src/pages/api/covid/json-schema-covid/tests/json-schema-covid.test.js
@@ -21,11 +21,14 @@ describe('JSON Schema Covid', () => {
       })
     ).toMatchSnapshot('json-schema-covid-schema');
   });
-  it.skip('should give correct response for STEP 1: 2 sources side by side', async () => {
+  it('should give correct response for STEP 1: 2 sources side by side', async () => {
     const getDataStep1Query = await readFile(join(__dirname, '../example-queries/getData_step1.graphql'), 'utf8');
     const { execute } = await mesh$;
     const result = await execute(getDataStep1Query);
     expect(result.errors).toBeFalsy();
+    // Check exposed response metadata
+    expect(result.data?.population?._response).toMatchSnapshot('json-schema-covid-response-metadata');
+
     expect(typeof result?.data?.case?.confirmed).toBe('number');
     expect(result?.data?.case?.countryRegion).toBe('France');
     expect(typeof result?.data?.case?.deaths).toBe('number');


### PR DESCRIPTION
Closes https://github.com/Urigo/graphql-mesh/issues/4077

**New `exposeResponseMetadata `flag to expose the details of the HTTP responses received from the remote API**

```yml
responseSchema: ...
exposeResponseMetadata: true
```

Now you will have another field called `$response` in the response type;

```graphql
type MyResponseType {
  myFooField: String
  _response: ResponseMetadata
}

type ResponseMetadata {
  url: URL
  status: Int
  method: String
  headers: JSON
  body: String
}
```


