### PR TITLE
docs(hoist): update transformer name

### DIFF
--- a/website/docs/transforms/hoist.mdx
+++ b/website/docs/transforms/hoist.mdx
@@ -43,7 +43,7 @@ type User {
 
 ```yaml
 transforms:
-  - hoist:
+  - hoist-field:
       - typeName: Query
         pathConfig:
           - users
@@ -69,7 +69,7 @@ type User {
 
 ```yaml
 transforms:
-  - hoist:
+  - hoist-field:
       - typeName: Query
         pathConfig:
           - users
@@ -96,7 +96,7 @@ type User {
 
 ```yaml
 transforms:
-  - hoist:
+  - hoist-field:
       - typeName: Query
         pathConfig:
           - fieldName: users


### PR DESCRIPTION
_The PR template doesn't match this PR. This is a documentation update_

Hey!

It seems like there's a minor issue with the documentation. It has:
```yml
transforms:
    - hoist:
          ...
```

While it should be 
```yml
transforms:
    - hoist-field:
          ...
```