### PR TITLE
Add more verbose logging for healJSONSchema and better debug details view in field descriptions

### DIFF
--- a/.changeset/json-machete-dependencies.md
+++ b/.changeset/json-machete-dependencies.md
@@ -1,0 +1,7 @@
+---
+"json-machete": patch
+---
+
+### Dependencies Updates
+
+- Added dependency ([`@graphql-mesh/types@0.78.6` ↗︎](https://www.npmjs.com/package/@graphql-mesh/types/v/0.78.6)) (to `dependencies`)

--- a/.changeset/sour-cougars-relate.md
+++ b/.changeset/sour-cougars-relate.md
@@ -3,6 +3,11 @@
 "@omnigraph/json-schema": minor
 ---
 
+## New debug logging for `healJSONSchema`
 JSON Schema loader tries to fix your JSON Schema while creating a final bundle for Mesh. Usually it works and it has a chance to have a different result rather than you expect. In the long term, if you don't fix your JSON Schema, you might get different results once the internals of `healJSONSchema` is changed.
 
-In order to see which parts of your schema need to be fixed, you can enable the debug mode with `DEBUG=1` environment variable.
+In order to see which parts of your schema need to be fixed, you can enable the debug mode with `DEBUG=healJSONSchema` environment variable.
+
+## New debug details in the field descriptions with `DEBUG=fieldDetails`
+Now you can see which operation has which HTTP request details in the field description with the new debug mode.
+![image](https://user-images.githubusercontent.com/20847995/182913565-a9d9c521-519b-4d57-88a9-13ea3edab96a.png)

--- a/.changeset/sour-cougars-relate.md
+++ b/.changeset/sour-cougars-relate.md
@@ -1,0 +1,8 @@
+---
+"json-machete": minor
+"@omnigraph/json-schema": minor
+---
+
+JSON Schema loader tries to fix your JSON Schema while creating a final bundle for Mesh. Usually it works and it has a chance to have a different result rather than you expect. In the long term, if you don't fix your JSON Schema, you might get different results once the internals of `healJSONSchema` is changed.
+
+In order to see which parts of your schema need to be fixed, you can enable the debug mode with `DEBUG=1` environment variable.

--- a/packages/json-machete/package.json
+++ b/packages/json-machete/package.json
@@ -28,6 +28,7 @@
     "@json-schema-tools/meta-schema": "1.6.19",
     "@whatwg-node/fetch": "^0.2.7",
     "json-pointer": "0.6.2",
+    "@graphql-mesh/types": "0.78.6",
     "@graphql-mesh/utils": "0.37.7",
     "@graphql-mesh/cross-helpers": "0.2.0",
     "@graphql-tools/utils": "8.9.0",

--- a/packages/json-machete/src/dereferenceObject.ts
+++ b/packages/json-machete/src/dereferenceObject.ts
@@ -93,9 +93,7 @@ export async function dereferenceObject<T extends object, TRoot = T>(
       if (refMap.has($ref)) {
         return refMap.get($ref);
       } else {
-        if (process.env.DEBUG) {
-          console.log(`Dereferencing `, obj);
-        }
+        logger.debug(`Resolving ${$ref}`);
         const [externalRelativeFilePath, refPath] = $ref.split('#');
         if (externalRelativeFilePath) {
           const externalFilePath = getAbsolutePath(externalRelativeFilePath, cwd);

--- a/packages/json-machete/src/healJSONSchema.ts
+++ b/packages/json-machete/src/healJSONSchema.ts
@@ -1,4 +1,3 @@
-import { process } from '@graphql-mesh/cross-helpers';
 import { JSONSchema, JSONSchemaObject } from './types';
 import { visitJSONSchema } from './visitJSONSchema';
 import toJsonSchema from 'to-json-schema';
@@ -152,14 +151,15 @@ async function getDeduplicatedTitles(schema: JSONSchema): Promise<Set<string>> {
 }
 export async function healJSONSchema(
   schema: JSONSchema,
-  options: { noDeduplication?: boolean } = {}
+  {
+    noDeduplication = false,
+    logger = console,
+  }: { noDeduplication?: boolean; logger?: { debug(msg: string): void } } = {}
 ): Promise<JSONSchema> {
   let readySchema = schema;
-  if (!options?.noDeduplication) {
+  if (!noDeduplication) {
     const schemaWithoutResolvedRefAndTitles = removeTitlesAndResolvedRefs(schema);
-    const deduplicatedSchemaWithoutResolvedRefAndTitles = options?.noDeduplication
-      ? schema
-      : deduplicateJSONSchema(schemaWithoutResolvedRefAndTitles);
+    const deduplicatedSchemaWithoutResolvedRefAndTitles = deduplicateJSONSchema(schemaWithoutResolvedRefAndTitles);
     const deduplicatedSchema = addTitlesAndResolvedRefs(deduplicatedSchemaWithoutResolvedRefAndTitles);
     readySchema = deduplicatedSchema;
   }
@@ -169,14 +169,13 @@ export async function healJSONSchema(
     {
       enter: async function healSubschema(subSchema, { path }) {
         if (typeof subSchema === 'object') {
-          if (process.env.DEBUG) {
-            console.log(`Healing ${path}`);
-          }
+          logger.debug(`Healing ${path}`);
           // We don't support following properties
           delete subSchema.readOnly;
           delete subSchema.writeOnly;
           const keys = Object.keys(subSchema);
           if (keys.length === 0) {
+            logger.debug(`${path} has an empty definition. Adding an object definition.`);
             subSchema.type = 'object';
             subSchema.additionalProperties = true;
           }
@@ -184,20 +183,26 @@ export async function healJSONSchema(
             delete subSchema.additionalProperties.readOnly;
             delete subSchema.additionalProperties.writeOnly;
             if (Object.keys(subSchema.additionalProperties).length === 0) {
+              logger.debug(
+                `${path} has an empty additionalProperties object. So this is invalid. Replacing it with 'true'`
+              );
               subSchema.additionalProperties = true;
             }
           }
           if (subSchema.allOf != null && subSchema.allOf.length === 1 && !subSchema.properties) {
+            logger.debug(`${path} has an "allOf" definition with only one element. Removing it.`);
             const realSubschema = subSchema.allOf[0];
             delete subSchema.allOf;
             return realSubschema;
           }
           if (subSchema.anyOf != null && subSchema.anyOf.length === 1 && !subSchema.properties) {
+            logger.debug(`${path} has an "anyOf" definition with only one element. Removing it.`);
             const realSubschema = subSchema.anyOf[0];
             delete subSchema.anyOf;
             return realSubschema;
           }
-          if (subSchema.oneOf != null && subSchema.oneOf.length === 1) {
+          if (subSchema.oneOf != null && subSchema.oneOf.length === 1 && !subSchema.properties) {
+            logger.debug(`${path} has an "oneOf" definition with only one element. Removing it.`);
             const realSubschema = subSchema.oneOf[0];
             delete subSchema.oneOf;
             return realSubschema;
@@ -205,29 +210,40 @@ export async function healJSONSchema(
           if (subSchema.description != null) {
             subSchema.description = subSchema.description.trim();
             if (keys.length === 1) {
+              logger.debug(`${path} has a description definition but has nothing else. Adding an object definition.`);
               subSchema.type = 'object';
               subSchema.additionalProperties = true;
             }
           }
           // Some JSON Schemas use this broken pattern and refer the type using `items`
           if (subSchema.type === 'object' && subSchema.items) {
+            logger.debug(
+              `${path} has an object definition but with "items" which is not valid. So setting "items" to the actual definition.`
+            );
             const realSubschema = subSchema.items;
             delete subSchema.items;
             return realSubschema;
           }
           if (subSchema.properties && subSchema.type !== 'object') {
+            logger.debug(`${path} has "properties" with no type defined. Adding a type property with "object" value.`);
             subSchema.type = 'object';
           }
           if (duplicatedTypeNames.has(subSchema.title)) {
+            logger.debug(`${path} has a duplicated title definition. Removing it.`);
             delete subSchema.title;
           }
           if (typeof subSchema.example === 'object' && !subSchema.type) {
+            logger.debug(`${path} has an example object but no type defined. Setting type to "object".`);
             subSchema.type = 'object';
           }
           // Try to find the type
           if (!subSchema.type) {
+            logger.debug(`${path} has no type defined. Trying to find it.`);
             // If required exists without properties
             if (subSchema.required && !subSchema.properties && !subSchema.anyOf && !subSchema.allOf) {
+              logger.debug(
+                `${path} has a required definition but no properties or oneOf/allOf. Setting missing properties with Any schema.`
+              );
               // Add properties
               subSchema.properties = {};
               for (const missingPropertyName of subSchema.required) {
@@ -236,16 +252,24 @@ export async function healJSONSchema(
             }
             // Properties only exist in objects
             if (subSchema.properties || subSchema.patternProperties || 'additionalProperties' in subSchema) {
+              logger.debug(
+                `${path} has properties or patternProperties or additionalProperties. Setting type to "object".`
+              );
               subSchema.type = 'object';
             }
             // Items only exist in arrays
             if (subSchema.items) {
+              logger.debug(`${path} has an items definition but no type defined. Setting type to "array".`);
               subSchema.type = 'array';
               // Items should be an object
               if (Array.isArray(subSchema.items)) {
                 if (subSchema.items.length === 0) {
+                  logger.debug(`${path} has an items array with a single value. Setting items to an object.`);
                   subSchema.items = subSchema.items[0];
                 } else {
+                  logger.debug(
+                    `${path} has an items array with multiple values. Setting items to an object with oneOf definition.`
+                  );
                   subSchema.items = {
                     oneOf: subSchema.items,
                   };
@@ -255,10 +279,12 @@ export async function healJSONSchema(
             switch (subSchema.format) {
               case 'int64':
               case 'int32':
+                logger.debug(`${path} has a format of ${subSchema.format}. Setting type to "integer".`);
                 subSchema.type = 'integer';
                 break;
               default:
                 if (subSchema.format != null) {
+                  logger.debug(`${path} has a format of ${subSchema.format}. Setting type to "string".`);
                   subSchema.type = 'string';
                 }
             }
@@ -268,20 +294,28 @@ export async function healJSONSchema(
             if (examples?.length) {
               const { format } = toJsonSchema(examples[0]);
               if (format) {
+                logger.debug(`${path} has a format of ${format} according to the example. Setting type to "string".`);
                 subSchema.format = format;
               }
             }
           }
           if (subSchema.format === 'dateTime') {
+            logger.debug(`${path} has a format of dateTime. It should be "date-time".`);
             subSchema.format = 'date-time';
           }
           if (subSchema.type === 'string' && subSchema.format) {
             if (!JSONSchemaStringFormats.includes(subSchema.format)) {
+              logger.debug(
+                `${path} has a format of ${subSchema.format}. It should be one of ${JSONSchemaStringFormats.join(
+                  ', '
+                )}.`
+              );
               delete subSchema.format;
             }
           }
           if (subSchema.required) {
             if (!Array.isArray(subSchema.required)) {
+              logger.debug(`${path} has a required definition but it is not an array. Removing it.`);
               delete subSchema.required;
             }
           }
@@ -299,10 +333,14 @@ export async function healJSONSchema(
                 mode: 'first',
               },
             });
-            const healedGeneratedSchema: any = await healJSONSchema(generatedSchema as any, options);
+            const healedGeneratedSchema: any = await healJSONSchema(generatedSchema as any, {
+              noDeduplication,
+              logger,
+            });
             subSchema.type = asArray(healedGeneratedSchema.type)[0] as any;
             subSchema.properties = healedGeneratedSchema.properties;
             // If type for properties is already given, use it
+            logger.debug(`${path} has an example but no type defined. Setting type to ${subSchema.type}.`);
             if (typeof subSchema.additionalProperties === 'object') {
               for (const propertyName in subSchema.properties) {
                 subSchema.properties[propertyName] = subSchema.additionalProperties;
@@ -331,6 +369,9 @@ export async function healJSONSchema(
               case 'string':
                 // If it has special pattern, use path based name because it is specific
                 if (subSchema.pattern || subSchema.maxLength || subSchema.minLength || subSchema.enum) {
+                  logger.debug(
+                    `${path} has a pattern or maxLength or minLength or enum but no title. Setting it to ${pathBasedName}`
+                  );
                   subSchema.title = pathBasedName;
                   // Otherwise use the format name
                 }
@@ -338,6 +379,7 @@ export async function healJSONSchema(
               case 'number':
               case 'integer':
                 if (subSchema.enum || subSchema.pattern) {
+                  logger.debug(`${path} has an enum or pattern but no title. Setting it to ${pathBasedName}`);
                   subSchema.title = pathBasedName;
                   // Otherwise use the format name
                 }
@@ -347,22 +389,29 @@ export async function healJSONSchema(
               case 'boolean':
                 // pattern is unnecessary for boolean
                 if (subSchema.pattern) {
+                  logger.debug(`${path} has a pattern for a boolean type. Removing it.`);
                   delete subSchema.pattern;
                 }
                 // enum is unnecessary for boolean
                 if (subSchema.enum) {
+                  logger.debug(`${path} is an enum but a boolean type. Removing it.`);
                   delete subSchema.enum;
                 }
                 break;
               default:
+                logger.debug(`${path} has no title. Setting it to ${pathBasedName}`);
                 subSchema.title = subSchema.title || pathBasedName;
             }
             // If type name is reserved, add a suffix
             if (reservedTypeNames.includes(pathBasedName)) {
+              logger.debug(`${path} has a title of ${pathBasedName}. It is a reserved type name. Adding a suffix.`);
               pathBasedName += '_';
             }
           }
           if (subSchema.type === 'object' && subSchema.properties && Object.keys(subSchema.properties).length === 0) {
+            logger.debug(
+              `${path} has an empty properties object. Removing it and adding "additionalProperties": true.`
+            );
             delete subSchema.properties;
             subSchema.additionalProperties = true;
           }

--- a/packages/loaders/json-schema/src/addExecutionLogicToComposer.ts
+++ b/packages/loaders/json-schema/src/addExecutionLogicToComposer.ts
@@ -133,12 +133,12 @@ export async function addExecutionLogicToComposer(
       };
       interpolationStrings.push(operationConfig.pubsubTopic);
     } else if (operationConfig.path) {
-      if (process.env.DEBUG) {
+      if (process.env.DEBUG === '1' || process.env.DEBUG === 'fieldDetails') {
         field.description = `
-    ***Original Description***: ${operationConfig.description || '(none)'}
-    ***Method***: ${operationConfig.method}
-    ***Base URL***: ${baseUrl}
-    ***Path***: ${operationConfig.path}
+>**Method**: \`${operationConfig.method}\`
+>**Base URL**: \`${baseUrl}\`
+>**Path**: \`${operationConfig.path}\`
+${operationConfig.description || ''}
 `;
       } else {
         field.description = operationConfig.description;

--- a/packages/loaders/json-schema/src/getComposerFromJSONSchema.ts
+++ b/packages/loaders/json-schema/src/getComposerFromJSONSchema.ts
@@ -90,7 +90,6 @@ export function getComposerFromJSONSchema(schema: JSONSchema, logger: Logger): P
 
   return visitJSONSchema(schema, {
     enter(subSchema: JSONSchema, { path, visitedSubschemaResultMap }) {
-      logger?.debug(`Entering ${path} for GraphQL Schema`);
       if (typeof subSchema === 'boolean') {
         const typeComposer = schemaComposer.getAnyTC(GraphQLJSON);
         return subSchema
@@ -541,7 +540,6 @@ export function getComposerFromJSONSchema(schema: JSONSchema, logger: Logger): P
       return subSchema;
     },
     leave(subSchemaAndTypeComposers: JSONSchemaObject & TypeComposers, { path }) {
-      logger?.debug(`Leaving ${path} for GraphQL Schema`);
       const validateWithJSONSchema = getValidateFnForSchemaPath(ajv, path, schema);
       const subSchemaOnly: JSONSchemaObject = {
         ...subSchemaAndTypeComposers,

--- a/packages/loaders/json-schema/src/getComposerFromJSONSchema.ts
+++ b/packages/loaders/json-schema/src/getComposerFromJSONSchema.ts
@@ -911,7 +911,7 @@ export function getComposerFromJSONSchema(schema: JSONSchema, logger: Logger): P
           nullable: subSchemaAndTypeComposers.nullable,
         };
       } else {
-        logger.warn(`GraphQL Type cannot be created for this JSON Schema definition;`, {
+        logger.debug(`GraphQL Type cannot be created for this JSON Schema definition;`, {
           subSchema: subSchemaOnly,
           path,
         });

--- a/packages/loaders/json-schema/src/getDereferencedJSONSchemaFromOperations.ts
+++ b/packages/loaders/json-schema/src/getDereferencedJSONSchemaFromOperations.ts
@@ -34,10 +34,13 @@ export async function getDereferencedJSONSchemaFromOperations({
   const fullyDeferencedSchema = await dereferenceObject(referencedJSONSchema, {
     cwd,
     fetchFn,
-    logger,
+    logger: logger.child('dereferenceObject'),
     headers: schemaHeadersFactory({ env: process.env }),
   });
   logger.debug(`Healing JSON Schema`);
-  const healedSchema = await healJSONSchema(fullyDeferencedSchema, { noDeduplication, logger });
+  const healedSchema = await healJSONSchema(fullyDeferencedSchema, {
+    noDeduplication,
+    logger: logger.child('healJSONSchema'),
+  });
   return healedSchema as JSONSchemaObject;
 }

--- a/packages/loaders/json-schema/src/getDereferencedJSONSchemaFromOperations.ts
+++ b/packages/loaders/json-schema/src/getDereferencedJSONSchemaFromOperations.ts
@@ -38,6 +38,6 @@ export async function getDereferencedJSONSchemaFromOperations({
     headers: schemaHeadersFactory({ env: process.env }),
   });
   logger.debug(`Healing JSON Schema`);
-  const healedSchema = await healJSONSchema(fullyDeferencedSchema, { noDeduplication });
+  const healedSchema = await healJSONSchema(fullyDeferencedSchema, { noDeduplication, logger });
   return healedSchema as JSONSchemaObject;
 }

--- a/packages/loaders/json-schema/src/getGraphQLSchemaFromDereferencedJSONSchema.ts
+++ b/packages/loaders/json-schema/src/getGraphQLSchemaFromDereferencedJSONSchema.ts
@@ -18,7 +18,10 @@ export async function getGraphQLSchemaFromDereferencedJSONSchema(
   }: AddExecutionLogicToComposerOptions
 ) {
   logger.debug(`Generating GraphQL Schema from the bundled JSON Schema`);
-  const visitorResult = await getComposerFromJSONSchema(fullyDeferencedSchema, logger);
+  const visitorResult = await getComposerFromJSONSchema(
+    fullyDeferencedSchema,
+    logger.child('getComposerFromJSONSchema')
+  );
 
   const schemaComposerWithoutExecutionLogic = visitorResult.output;
 

--- a/packages/loaders/openapi/src/getJSONSchemaOptionsFromOpenAPIOptions.ts
+++ b/packages/loaders/openapi/src/getJSONSchemaOptionsFromOpenAPIOptions.ts
@@ -290,11 +290,9 @@ export async function getJSONSchemaOptionsFromOpenAPIOptions({
             if ('operationRef' in linkObj) {
               const [externalPath, ref] = linkObj.operationRef.split('#');
               if (externalPath) {
-                if (process.env.DEBUG) {
-                  console.warn(
-                    `Skipping external operation reference ${linkObj.operationRef}\n Use additionalTypeDefs and additionalResolvers instead.`
-                  );
-                }
+                logger.debug(
+                  `Skipping external operation reference ${linkObj.operationRef}\n Use additionalTypeDefs and additionalResolvers instead.`
+                );
               } else {
                 const actualOperation = resolvePath(ref, oasOrSwagger);
                 if (actualOperation.operationId) {

--- a/packages/types/src/config-schema.json
+++ b/packages/types/src/config-schema.json
@@ -1868,6 +1868,9 @@
               "additionalItems": true
             }
           ]
+        },
+        "noDeduplication": {
+          "type": "boolean"
         }
       },
       "required": ["oasFilePath"]

--- a/packages/types/src/config.ts
+++ b/packages/types/src/config.ts
@@ -819,6 +819,7 @@ export interface NewOpenapiHandler {
   ignoreErrorResponses?: boolean;
   selectQueryOrMutationField?: OASSelectQueryOrMutationFieldConfig[];
   queryParams?: any;
+  noDeduplication?: boolean;
 }
 export interface OASSelectQueryOrMutationFieldConfig {
   /**


### PR DESCRIPTION
## New debug logging for `healJSONSchema`
JSON Schema loader tries to fix your JSON Schema while creating a final bundle for Mesh. Usually it works and it has a chance to have a different result rather than you expect. In the long term, if you don't fix your JSON Schema, you might get different results once the internals of `healJSONSchema` is changed.

In order to see which parts of your schema need to be fixed, you can enable the debug mode with `DEBUG=healJSONSchema` environment variable.

## New debug details in the field descriptions with `DEBUG=fieldDetails`
Now you can see which operation has which HTTP request details in the field description with the new debug mode.
![image](https://user-images.githubusercontent.com/20847995/182913565-a9d9c521-519b-4d57-88a9-13ea3edab96a.png)