### PR TITLE
Improve string interpolation in non Node environments

### DIFF
--- a/.changeset/rotten-walls-shop.md
+++ b/.changeset/rotten-walls-shop.md
@@ -1,0 +1,20 @@
+---
+"@graphql-mesh/cli": minor
+"@graphql-mesh/cross-helpers": minor
+"@graphql-mesh/openapi": minor
+"@graphql-mesh/soap": minor
+"@omnigraph/json-schema": minor
+"@graphql-mesh/runtime": minor
+"@graphql-mesh/utils": minor
+---
+
+Improvements on string interpolation ({env.sth} or {context.headers.sth}) for different environments
+
+As we mention in most of our docs, we usually expect a key-value `header` object in the context.
+But Fetch-like environments don't have this kind of object but instead `Headers` object which is a kind `Map`.
+Now Mesh can detect this and automatically convert it to the key-value object especially for Yoga users.
+
+So for non-Node environments;
+
+Mesh will consider `import.meta.env` as `env` if available.
+Otherwise it will take `globalThis` as `env`.

--- a/.changeset/rotten-walls-shop.md
+++ b/.changeset/rotten-walls-shop.md
@@ -8,13 +8,12 @@
 "@graphql-mesh/utils": minor
 ---
 
-Improvements on string interpolation ({env.sth} or {context.headers.sth}) for different environments
+**Improvements on string interpolation ({env.sth} or {context.headers.sth}) for different environments**
 
 As we mention in most of our docs, we usually expect a key-value `header` object in the context.
 But Fetch-like environments don't have this kind of object but instead `Headers` object which is a kind `Map`.
 Now Mesh can detect this and automatically convert it to the key-value object especially for Yoga users.
 
-So for non-Node environments;
+Also Mesh now handles `env` in a better way for non-Node environments;
 
-Mesh will consider `import.meta.env` as `env` if available.
-Otherwise it will take `globalThis` as `env`.
+Consider `import.meta.env` as `env` if available, else take `globalThis` as `env`.

--- a/.changeset/wild-kangaroos-chew.md
+++ b/.changeset/wild-kangaroos-chew.md
@@ -1,0 +1,7 @@
+---
+"@graphql-mesh/config": patch
+---
+
+Fix: Resolve `customFetch` properly and write the import statement properly in the artifacts
+
+If given `customFetch` path is relative, it wasn't reflected properly in the generated artifacts so artifacts were failing. Now it is resolved correctly based on the given working directory(`baseDir`).

--- a/examples/spacex-cfw/.env
+++ b/examples/spacex-cfw/.env
@@ -1,0 +1,1 @@
+GRAPHQL_API="https://api.spacex.land/graphql/"

--- a/examples/spacex-cfw/.meshrc.yml
+++ b/examples/spacex-cfw/.meshrc.yml
@@ -1,0 +1,16 @@
+sources:
+  - name: GraphQLAPI
+    handler:
+      graphql:
+        endpoint: '{env.GRAPHQL_API}'
+        credentials: disable
+
+plugins:
+  - responseCache:
+      ttlPerCoordinate:
+        - coordinate: Query.*
+          ttl: 3600
+
+cache:
+  cfwKv:
+    namespace: MESH

--- a/examples/spacex-cfw/.meshrc.yml
+++ b/examples/spacex-cfw/.meshrc.yml
@@ -3,6 +3,10 @@ sources:
     handler:
       graphql:
         endpoint: '{env.GRAPHQL_API}'
+        # Use some fetch strategy
+        timeout: 2000
+        retry: 2
+        # The following is needed for Cloudflare Workers
         credentials: disable
 
 plugins:

--- a/examples/spacex-cfw/package.json
+++ b/examples/spacex-cfw/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "spacex-cfw",
+  "private": true,
+  "version": "0.0.0",
+  "dependencies": {
+    "@graphql-mesh/cli": "0.73.4",
+    "@graphql-mesh/graphql": "0.28.1",
+    "@graphql-mesh/cache-cfw-kv": "0.0.1",
+    "@graphql-mesh/plugin-response-cache": "0.1.2",
+    "graphql": "16.0.1"
+  },
+  "devDependencies": {
+    "wrangler": "2.0.15"
+  }
+}

--- a/examples/spacex-cfw/src/index.ts
+++ b/examples/spacex-cfw/src/index.ts
@@ -1,0 +1,24 @@
+import { getBuiltMesh } from '../.mesh';
+import { createServer } from '@graphql-yoga/common';
+
+async function handleRequest(request: Request, event: any) {
+  try {
+    const mesh = await getBuiltMesh();
+    const server = createServer({
+      plugins: mesh.plugins,
+      maskedErrors: false,
+      graphiql: {
+        title: 'SpaceX Mesh',
+      },
+    });
+    return server.handleRequest(request, event);
+  } catch (e) {
+    return new Response(e.stack, {
+      status: 500,
+    });
+  }
+}
+
+self.addEventListener('fetch', (event: any) => {
+  event.respondWith(handleRequest(event.request, event));
+});

--- a/examples/spacex-cfw/wrangler.toml
+++ b/examples/spacex-cfw/wrangler.toml
@@ -1,0 +1,12 @@
+name = "graphql_mesh"
+main = "src/index.ts"
+compatibility_date = "2022-06-27"
+account_id = "47efd9199a2f2a26049d85b9d3dfe31a"
+usage_model = "bundled"
+kv_namespaces = [
+  { binding = "MESH", id = "6efcacf054f9427e8b5f70b28da08e07", preview_id = "0418af2eda0646928a23850d278837e5" }
+]
+
+[vars]
+DEBUG = "1"
+GRAPHQL_API = "https://api.spacex.land/graphql/"

--- a/packages/cache/cfw-kv/src/index.ts
+++ b/packages/cache/cfw-kv/src/index.ts
@@ -7,7 +7,7 @@ export default class CFWorkerKVCache implements KeyValueCache {
     this.kvNamespace = globalThis[config.namespace];
     if (this.kvNamespace === undefined) {
       // We don't use mocks because they increase the bundle size.
-      config.logger.warn(`Disabling caching because ${config.namespace} is not available.`);
+      config.logger.warn(`Make sure KV Namespace: ${config.namespace} exists.`);
     }
   }
 

--- a/packages/cli/src/commands/serve/graphql-handler.ts
+++ b/packages/cli/src/commands/serve/graphql-handler.ts
@@ -15,7 +15,6 @@ export const graphqlHandler = (
         ...mesh.plugins,
         useExtendContext(({ req, res }) => ({
           ...req,
-          headers: req.headers,
           cookies: req.cookies,
           res,
         })),

--- a/packages/config/src/process.ts
+++ b/packages/config/src/process.ts
@@ -29,8 +29,6 @@ import { camelCase } from 'camel-case';
 import { defaultImportFn, parseWithCache, resolveAdditionalResolvers } from '@graphql-mesh/utils';
 import { envelop, useMaskedErrors, useImmediateIntrospection } from '@envelop/core';
 import { getAdditionalResolversFromTypeDefs } from './getAdditionalResolversFromTypeDefs';
-import { fetch, Request, Response } from 'cross-undici-fetch';
-import { fetchFactory } from 'fetchache';
 
 const ENVELOP_CORE_PLUGINS_MAP = {
   maskedErrors: {
@@ -155,14 +153,14 @@ export async function processConfig(
     codes.push('const fetchFn = fetchFactory({ cache, fetch, Request, Response });');
   }
 
-  const fetchFn = config.customFetch
-    ? await importFn(config.customFetch, true)
-    : fetchFactory({
-        cache,
-        fetch,
-        Request,
-        Response,
-      });
+  const {
+    fetchFn,
+    importCode: fetchFnImportCode,
+    code: fetchFnCode,
+  } = await resolveFetch(config.customFetch, importFn, dir, additionalPackagePrefixes);
+
+  importCodes.push(fetchFnImportCode);
+  codes.push(fetchFnCode);
 
   const sourcesStore = rootStore.child('sources');
   codes.push(`const sourcesStore = rootStore.child('sources');`);
@@ -576,4 +574,12 @@ export async function processConfig(
     additionalEnvelopPlugins,
     code: [...new Set([...importCodes, ...codes])].join('\n'),
   };
+}
+function resolveFetch(
+  customFetch: any,
+  importFn: ImportFn | ((path: string) => Promise<any>),
+  dir: string,
+  additionalPackagePrefixes: string[]
+): { fetchFn: any; importCode: any; code: any } | PromiseLike<{ fetchFn: any; importCode: any; code: any }> {
+  throw new Error('Function not implemented.');
 }

--- a/packages/config/src/utils.ts
+++ b/packages/config/src/utils.ts
@@ -102,7 +102,7 @@ export async function resolveCustomFetch({
   code: string;
 }> {
   let importCode = '';
-  if (fetchConfig) {
+  if (!fetchConfig) {
     importCode += `import { fetchFactory } from 'fetchache';\n`;
     importCode += `import { fetch, Request, Response } from 'cross-undici-fetch';\n`;
     return {
@@ -124,7 +124,7 @@ export async function resolveCustomFetch({
     additionalPrefixes: additionalPackagePrefixes,
   });
 
-  importCode += `import fetchFn from '${moduleName}';\n`;
+  importCode += `import fetchFn from ${JSON.stringify(moduleName)};\n`;
 
   return {
     fetchFn,
@@ -141,6 +141,7 @@ export async function resolveCache(
   rootStore: MeshStore,
   cwd: string,
   pubsub: MeshPubSub,
+  logger: Logger,
   additionalPackagePrefixes: string[]
 ): Promise<{
   cache: KeyValueCache;
@@ -163,6 +164,7 @@ export async function resolveCache(
     importFn,
     store: rootStore.child('cache'),
     pubsub,
+    logger,
   });
 
   const code = `const cache = new (MeshCache as any)({
@@ -170,6 +172,7 @@ export async function resolveCache(
       importFn,
       store: rootStore.child('cache'),
       pubsub,
+      logger,
     } as any)`;
   const importCode = `import MeshCache from ${JSON.stringify(moduleName)};`;
 

--- a/packages/cross-helpers/browser.js
+++ b/packages/cross-helpers/browser.js
@@ -11,15 +11,23 @@ const processObj =
   typeof process !== 'undefined'
     ? process
     : {
+        platform: 'linux',
         get env() {
           try {
             // eslint-disable-next-line no-new-func
             return new Function('return import.meta.env')();
           } catch {
-            return {
-              NODE_ENV: 'production',
-              platform: 'linux',
-            };
+            return new Proxy(
+              {},
+              {
+                get(key) {
+                  if (key === 'NODE_ENV') {
+                    return 'development';
+                  }
+                  return globalThis[key];
+                },
+              }
+            );
           }
         },
       };

--- a/packages/cross-helpers/browser.js
+++ b/packages/cross-helpers/browser.js
@@ -20,7 +20,7 @@ const processObj =
             return new Proxy(
               {},
               {
-                get(key) {
+                get(_, key) {
                   if (key === 'NODE_ENV') {
                     return 'development';
                   }

--- a/packages/handlers/openapi/src/openapi-to-graphql/resolver_builder.ts
+++ b/packages/handlers/openapi/src/openapi-to-graphql/resolver_builder.ts
@@ -25,6 +25,7 @@ import { Path } from 'graphql/jsutils/Path';
 import { ConnectOptions, RequestOptions } from './types/options';
 import { Logger, MeshPubSub } from '@graphql-mesh/types';
 import { Headers } from 'cross-undici-fetch';
+import { getHeadersObj } from '@graphql-mesh/utils';
 
 // Type definitions & exports:
 type AuthReqAndProtcolName = {
@@ -50,14 +51,6 @@ type GetResolverParams<TSource, TContext, TArgs> = {
   qs?: Record<string, string>;
   logger: Logger;
 };
-
-function headersToObject(headers: Headers) {
-  const headersObj: HeadersInit = {};
-  headers.forEach((value, key) => {
-    headersObj[key] = value;
-  });
-  return headersObj;
-}
 
 interface ResolveData {
   url: string;
@@ -631,7 +624,7 @@ export function getResolver<TSource, TContext, TArgs>(
           path: operation.path,
           statusText: response.statusText,
           statusCode: response.status,
-          responseHeaders: headersToObject(response.headers),
+          responseHeaders: getHeadersObj(response.headers),
           responseBody,
         };
         throw graphQLErrorWithExtensions(errorString, extensions);
@@ -664,7 +657,7 @@ export function getResolver<TSource, TContext, TArgs>(
             throw errorString;
           }
 
-          resolveData.responseHeaders = headersToObject(response.headers);
+          resolveData.responseHeaders = getHeadersObj(response.headers);
 
           // Deal with the fact that the server might send unsanitized data
           let saneData = Oas3Tools.sanitizeObjectKeys(

--- a/packages/handlers/openapi/src/openapi-to-graphql/resolver_builder.ts
+++ b/packages/handlers/openapi/src/openapi-to-graphql/resolver_builder.ts
@@ -666,16 +666,16 @@ export function getResolver<TSource, TContext, TArgs>(
           );
 
           // Pass on _openAPIToGraphQL to subsequent resolvers
-          if (saneData && typeof saneData === 'object') {
+          if (saneData != null && typeof saneData === 'object') {
             if (Array.isArray(saneData)) {
               saneData.forEach(element => {
-                if (typeof element._openAPIToGraphQL === 'undefined') {
+                if (typeof element === 'object' && typeof element._openAPIToGraphQL === 'undefined') {
                   element._openAPIToGraphQL = {
                     data: {},
                   };
                 }
 
-                if (root && typeof root === 'object' && typeof root._openAPIToGraphQL === 'object') {
+                if (root != null && typeof root === 'object' && typeof root._openAPIToGraphQL === 'object') {
                   Object.assign(element._openAPIToGraphQL, root._openAPIToGraphQL);
                 }
 
@@ -995,7 +995,9 @@ function resolveLinkParameter(
        * _openAPIToGraphQL contains data used by OpenAPI-to-GraphQL to create the GraphQL interface
        * and should not be exposed
        */
-      result._openAPIToGraphQL = undefined;
+      if (typeof result === 'object' && result?._openAPIToGraphQL != null) {
+        result._openAPIToGraphQL = undefined;
+      }
       return result;
 
       // CASE: parameter in body
@@ -1094,7 +1096,9 @@ function resolveRuntimeExpression(
        * _openAPIToGraphQL contains data used by OpenAPI-to-GraphQL to create the GraphQL interface
        * and should not be exposed
        */
-      result._openAPIToGraphQL = undefined;
+      if (typeof result === 'object' && result?._openAPIToGraphQL != null) {
+        result._openAPIToGraphQL = undefined;
+      }
       return result;
 
       // CASE: parameter in body

--- a/packages/handlers/soap/src/index.ts
+++ b/packages/handlers/soap/src/index.ts
@@ -1,18 +1,10 @@
 import { GetMeshSourceOptions, MeshHandler, YamlConfig, ImportFn, Logger } from '@graphql-mesh/types';
 import { soapGraphqlSchema, createSoapClient } from './soap-graphql';
 import soap from 'soap';
-import { loadFromModuleExportExpression, readFileOrUrl } from '@graphql-mesh/utils';
+import { getHeadersObj, loadFromModuleExportExpression, readFileOrUrl } from '@graphql-mesh/utils';
 import { PredefinedProxyOptions, StoreProxy } from '@graphql-mesh/store';
 import type { AxiosRequestConfig, AxiosResponse, AxiosInstance } from 'axios';
 import { process } from '@graphql-mesh/cross-helpers';
-
-function getHeadersObject(headers: Headers): Record<string, string> {
-  const headersObj: Record<string, string> = {};
-  headers.forEach((value, key) => {
-    headersObj[key] = value;
-  });
-  return headersObj;
-}
 
 export default class SoapHandler implements MeshHandler {
   private config: YamlConfig.SoapHandler;
@@ -67,7 +59,7 @@ export default class SoapHandler implements MeshHandler {
               data,
               status: res.status,
               statusText: res.statusText,
-              headers: getHeadersObject(res.headers),
+              headers: getHeadersObj(res.headers),
               config: requestObj,
             };
           };

--- a/packages/loaders/json-schema/src/addExecutionLogicToComposer.ts
+++ b/packages/loaders/json-schema/src/addExecutionLogicToComposer.ts
@@ -23,6 +23,7 @@ import {
 import lodashSet from 'lodash.set';
 import { stringInterpolator, parseInterpolationStrings } from '@graphql-mesh/string-interpolation';
 import { process } from '@graphql-mesh/cross-helpers';
+import { getHeadersObj } from '@graphql-mesh/utils';
 
 export interface AddExecutionLogicToComposerOptions {
   baseUrl: string;
@@ -329,13 +330,7 @@ export async function addExecutionLogicToComposer(
               method: httpMethod,
               status: response.status,
               statusText: response.statusText,
-              get headers() {
-                const headersObj = {};
-                response.headers.forEach((value, key) => {
-                  headersObj[key] = value;
-                });
-                return headersObj;
-              },
+              headers: getHeadersObj(response.headers),
               body: obj,
             },
           };

--- a/packages/utils/src/getHeadersObj.ts
+++ b/packages/utils/src/getHeadersObj.ts
@@ -1,11 +1,25 @@
+function headersToJSON(headers: Headers): Record<string, string> {
+  const obj: Record<string, string> = {};
+  headers.forEach((value, key) => {
+    obj[key] = value;
+  });
+  return obj;
+}
+
 export function getHeadersObj(headers: Headers): Record<string, string> {
   return new Proxy(
     {},
     {
       get(_target, name) {
+        if (name === 'toJSON') {
+          return () => headersToJSON(headers);
+        }
         return headers.get(name.toString());
       },
       has(_target, name) {
+        if (name === 'toJSON') {
+          return true;
+        }
         return headers.has(name.toString());
       },
       ownKeys(_target) {
@@ -21,6 +35,9 @@ export function getHeadersObj(headers: Headers): Record<string, string> {
       },
       deleteProperty(_target, name) {
         headers.delete(name.toString());
+        return true;
+      },
+      preventExtensions() {
         return true;
       },
     }

--- a/packages/utils/src/getHeadersObj.ts
+++ b/packages/utils/src/getHeadersObj.ts
@@ -1,0 +1,28 @@
+export function getHeadersObj(headers: Headers): Record<string, string> {
+  return new Proxy(
+    {},
+    {
+      get(_target, name) {
+        return headers.get(name.toString());
+      },
+      has(_target, name) {
+        return headers.has(name.toString());
+      },
+      ownKeys(_target) {
+        const keys: string[] = [];
+        headers.forEach((_value, name) => {
+          keys.push(name);
+        });
+        return keys;
+      },
+      set(_target, name, value) {
+        headers.set(name.toString(), value);
+        return true;
+      },
+      deleteProperty(_target, name) {
+        headers.delete(name.toString());
+        return true;
+      },
+    }
+  );
+}

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -13,3 +13,4 @@ export * from './parseAndPrintWithCache';
 export * from './defaultImportFn';
 export * from './pubsub';
 export * from './fileURLToPath';
+export * from './getHeadersObj';


### PR DESCRIPTION

**Improvements on string interpolation ({env.sth} or {context.headers.sth}) for different environments**

As we mention in most of our docs, we usually expect a key-value `header` object in the context.
But Fetch-like environments don't have this kind of object but instead `Headers` object which is a kind `Map`.
Now Mesh can detect this and automatically convert it to the key-value object especially for Yoga users.

Also Mesh now handles `env` in a better way for non-Node environments;

Consider `import.meta.env` as `env` if available, else take `globalThis` as `env`.
