### PR TITLE
Fix missing scalar 'File' error when there is a stream request in the gRPC protobuf schema

### DIFF
--- a/.changeset/itchy-lemons-shake.md
+++ b/.changeset/itchy-lemons-shake.md
@@ -1,0 +1,5 @@
+---
+"@graphql-mesh/grpc": patch
+---
+
+Missing scalar 'File' error has been fixed when there is a stream request in the gRPC protobuf schema

--- a/packages/handlers/grpc/src/index.ts
+++ b/packages/handlers/grpc/src/index.ts
@@ -444,6 +444,9 @@ ${rootJsonAndDecodedDescriptorSets
     this.schemaComposer.add(GraphQLUnsignedInt);
     this.schemaComposer.add(GraphQLVoid);
     this.schemaComposer.add(GraphQLJSON);
+    this.schemaComposer.createScalarTC({
+      name: 'File',
+    });
     // identical of grpc's ConnectivityState
     this.schemaComposer.createEnumTC({
       name: 'ConnectivityState',


### PR DESCRIPTION
Closes https://github.com/Urigo/graphql-mesh/issues/4113