### PR TITLE
fix(read-file): fix path resolution on Windows

### DIFF
--- a/.changeset/odd-planes-think.md
+++ b/.changeset/odd-planes-think.md
@@ -1,0 +1,5 @@
+---
+"@graphql-mesh/utils": patch
+---
+
+Fix path resolution issue on `readFileOrUrl` that causes a bug while loading files from the file system for building artifacts

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -66,7 +66,7 @@ jobs:
   test:
     name: Testing on Node ${{matrix.node-version}} & ${{matrix.os}}
     timeout-minutes: 60
-    runs-on:
+    runs-on: ${{matrix.os}}
     strategy:
       matrix:
         os: [ubuntu-latest]

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -64,11 +64,12 @@ jobs:
         run: yarn transpile-ts --noEmit # We need build for playground
 
   test:
-    name: Testing on Node ${{matrix.node-version}}
+    name: Testing on Node ${{matrix.node-version}} & ${{matrix.os}}
     timeout-minutes: 60
-    runs-on: ubuntu-latest
+    runs-on:
     strategy:
       matrix:
+        os: [ubuntu-latest]
         node-version: [14, 18]
         include:
           - node-version: 18

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -71,9 +71,6 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         node-version: [14, 18]
-        include:
-          - node-version: 18
-            os: windows-latest
     # Service containers to run with `runner-job`
     services:
       # Label used to access the service container

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -70,6 +70,9 @@ jobs:
     strategy:
       matrix:
         node-version: [14, 18]
+        include:
+          - node-version: 18
+            os: windows-latest
     # Service containers to run with `runner-job`
     services:
       # Label used to access the service container

--- a/packages/utils/src/read-file-or-url.ts
+++ b/packages/utils/src/read-file-or-url.ts
@@ -89,7 +89,7 @@ export async function readFile<T>(
       defaultExportName: 'default',
     });
   }
-  const actualPath = pathModule.isAbsolute(filePath) ? filePath : pathModule.join(cwd || process.cwd(), filePath);
+  const actualPath = pathModule.isAbsolute(filePath) ? filePath : pathModule.join(cwd, filePath);
   const rawResult = await fs.promises.readFile(actualPath, 'utf-8');
   if (/json$/.test(actualPath)) {
     return JSON.parse(rawResult);

--- a/packages/utils/test/read-file-or-url.spec.ts
+++ b/packages/utils/test/read-file-or-url.spec.ts
@@ -3,6 +3,7 @@ import { tmpdir } from 'os';
 import { join, relative } from 'path';
 import { DefaultLogger } from '../src/logger';
 import { readFile } from '../src/read-file-or-url';
+import { fetch } from 'cross-undici-fetch';
 
 describe('readFile', () => {
   it('should convert relative paths to absolute paths correctly', async () => {

--- a/packages/utils/test/read-file-or-url.spec.ts
+++ b/packages/utils/test/read-file-or-url.spec.ts
@@ -1,8 +1,8 @@
 import { writeFileSync } from 'fs';
 import { tmpdir } from 'os';
 import { join, relative } from 'path';
+import { DefaultLogger } from '../src/logger';
 import { readFile } from '../src/read-file-or-url';
-import { cwd } from 'process';
 
 describe('readFile', () => {
   it('should convert relative paths to absolute paths correctly', async () => {
@@ -11,8 +11,13 @@ describe('readFile', () => {
       test: 'TEST',
     };
     writeFileSync(tmpFileAbsolutePath, JSON.stringify(tmpFileContent));
-    const tmpFileRelativePath = relative(cwd(), tmpFileAbsolutePath);
-    const receivedFileContent = await readFile(tmpFileRelativePath);
+    const tmpFileRelativePath = relative(process.cwd(), tmpFileAbsolutePath);
+    const receivedFileContent = await readFile(tmpFileRelativePath, {
+      cwd: process.cwd(),
+      fetch,
+      logger: new DefaultLogger(),
+      importFn: m => import(m),
+    });
     expect(receivedFileContent).toStrictEqual(tmpFileContent);
   });
   it('should respect absolute paths correctly', async () => {
@@ -21,7 +26,12 @@ describe('readFile', () => {
       test: 'TEST',
     };
     writeFileSync(tmpFileAbsolutePath, JSON.stringify(tmpFileContent));
-    const receivedFileContent = await readFile(tmpFileAbsolutePath);
+    const receivedFileContent = await readFile(tmpFileAbsolutePath, {
+      cwd: process.cwd(),
+      fetch,
+      logger: new DefaultLogger(),
+      importFn: m => import(m),
+    });
     expect(receivedFileContent).toStrictEqual(tmpFileContent);
   });
 });


### PR DESCRIPTION
Closes https://github.com/Urigo/graphql-mesh/issues/4094

`json-machete` uses `readFileOrUrl` from `@graphql-mesh/utils` package. Differently than the other users of this function usually provide an absolute path. But `json-machete`'s `deference` function nestedly resolves the differences with dynamic base paths. 
For example, when it resolves `../x/y/z/foo.json`, it uses `process.cwd` but then, it should resolve the `$ref: "../t/bar.json"` path with `foo.json`'s directory.
That's the case, readFileOrUrl ensures the path is absolute and resolves it correctly with the given "cwd".