### PR TITLE
fix(cli): WebSocket request must be under `req` for envelop context

### DIFF
--- a/.changeset/young-owls-own.md
+++ b/.changeset/young-owls-own.md
@@ -1,0 +1,5 @@
+---
+"@graphql-mesh/cli": patch
+---
+
+WebSocket request must be under `req` for envelop context

--- a/packages/cli/src/commands/serve/serve.ts
+++ b/packages/cli/src/commands/serve/serve.ts
@@ -177,7 +177,10 @@ export async function serveMesh(
             }
           }
           const { getEnveloped } = await mesh$;
-          const { schema, execute, subscribe, contextFactory, parse, validate } = getEnveloped(request);
+          const { schema, execute, subscribe, contextFactory, parse, validate } = getEnveloped({
+            // req object holds the Node request used for extracting the headers (see packages/runtime/src/get-mesh.ts)
+            req: request,
+          });
 
           const args = {
             schema,


### PR DESCRIPTION
## Description

In order to correctly assemble request headers and inject the ones from WebSocket, the request must be in the Node-like `req` object for envelop context factory.

https://github.com/Urigo/graphql-mesh/blob/79ade1b7fb8b72a4185fbd06438a44ed3fb4bd36/packages/runtime/src/get-mesh.ts#L143-L157

Fixes #4040

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Manually.