### PR TITLE
fix(cli): WebSocket clients mustn't provide `connectionParams`

### DIFF
--- a/.changeset/yellow-laws-behave.md
+++ b/.changeset/yellow-laws-behave.md
@@ -1,0 +1,5 @@
+---
+"@graphql-mesh/cli": patch
+---
+
+WebSocket clients mustn't provide `connectionParams`

--- a/packages/cli/src/commands/serve/serve.ts
+++ b/packages/cli/src/commands/serve/serve.ts
@@ -170,7 +170,7 @@ export async function serveMesh(
           // spread connectionParams.headers to upgrade request headers.
           // we completely ignore the root connectionParams because
           // [@graphql-tools/url-loader adds the headers inside the "headers" field](https://github.com/ardatan/graphql-tools/blob/9a13357c4be98038c645f6efb26f0584828177cf/packages/loaders/url/src/index.ts#L597)
-          for (const [key, value] of Object.entries(connectionParams.headers ?? {})) {
+          for (const [key, value] of Object.entries(connectionParams?.headers ?? {})) {
             // dont overwrite existing upgrade headers due to security reasons
             if (!(key.toLowerCase() in request.headers)) {
               request.headers[key.toLowerCase()] = value;

--- a/packages/handlers/json-schema/CHANGELOG.md
+++ b/packages/handlers/json-schema/CHANGELOG.md
@@ -16,11 +16,11 @@
 
   ```ts
   export default function myOperationHeaders({ context }: ResolverData) {
-    const someToken = context.request.headers.get("some-token");
-    const anotherToken = await someLogicThatReturnsAnotherToken(someToken);
+    const someToken = context.request.headers.get('some-token')
+    const anotherToken = await someLogicThatReturnsAnotherToken(someToken)
     return {
-      "x-bar-token": anotherToken
-    };
+      'x-bar-token': anotherToken
+    }
   }
   ```
 

--- a/packages/handlers/new-openapi/CHANGELOG.md
+++ b/packages/handlers/new-openapi/CHANGELOG.md
@@ -16,11 +16,11 @@
 
   ```ts
   export default function myOperationHeaders({ context }: ResolverData) {
-    const someToken = context.request.headers.get("some-token");
-    const anotherToken = await someLogicThatReturnsAnotherToken(someToken);
+    const someToken = context.request.headers.get('some-token')
+    const anotherToken = await someLogicThatReturnsAnotherToken(someToken)
     return {
-      "x-bar-token": anotherToken
-    };
+      'x-bar-token': anotherToken
+    }
   }
   ```
 

--- a/packages/loaders/json-schema/CHANGELOG.md
+++ b/packages/loaders/json-schema/CHANGELOG.md
@@ -18,11 +18,11 @@
 
   ```ts
   export default function myOperationHeaders({ context }: ResolverData) {
-    const someToken = context.request.headers.get("some-token");
-    const anotherToken = await someLogicThatReturnsAnotherToken(someToken);
+    const someToken = context.request.headers.get('some-token')
+    const anotherToken = await someLogicThatReturnsAnotherToken(someToken)
     return {
-      "x-bar-token": anotherToken
-    };
+      'x-bar-token': anotherToken
+    }
   }
   ```
 

--- a/packages/loaders/openapi/CHANGELOG.md
+++ b/packages/loaders/openapi/CHANGELOG.md
@@ -18,11 +18,11 @@
 
   ```ts
   export default function myOperationHeaders({ context }: ResolverData) {
-    const someToken = context.request.headers.get("some-token");
-    const anotherToken = await someLogicThatReturnsAnotherToken(someToken);
+    const someToken = context.request.headers.get('some-token')
+    const anotherToken = await someLogicThatReturnsAnotherToken(someToken)
     return {
-      "x-bar-token": anotherToken
-    };
+      'x-bar-token': anotherToken
+    }
   }
   ```
 


### PR DESCRIPTION
## Description

Mesh server will fail with `TypeError: Cannot read properties of undefined (reading 'headers')` if WebSocket clients don't provide any `connectionParams` at this location:

https://github.com/Urigo/graphql-mesh/blob/a134d17deba62db438d68f1ee81ef4adbcf32691/packages/cli/src/commands/serve/serve.ts#L173

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Start any Mesh server, connect to it using [GraphiQL with WebSockets only](https://gist.github.com/enisdenjo/a68312878fdc4df299cb0433c60c1dea).

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] ~I have commented my code, particularly in hard-to-understand areas~
- [ ] ~I have made corresponding changes to the documentation~
- [ ] ~My changes generate no new warnings~
- [ ] ~I have added tests that prove my fix is effective or that my feature works~
- [x] New and existing unit tests and linter rules pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

## Further comments

The weirdest thing is: why are the `connectionParams` not considered optional ([because they really are](https://github.com/enisdenjo/graphql-ws/blob/1a79552690ed1d07482585327b03613571537612/src/common.ts#L101) and [here too](https://github.com/enisdenjo/graphql-ws/blob/1a79552690ed1d07482585327b03613571537612/src/server.ts#L502))?