### PR TITLE
feat(json-schema): noDeduplication flag

### DIFF
--- a/.changeset/happy-cameras-attack.md
+++ b/.changeset/happy-cameras-attack.md
@@ -1,0 +1,90 @@
+---
+"@graphql-mesh/json-schema": minor
+"json-machete": minor
+"@omnigraph/json-schema": minor
+---
+
+**New `noDeduplication` flag**
+
+By default, JSON Schema handler tries to deduplicate similar JSON Schema types;
+
+Let's say we have the following JSON Schema;
+
+```json
+{
+  "definitions": {
+    "Book": {
+    "type": "object",
+    "title": "Book",
+    "properties": {
+      "title": {
+        "type": "string"
+      },
+      "author": {
+        "type": "string"
+      },
+      "price": {
+        "type": "number"
+      },
+      "similarBooks": {
+        "type": "array",
+        "items": {
+          "$ref": "#/definitions/SimilarBook"
+        }
+      }
+    }
+    },
+    "SimilarBook": {
+      "type": "object",
+      "title": "Book",
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "author": {
+          "type": "string"
+        },
+        "price": {
+          "type": "number"
+        },
+        "similarBooks": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/SimilarBook"
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+And the result will be the following by default;
+
+```graphql
+type Book {
+  title: String
+  author: String
+  price: Float
+  similarBooks: [Book]
+}
+```
+
+But if you set this flag true, it will not deduplicate similar JSON Schema types;
+
+```graphql
+type Book {
+  title: String
+  author: String
+  price: Float
+  similarBooks: [SimilarBook]
+}
+
+type SimilarBook {
+  title: String
+  author: String
+  price: Float
+  similarBooks: [SimilarBook]
+}
+```
+

--- a/packages/handlers/json-schema/yaml-config.graphql
+++ b/packages/handlers/json-schema/yaml-config.graphql
@@ -29,6 +29,11 @@ type JsonSchemaHandler @md {
   operations: [JsonSchemaOperation!]!
   ignoreErrorResponses: Boolean
   queryParams: Any
+  """
+  By default, the handler will try to deduplicate the similar types to reduce the complexity of the final schema.
+  You can disable this behavior by setting this to true.
+  """
+  noDeduplication: Boolean
 }
 
 enum JsonSchemaOperationType {

--- a/packages/json-machete/src/healJSONSchema.ts
+++ b/packages/json-machete/src/healJSONSchema.ts
@@ -70,8 +70,11 @@ async function getDeduplicatedTitles(schema: JSONSchema): Promise<Set<string>> {
   );
   return duplicatedTypeNames;
 }
-export async function healJSONSchema(schema: JSONSchema) {
-  const deduplicatedSchema = deduplicateJSONSchema(schema);
+export async function healJSONSchema(
+  schema: JSONSchema,
+  options: { noDeduplication?: boolean } = {}
+): Promise<JSONSchema> {
+  const deduplicatedSchema = options?.noDeduplication ? schema : deduplicateJSONSchema(schema);
   const duplicatedTypeNames = await getDeduplicatedTitles(deduplicatedSchema);
   return visitJSONSchema<JSONSchema>(
     deduplicatedSchema,
@@ -200,7 +203,7 @@ export async function healJSONSchema(schema: JSONSchema) {
               mode: 'first',
             },
           });
-          const healedGeneratedSchema = await healJSONSchema(generatedSchema as any);
+          const healedGeneratedSchema: any = await healJSONSchema(generatedSchema as any, options);
           subSchema.type = asArray(healedGeneratedSchema.type)[0] as any;
           subSchema.properties = healedGeneratedSchema.properties;
           // If type for properties is already given, use it

--- a/packages/loaders/json-schema/src/bundle.ts
+++ b/packages/loaders/json-schema/src/bundle.ts
@@ -23,6 +23,7 @@ export interface JSONSchemaLoaderBundleOptions {
   operationHeaders?: Record<string, string>;
   cwd?: string;
   ignoreErrorResponses?: boolean;
+  noDeduplication?: boolean;
 
   fetch?: WindowOrWorkerGlobalScope['fetch'];
   logger?: Logger;
@@ -39,6 +40,7 @@ export async function createBundle(
     fetch = crossUndiciFetch,
     logger = new DefaultLogger(name),
     ignoreErrorResponses = false,
+    noDeduplication = false,
   }: JSONSchemaLoaderBundleOptions
 ): Promise<JSONSchemaLoaderBundle> {
   logger.debug(`Creating the dereferenced schema from operations config`);
@@ -49,6 +51,7 @@ export async function createBundle(
     fetchFn: fetch,
     schemaHeaders,
     ignoreErrorResponses,
+    noDeduplication,
   });
   logger.debug(`Creating references from dereferenced schema`);
   const referencedSchema = await referenceJSONSchema(dereferencedSchema);

--- a/packages/loaders/json-schema/src/getDereferencedJSONSchemaFromOperations.ts
+++ b/packages/loaders/json-schema/src/getDereferencedJSONSchemaFromOperations.ts
@@ -12,6 +12,7 @@ export async function getDereferencedJSONSchemaFromOperations({
   fetchFn,
   schemaHeaders,
   ignoreErrorResponses,
+  noDeduplication = false,
 }: {
   operations: JSONSchemaOperationConfig[];
   cwd: string;
@@ -19,6 +20,7 @@ export async function getDereferencedJSONSchemaFromOperations({
   fetchFn: WindowOrWorkerGlobalScope['fetch'];
   schemaHeaders?: Record<string, string>;
   ignoreErrorResponses?: boolean;
+  noDeduplication?: boolean;
 }): Promise<JSONSchemaObject> {
   const referencedJSONSchema = await getReferencedJSONSchemaFromOperations({
     operations,
@@ -36,6 +38,6 @@ export async function getDereferencedJSONSchemaFromOperations({
     headers: schemaHeadersFactory({ env: process.env }),
   });
   logger.debug(`Healing JSON Schema`);
-  const healedSchema = await healJSONSchema(fullyDeferencedSchema);
-  return healedSchema;
+  const healedSchema = await healJSONSchema(fullyDeferencedSchema, { noDeduplication });
+  return healedSchema as JSONSchemaObject;
 }

--- a/packages/loaders/json-schema/src/loadGraphQLSchemaFromJSONSchemas.ts
+++ b/packages/loaders/json-schema/src/loadGraphQLSchemaFromJSONSchemas.ts
@@ -14,6 +14,7 @@ export async function loadGraphQLSchemaFromJSONSchemas(name: string, options: JS
     fetchFn: options.fetch,
     schemaHeaders: options.schemaHeaders,
     ignoreErrorResponses: options.ignoreErrorResponses,
+    noDeduplication: options.noDeduplication,
   });
   const graphqlSchema = await getGraphQLSchemaFromDereferencedJSONSchema(fullyDeferencedSchema, {
     fetch: options.fetch,

--- a/packages/loaders/json-schema/src/types.ts
+++ b/packages/loaders/json-schema/src/types.ts
@@ -15,6 +15,7 @@ export interface JSONSchemaLoaderOptions extends BaseLoaderOptions {
   generateInterfaceFromSharedFields?: boolean;
   ignoreErrorResponses?: boolean;
   queryParams?: Record<string, string>;
+  noDeduplication?: boolean;
 }
 
 export interface JSONSchemaOperationResponseConfig {

--- a/packages/types/src/config-schema.json
+++ b/packages/types/src/config-schema.json
@@ -1074,6 +1074,10 @@
               "additionalItems": true
             }
           ]
+        },
+        "noDeduplication": {
+          "type": "boolean",
+          "description": "By default, the handler will try to deduplicate the similar types to reduce the complexity of the final schema.\nYou can disable this behavior by setting this to true."
         }
       },
       "required": ["operations"]

--- a/packages/types/src/config.ts
+++ b/packages/types/src/config.ts
@@ -390,6 +390,11 @@ export interface JsonSchemaHandler {
   operations: (JsonSchemaHTTPOperation | JsonSchemaPubSubOperation)[];
   ignoreErrorResponses?: boolean;
   queryParams?: any;
+  /**
+   * By default, the handler will try to deduplicate the similar types to reduce the complexity of the final schema.
+   * You can disable this behavior by setting this to true.
+   */
+  noDeduplication?: boolean;
 }
 export interface JsonSchemaHTTPOperation {
   /**

--- a/website/docs/generated-markdown/JsonSchemaHandler.generated.md
+++ b/website/docs/generated-markdown/JsonSchemaHandler.generated.md
@@ -67,3 +67,5 @@ the underlying HTTP request
     * `pubsubTopic` (type: `String`, required)
 * `ignoreErrorResponses` (type: `Boolean`)
 * `queryParams` (type: `Any`)
+* `noDeduplication` (type: `Boolean`) - By default, the handler will try to deduplicate the similar types to reduce the complexity of the final schema.
+You can disable this behavior by setting this to true.

--- a/website/docs/handlers/json-schema.mdx
+++ b/website/docs/handlers/json-schema.mdx
@@ -148,6 +148,98 @@ Any JSON sample file can be used.
 
 <p>&nbsp;</p>
 
+## Configure deduplication behavior
+
+By default, JSON Schema handler tries to deduplicate similar JSON Schema types to reduce the size of the GraphQL schema because usually JSON Schemas are large and they don't have the modular structure like the most of GraphQL schemas.
+
+You can use `noDeduplication: true` flag to disable this behavior
+
+Let's say we have the following JSON Schema;
+
+```json
+{
+  "definitions": {
+    "Book": {
+      "type": "object",
+      "title": "Book",
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "author": {
+          "type": "string"
+        },
+        "price": {
+          "type": "number"
+        },
+        "similarBooks": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/SimilarBook"
+          }
+        }
+      }
+    },
+    "SimilarBook": {
+      "type": "object",
+      "title": "Book",
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "author": {
+          "type": "string"
+        },
+        "price": {
+          "type": "number"
+        },
+        "similarBooks": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/SimilarBook"
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+And the result will be the following by default;
+
+```graphql
+type Book {
+  title: String
+  author: String
+  price: Float
+  similarBooks: [Book]
+}
+```
+
+But if you set this flag true, it will not deduplicate similar JSON Schema types;
+
+```graphql
+type Book {
+  title: String
+  author: String
+  price: Float
+  similarBooks: [SimilarBook]
+}
+
+type SimilarBook {
+  title: String
+  author: String
+  price: Float
+  similarBooks: [SimilarBook]
+}
+```
+
+<p>&nbsp;</p>
+
+---
+
+<p>&nbsp;</p>
+
 ## Codesandbox Example
 
 You can check out our example that uses the JSON Schema handler with mock data.


### PR DESCRIPTION

**New `noDeduplication` flag**

By default, JSON Schema handler tries to deduplicate similar JSON Schema types;

Let's say we have the following JSON Schema;

```json
{
  "definitions": {
    "Book": {
    "type": "object",
    "title": "Book",
    "properties": {
      "title": {
        "type": "string"
      },
      "author": {
        "type": "string"
      },
      "price": {
        "type": "number"
      },
      "similarBooks": {
        "type": "array",
        "items": {
          "$ref": "#/definitions/SimilarBook"
        }
      }
    }
    },
    "SimilarBook": {
      "type": "object",
      "title": "Book",
      "properties": {
        "title": {
          "type": "string"
        },
        "author": {
          "type": "string"
        },
        "price": {
          "type": "number"
        },
        "similarBooks": {
          "type": "array",
          "items": {
            "$ref": "#/definitions/SimilarBook"
          }
        }
      }
    }
  }
}
```

And the result will be the following by default;

```graphql
type Book {
  title: String
  author: String
  price: Float
  similarBooks: [Book]
}
```

But if you set this flag true, it will not deduplicate similar JSON Schema types;

```graphql
type Book {
  title: String
  author: String
  price: Float
  similarBooks: [SimilarBook]
}
type SimilarBook {
  title: String
  author: String
  price: Float
  similarBooks: [SimilarBook]
}
```