### PR TITLE
chore: add licence field (MIT) in string-interpolation package.json

### DIFF
--- a/.changeset/six-dots-breathe.md
+++ b/.changeset/six-dots-breathe.md
@@ -1,0 +1,5 @@
+---
+"@graphql-mesh/string-interpolation": patch
+---
+
+Add MIT licence field in package.json

--- a/packages/string-interpolation/package.json
+++ b/packages/string-interpolation/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@graphql-mesh/string-interpolation",
   "version": "0.3.1",
+  "license": "MIT",
   "description": "Dynamic string manipulation",
   "sideEffects": false,
   "main": "dist/index.js",


### PR DESCRIPTION
🚨 **IMPORTANT: Please do not create a Pull Request without creating an issue first.**

_Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request._

## Description

A missing licence field in the string-interpolation package.

Fixes https://github.com/Urigo/graphql-mesh/issues/4309

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots/Sandbox (if appropriate/relevant):

![image](https://user-images.githubusercontent.com/259798/184897155-9da38081-66ec-4016-99cc-c1f27ef7b40c.png)


## How Has This Been Tested?

None

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests and linter rules pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

