### PR TITLE
fix: do not ignore resolvers when there is a single source w/ an executor

### DIFF
--- a/.changeset/clever-zebras-switch.md
+++ b/.changeset/clever-zebras-switch.md
@@ -1,0 +1,6 @@
+---
+"@graphql-mesh/config": patch
+"@graphql-mesh/merger-bare": patch
+---
+
+Fix a bug that is causing the additional resolvers to be ignored when there is a single source with an executor(GraphQL handler e.g.) because resolvers are added to the schema while the execution should respect those.

--- a/packages/config/src/process.ts
+++ b/packages/config/src/process.ts
@@ -458,23 +458,27 @@ export async function processConfig(
       mergerName = 'stitching';
     } else {
       // eslint-disable-next-line no-labels
-      typeLoop: for (const typeName in additionalResolvers || {}) {
-        const fieldResolvers = additionalResolvers[typeName];
-        if (typeof fieldResolvers === 'object') {
-          for (const fieldName in fieldResolvers) {
-            const fieldResolveObj = fieldResolvers[fieldName];
-            if (typeof fieldResolveObj === 'object') {
-              // selectionSet needs stitching merger even if there is a single source
-              if (fieldResolveObj.selectionSet != null) {
-                mergerName = 'stitching';
-                // eslint-disable-next-line no-labels
-                break typeLoop;
+      resolversLoop: for (const resolversObj of additionalResolvers || []) {
+        for (const typeName in resolversObj || {}) {
+          const fieldResolvers = resolversObj[typeName];
+          if (typeof fieldResolvers === 'object') {
+            for (const fieldName in fieldResolvers) {
+              const fieldResolveObj = fieldResolvers[fieldName];
+              if (typeof fieldResolveObj === 'object') {
+                // selectionSet needs stitching merger even if there is a single source
+                if (fieldResolveObj.selectionSet != null) {
+                  mergerName = 'stitching';
+                  // eslint-disable-next-line no-labels
+                  break resolversLoop;
+                }
               }
             }
           }
         }
       }
-      mergerName = 'bare';
+      if (!mergerName) {
+        mergerName = 'bare';
+      }
     }
   }
 

--- a/packages/mergers/bare/package.json
+++ b/packages/mergers/bare/package.json
@@ -30,6 +30,7 @@
   "dependencies": {
     "@graphql-mesh/types": "0.78.4",
     "@graphql-mesh/utils": "0.37.5",
+    "@graphql-tools/wrap": "8.5.0",
     "@graphql-tools/schema": "8.5.0",
     "@graphql-tools/utils": "8.8.0",
     "tslib": "^2.4.0"

--- a/packages/mergers/bare/src/index.ts
+++ b/packages/mergers/bare/src/index.ts
@@ -12,7 +12,7 @@ export default class BareMerger implements MeshMerger {
     this.logger = options.logger;
   }
 
-  handleSingleWrappedSource({ rawSources: [rawSource], typeDefs, resolvers }: MeshMergerContext) {
+  handleSingleWrappedExtendedSource({ rawSources: [rawSource], typeDefs, resolvers }: MeshMergerContext) {
     let schema = wrapSchema(rawSource);
     if (typeDefs.length > 0 || asArray(resolvers).length > 0) {
       for (const typeDef of typeDefs) {
@@ -38,12 +38,11 @@ export default class BareMerger implements MeshMerger {
       },
     });
     return {
-      ...rawSource,
       schema,
     };
   }
 
-  handleSingleBareSource({ rawSources: [rawSource], typeDefs, resolvers }: MeshMergerContext) {
+  handleSingleRegularSource({ rawSources: [rawSource], typeDefs, resolvers }: MeshMergerContext) {
     let schema = rawSource.schema;
     if (typeDefs.length > 0 || asArray(resolvers).length > 0) {
       for (const typeDef of typeDefs) {
@@ -79,10 +78,13 @@ export default class BareMerger implements MeshMerger {
 
   async getUnifiedSchema({ rawSources, typeDefs, resolvers }: MeshMergerContext) {
     if (rawSources.length === 1) {
-      if (rawSources[0].executor || rawSources[0].transforms?.length) {
-        return this.handleSingleWrappedSource({ rawSources, typeDefs, resolvers });
+      if (
+        (rawSources[0].executor || rawSources[0].transforms?.length) &&
+        (typeDefs.length > 0 || asArray(resolvers).length > 0)
+      ) {
+        return this.handleSingleWrappedExtendedSource({ rawSources, typeDefs, resolvers });
       }
-      return this.handleSingleBareSource({ rawSources, typeDefs, resolvers });
+      return this.handleSingleRegularSource({ rawSources, typeDefs, resolvers });
     }
     const sourceMap = new Map<RawSourceOutput, GraphQLSchema>();
     this.logger.debug(`Applying transforms for each source`);


### PR DESCRIPTION
Related https://github.com/graphprotocol/graph-client/issues/167