### PR TITLE
Invalid URL at new NodeError

### DIFF
--- a/.changeset/eight-bats-attack.md
+++ b/.changeset/eight-bats-attack.md
@@ -1,0 +1,13 @@
+---
+"@graphql-mesh/cache-redis": patch
+---
+
+fix(redis): add missing string interpolation for URL parameter
+
+```
+cache:
+  redis:
+    url: '{env.REDIS_DSN}'
+```
+
+This wasn't working before and user gets a random parse error.

--- a/packages/cache/redis/src/index.ts
+++ b/packages/cache/redis/src/index.ts
@@ -13,7 +13,7 @@ export default class RedisCache<V = string> implements KeyValueCache<V> {
 
   constructor(options: YamlConfig.Cache['redis'] & { pubsub: MeshPubSub }) {
     if (options.url) {
-      const redisUrl = new URL(options.url);
+      const redisUrl = new URL(interpolateStrWithEnv(options.url));
 
       redisUrl.searchParams.set('lazyConnect', 'true');
       redisUrl.searchParams.set('enableAutoPipelining', 'true');
@@ -23,10 +23,7 @@ export default class RedisCache<V = string> implements KeyValueCache<V> {
         throw new Error('Redis URL must use either redis:// or rediss://');
       }
 
-      const fullUrl = redisUrl.toString();
-      const parsedFullUrl = interpolateStrWithEnv(fullUrl);
-
-      this.client = new Redis(parsedFullUrl);
+      this.client = new Redis(redisUrl.toString());
     } else {
       const parsedHost = interpolateStrWithEnv(options.host);
       const parsedPort = interpolateStrWithEnv(options.port);


### PR DESCRIPTION
When having 
```
cache:
  redis:
    url: '{env.REDIS_DSN}'
```

it simply doesn't work because its interoplated after it's parsed, but cannot be parsed in first place because `{env.REDIS_DSN}` is not an valid url.

🚨 **IMPORTANT: Please do not create a Pull Request without creating an issue first.**

_Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request._

## Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Screenshots/Sandbox (if appropriate/relevant):

Adding links to sandbox or providing screenshots can help us understand more about this PR and take action on it as appropriate

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Environment**:

- OS:
- `@graphql-mesh/...`:
- NodeJS:

## Checklist:

- [ ] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests and linter rules pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
