### PR TITLE
fix(json-schema): do not ignore operationHeaders defined in the config even if they are defined in the bundle

### DIFF
--- a/.changeset/six-parents-search.md
+++ b/.changeset/six-parents-search.md
@@ -1,0 +1,5 @@
+---
+"@omnigraph/json-schema": patch
+---
+
+Do not ignore operationHeaders defined in the configuration even if there are some already defined in the bundle

--- a/packages/loaders/json-schema/src/bundle.ts
+++ b/packages/loaders/json-schema/src/bundle.ts
@@ -118,6 +118,11 @@ export async function getGraphQLSchemaFromBundle(
         ...result,
       };
     };
+  } else {
+    operationHeaders = {
+      ...bundledOperationHeaders,
+      ...additionalOperationHeaders,
+    };
   }
   logger.info(`Creating the GraphQL Schema from dereferenced schema`);
   return getGraphQLSchemaFromDereferencedJSONSchema(fullyDeferencedSchema, {


### PR DESCRIPTION
When a bundle from a CDN or somewhere else is used as an input instead of locally built artifacts, `operationHeaders` from the actual configuration file was ignored.
This PR fixes this issue.