### PR TITLE
fix json stringify Maximum-call-stack-size-exceeded

### DIFF
--- a/.changeset/many-cats-eat.md
+++ b/.changeset/many-cats-eat.md
@@ -1,0 +1,5 @@
+---
+"@graphql-mesh/openapi": patch
+---
+
+Change from JSON.stringify to inspect from graphql-tools to prevent: Maximum call stack size exceeded when logging complext objects with cycle references

--- a/packages/handlers/openapi/src/openapi-to-graphql/schema_builder.ts
+++ b/packages/handlers/openapi/src/openapi-to-graphql/schema_builder.ts
@@ -403,7 +403,7 @@ function checkAmbiguousMemberTypes<TSource, TContext, TArgs>(
         handleWarning({
           mitigationType: MitigationTypes.AMBIGUOUS_UNION_MEMBERS,
           message:
-            `Union created from schema '${JSON.stringify(def)}' contains ` +
+            `Union created from schema '${JSON.stringify(def.schema)}' contains ` +
             `member types such as '${currentType}' and '${otherType}' ` +
             `which are ambiguous. Ambiguous member types can cause ` +
             `problems when trying to resolve types.`,

--- a/packages/handlers/openapi/src/openapi-to-graphql/schema_builder.ts
+++ b/packages/handlers/openapi/src/openapi-to-graphql/schema_builder.ts
@@ -623,8 +623,7 @@ function createFields<TSource, TContext, TArgs>({
       handleWarning({
         mitigationType: MitigationTypes.CANNOT_GET_FIELD_TYPE,
         message:
-          `Cannot obtain GraphQL type for field '${fieldTypeKey}' in ` +
-          `GraphQL type '${inspect(def.schema)}'.`,
+          `Cannot obtain GraphQL type for field '${fieldTypeKey}' in ` + `GraphQL type '${inspect(def.schema)}'.`,
         data,
         logger: translationLogger,
       });

--- a/packages/handlers/openapi/src/openapi-to-graphql/schema_builder.ts
+++ b/packages/handlers/openapi/src/openapi-to-graphql/schema_builder.ts
@@ -36,6 +36,7 @@ import {
 
 // Imports:
 import { GraphQLJSON, GraphQLBigInt, GraphQLDateTime } from 'graphql-scalars';
+import { inspect } from '@graphql-tools/utils';
 import * as Oas3Tools from './oas_3_tools';
 import { getResolver } from './resolver_builder';
 import { createDataDef } from './preprocessor';
@@ -403,7 +404,7 @@ function checkAmbiguousMemberTypes<TSource, TContext, TArgs>(
         handleWarning({
           mitigationType: MitigationTypes.AMBIGUOUS_UNION_MEMBERS,
           message:
-            `Union created from schema '${JSON.stringify(def.schema)}' contains ` +
+            `Union created from schema '${inspect(def)}' contains ` +
             `member types such as '${currentType}' and '${otherType}' ` +
             `which are ambiguous. Ambiguous member types can cause ` +
             `problems when trying to resolve types.`,
@@ -474,7 +475,7 @@ function createOrReuseList<TSource, TContext, TArgs>({
     return listObjectType;
   } else {
     throw new Error(`Cannot create list item object type '${itemsName}' in list
-    '${name}' with schema '${JSON.stringify(itemsSchema)}'`);
+    '${name}' with schema '${inspect(itemsSchema)}'`);
   }
 }
 
@@ -623,7 +624,7 @@ function createFields<TSource, TContext, TArgs>({
         mitigationType: MitigationTypes.CANNOT_GET_FIELD_TYPE,
         message:
           `Cannot obtain GraphQL type for field '${fieldTypeKey}' in ` +
-          `GraphQL type '${JSON.stringify(def.schema)}'.`,
+          `GraphQL type '${inspect(def.schema)}'.`,
         data,
         logger: translationLogger,
       });
@@ -1084,7 +1085,7 @@ export function getArgs<TSource, TContext, TArgs>({
         mitigationType: MitigationTypes.INVALID_OAS,
         message:
           `The operation '${operation.operationString}' contains a ` +
-          `parameter '${JSON.stringify(parameter)}' with no 'name' property`,
+          `parameter '${inspect(parameter)}' with no 'name' property`,
         data,
         logger: translationLogger,
       });
@@ -1121,7 +1122,7 @@ export function getArgs<TSource, TContext, TArgs>({
           mitigationType: MitigationTypes.NON_APPLICATION_JSON_SCHEMA,
           message:
             `The operation '${operation.operationString}' contains a ` +
-            `parameter '${JSON.stringify(parameter)}' that has a 'content' ` +
+            `parameter '${inspect(parameter)}' that has a 'content' ` +
             `property but no schemas in application/json format. The ` +
             `parameter will not be created`,
           data,
@@ -1135,7 +1136,7 @@ export function getArgs<TSource, TContext, TArgs>({
         mitigationType: MitigationTypes.INVALID_OAS,
         message:
           `The operation '${operation.operationString}' contains a ` +
-          `parameter '${JSON.stringify(parameter)}' with no 'schema' or ` +
+          `parameter '${inspect(parameter)}' with no 'schema' or ` +
           `'content' property`,
         data,
         logger: translationLogger,


### PR DESCRIPTION
🚨 **IMPORTANT: Please do not create a Pull Request without creating an issue first.**

_Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request._

## Description

At trainline we have a swagger schema with a bunch of loops in types ex:

```
type TypeA  {
    childrens: [TypeA]
}
``` 

This was causing a `Failed to generate the schema RangeError: Maximum call stack size exceeded. I managed to track the issue to the JSON.stringify that was using the entire object. Probably due to the cycle dependencies it has some references pointing to each other which will make the JSON.stringify recursivity to never end.

Fixes # ([issue](https://github.com/Urigo/graphql-mesh/issues/4152))

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Screenshots/Sandbox (if appropriate/relevant):

Adding links to sandbox or providing screenshots can help us understand more about this PR and take action on it as appropriate

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Environment**:

- OS:
- `@graphql-mesh/...`:
- NodeJS:

## Checklist:

- [ ] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests and linter rules pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
