### PR TITLE
docs(transforms:federation): `external` should be nested in `config:`

### DIFF
--- a/website/src/pages/docs/transforms/federation.mdx
+++ b/website/src/pages/docs/transforms/federation.mdx
@@ -28,7 +28,8 @@ transforms:
             fields:
               # id: Int! @external
               - name: id
-                external: true
+                config:
+                  external: true
             resolveReference:
               queryFieldName: user
 ```


### PR DESCRIPTION
I hope I can skip the PR template and creating an issue for such a small change :) If not, let me know.

 `external` should be nested in `config:`, not shown on the top level

See https://github.com/Urigo/graphql-mesh/blob/master/packages/transforms/federation/yaml-config.graphql#L11

<img width="776" alt="image" src="https://user-images.githubusercontent.com/5359825/186707919-24f804fd-f202-4fc8-bbae-7d095ff8d1ea.png">

<img width="797" alt="image" src="https://user-images.githubusercontent.com/5359825/186707974-dd560fe5-17e6-4fad-9764-59183497a501.png">
