### PR TITLE
Do not use AggregateError if there is only one error

### DIFF
--- a/.changeset/heavy-ways-talk.md
+++ b/.changeset/heavy-ways-talk.md
@@ -1,0 +1,7 @@
+---
+"@graphql-mesh/thrift": patch
+"@graphql-mesh/runtime": patch
+"@graphql-mesh/store": patch
+---
+
+Now if there is only one error to be thrown, throw it as it is instead of using AggregateError in SDK and handlers

--- a/packages/handlers/thrift/src/index.ts
+++ b/packages/handlers/thrift/src/index.ts
@@ -73,6 +73,9 @@ export default class ThriftHandler implements MeshHandler {
       });
       const parseResult = parse(rawThrift, { organize: false });
       if (parseResult.type === SyntaxType.ThriftErrors) {
+        if (parseResult.errors.length === 1) {
+          throw parseResult.errors[0];
+        }
         throw new AggregateError(parseResult.errors);
       }
       return parseResult;

--- a/packages/store/src/index.ts
+++ b/packages/store/src/index.ts
@@ -151,7 +151,11 @@ export default buildASTSchema(schemaAST, {
         }
       }
       if (errors.length) {
-        throw new AggregateError(errors);
+        if (errors.length === 1) {
+          throw errors[0];
+        } else {
+          throw new AggregateError(errors);
+        }
       }
     },
   },


### PR DESCRIPTION
Usually there is only one error thrown and in that case we can throw it as it is instead of wrapping it inside AggregateError so it would be easier for the user to debug.