### PR TITLE
feat(graphql): new 'credentials' option to configure `RequestCredentials`

### DIFF
--- a/.changeset/nice-countries-explode.md
+++ b/.changeset/nice-countries-explode.md
@@ -1,0 +1,15 @@
+---
+"@graphql-mesh/graphql": minor
+"@graphql-mesh/types": patch
+---
+
+**New `credentials` configuration option**
+
+Previously it wasn't possible to configure `credentials` of outgoing `Request` object passed to `fetch`. And the default behavior was `same-origin`.
+Now it is possible to configure it and you can also remove it completely for the environments (e.g. CF Workers) to avoid errors like `'credentials' hasn't been implemented yet` etc.
+
+```yml
+graphql:
+  endpoint: ...
+  credentials: disable
+```

--- a/packages/config/CHANGELOG.md
+++ b/packages/config/CHANGELOG.md
@@ -25,7 +25,7 @@
   Before we use declarative approach for `additionalResolvers` that is added besides `additionalTypeDefs` which might be confusing once the project grows.
   And now we introduce new `@resolveTo` directive which has the same declarative syntax inside the SDL instead of the configuration file.
 
-  Before;
+  Before:
 
   ```yaml
   additionalTypeDefs: |
@@ -39,9 +39,9 @@
       sourceName: Author
       sourceTypeName: Query
       sourceFieldName: authorById
-      requiredSelectionSet: "{ id }"
+      requiredSelectionSet: '{ id }'
       sourceArgs:
-        id: "{root.id}"
+        id: '{root.id}'
   ```
 
   After:

--- a/packages/config/CHANGELOG.md
+++ b/packages/config/CHANGELOG.md
@@ -25,7 +25,7 @@
   Before we use declarative approach for `additionalResolvers` that is added besides `additionalTypeDefs` which might be confusing once the project grows.
   And now we introduce new `@resolveTo` directive which has the same declarative syntax inside the SDL instead of the configuration file.
 
-  Before:
+  Before;
 
   ```yaml
   additionalTypeDefs: |

--- a/packages/handlers/graphql/package.json
+++ b/packages/handlers/graphql/package.json
@@ -33,7 +33,7 @@
     "@graphql-mesh/string-interpolation": "0.3.0",
     "@graphql-mesh/utils": "0.36.1",
     "@graphql-mesh/types": "0.77.0",
-    "@graphql-tools/url-loader": "7.11.0",
+    "@graphql-tools/url-loader": "7.12.0",
     "@graphql-tools/wrap": "8.5.0",
     "@graphql-tools/delegate": "8.8.0",
     "@graphql-tools/utils": "8.8.0",

--- a/packages/handlers/graphql/yaml-config.graphql
+++ b/packages/handlers/graphql/yaml-config.graphql
@@ -69,6 +69,14 @@ type GraphQLHandlerHTTPConfiguration @md {
   """
   method: GraphQLHandlerHTTPMethod
   """
+  Request Credentials if your environment supports it.
+  [See more](https://developer.mozilla.org/en-US/docs/Web/API/Request/credentials)
+
+  Some environments like CF Workers don't even want to have this set.
+  So if you have problems like that. Just pass `disable` here.
+  """
+  credentials: RequestCredentials
+  """
   Path to a custom W3 Compatible WebSocket Implementation
   """
   webSocketImpl: String
@@ -110,4 +118,10 @@ enum SubscriptionProtocol {
 enum GraphQLHandlerHTTPMethod {
   GET
   POST
+}
+
+enum RequestCredentials {
+  omit
+  include
+  disable
 }

--- a/packages/types/src/config-schema.json
+++ b/packages/types/src/config-schema.json
@@ -842,6 +842,11 @@
           "enum": ["GET", "POST"],
           "description": "HTTP method used for GraphQL operations (Allowed values: GET, POST)"
         },
+        "credentials": {
+          "type": "string",
+          "enum": ["omit", "include", "disable"],
+          "description": "Request Credentials if your environment supports it.\n[See more](https://developer.mozilla.org/en-US/docs/Web/API/Request/credentials)\n\nSome environments like CF Workers don't even want to have this set.\nSo if you have problems like that. Just pass `disable` here. (Allowed values: omit, include, disable)"
+        },
         "webSocketImpl": {
           "type": "string",
           "description": "Path to a custom W3 Compatible WebSocket Implementation"

--- a/packages/types/src/config.ts
+++ b/packages/types/src/config.ts
@@ -254,6 +254,14 @@ export interface GraphQLHandlerHTTPConfiguration {
    */
   method?: 'GET' | 'POST';
   /**
+   * Request Credentials if your environment supports it.
+   * [See more](https://developer.mozilla.org/en-US/docs/Web/API/Request/credentials)
+   *
+   * Some environments like CF Workers don't even want to have this set.
+   * So if you have problems like that. Just pass `disable` here. (Allowed values: omit, include, disable)
+   */
+  credentials?: 'omit' | 'include' | 'disable';
+  /**
    * Path to a custom W3 Compatible WebSocket Implementation
    */
   webSocketImpl?: string;

--- a/website/docs/generated-markdown/GraphQLHandlerHTTPConfiguration.generated.md
+++ b/website/docs/generated-markdown/GraphQLHandlerHTTPConfiguration.generated.md
@@ -6,6 +6,11 @@ other options will be ignored and the schema exported from the file will be used
 * `operationHeaders` (type: `JSON`) - JSON object representing the Headers to add to the runtime of the API calls only for operation during runtime
 * `useGETForQueries` (type: `Boolean`) - Use HTTP GET for Query operations
 * `method` (type: `String (GET | POST)`) - HTTP method used for GraphQL operations
+* `credentials` (type: `String (omit | include | disable)`) - Request Credentials if your environment supports it.
+[See more](https://developer.mozilla.org/en-US/docs/Web/API/Request/credentials)
+
+Some environments like CF Workers don't even want to have this set.
+So if you have problems like that. Just pass `disable` here.
 * `webSocketImpl` (type: `String`) - Path to a custom W3 Compatible WebSocket Implementation
 * `introspection` (type: `String`) - Path to the introspection
 You can seperately give schema introspection

--- a/yarn.lock
+++ b/yarn.lock
@@ -3155,10 +3155,10 @@
     valid-url "1.0.9"
     websocket "1.0.31"
 
-"@graphql-tools/url-loader@7.11.0":
-  version "7.11.0"
-  resolved "https://registry.yarnpkg.com/@graphql-tools/url-loader/-/url-loader-7.11.0.tgz#c04d4d9f18af58230b589bdd55e81a003e19e5d6"
-  integrity sha512-c3L/NW9MRkYct4FoQQubTf/VeBhPm0lry2EsgDdcdKmV+lOh3RQ4DAYMH61cTX++MPeQiECYEwCCm68J52xlMg==
+"@graphql-tools/url-loader@7.12.0":
+  version "7.12.0"
+  resolved "https://registry.yarnpkg.com/@graphql-tools/url-loader/-/url-loader-7.12.0.tgz#a80da06c4ccfe12dc983e6638d366a13a9cbf0e3"
+  integrity sha512-V5F3KgU5cpTQ5eghvwUVw1ac784Lxf66WgnmUO1ksFzfwhcvz2RZLvgpFdZ9x6ECnh31VOtxBmIarODnalPzPA==
   dependencies:
     "@graphql-tools/delegate" "8.8.0"
     "@graphql-tools/utils" "8.8.0"
@@ -3169,7 +3169,7 @@
     dset "^3.1.2"
     extract-files "^11.0.0"
     graphql-ws "^5.4.1"
-    isomorphic-ws "^4.0.1"
+    isomorphic-ws "^5.0.0"
     meros "^1.1.4"
     sync-fetch "^0.4.0"
     tslib "^2.4.0"
@@ -14482,6 +14482,11 @@ isomorphic-ws@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/isomorphic-ws/-/isomorphic-ws-4.0.1.tgz#55fd4cd6c5e6491e76dc125938dd863f5cd4f2dc"
   integrity sha512-BhBvN2MBpWTaSHdWRb/bwdZJ1WaehQ2L1KngkCkfLUGF0mAWAT1sQUQacEmQ0jXkFw/czDXPNQSL5u2/Krsz1w==
+
+isomorphic-ws@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/isomorphic-ws/-/isomorphic-ws-5.0.0.tgz#e5529148912ecb9b451b46ed44d53dae1ce04bbf"
+  integrity sha512-muId7Zzn9ywDsyXgTIafTry2sV3nySZeUDe6YedVd1Hvuuep5AsIlqK+XefWpYTyJG5e503F2xIuT2lcU6rCSw==
 
 isstream@~0.1.2:
   version "0.1.2"


### PR DESCRIPTION

**New `credentials` configuration option**

Previously it wasn't possible to configure `credentials` of outgoing `Request` object passed to `fetch`. And the default behavior was `same-origin`.
Now it is possible to configure it and you can also remove it completely for the environments (e.g. CF Workers) to avoid errors like `'credentials' hasn't been implemented yet` etc.

```yml
graphql:
  endpoint: ...
  credentials: disable
```
