### PR TITLE
Introduce 'bare' mode on naming-convention transform

### DIFF
--- a/.changeset/cyan-beans-bake.md
+++ b/.changeset/cyan-beans-bake.md
@@ -1,0 +1,6 @@
+---
+'@graphql-mesh/transform-naming-convention': minor
+'@graphql-mesh/types': minor
+---
+
+Introduce 'bare' mode on naming-convention transform

--- a/packages/transforms/naming-convention/package.json
+++ b/packages/transforms/naming-convention/package.json
@@ -27,17 +27,21 @@
   "peerDependencies": {
     "graphql": "*"
   },
+  "devDependencies": {
+    "@graphql-mesh/cache-localforage": "^0.6.35",
+    "@graphql-tools/schema": "9.0.3"
+  },
   "dependencies": {
     "@graphql-mesh/types": "0.83.5",
     "@graphql-mesh/utils": "0.41.10",
-    "@graphql-tools/wrap": "9.2.1",
     "@graphql-tools/delegate": "9.0.6",
     "@graphql-tools/utils": "8.12.0",
+    "@graphql-tools/wrap": "9.2.1",
     "change-case": "4.1.2",
-    "upper-case": "2.0.2",
-    "lower-case": "2.0.2",
     "graphql-scalars": "1.18.0",
-    "tslib": "^2.4.0"
+    "lower-case": "2.0.2",
+    "tslib": "2.4.0",
+    "upper-case": "2.0.2"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/transforms/naming-convention/src/bareNamingConvention.ts
+++ b/packages/transforms/naming-convention/src/bareNamingConvention.ts
@@ -1,0 +1,184 @@
+import { defaultFieldResolver, GraphQLInputObjectType, GraphQLSchema, isInputObjectType, isEnumType } from 'graphql';
+import { MeshTransform, YamlConfig, MeshTransformOptions } from '@graphql-mesh/types';
+import { MapperKind, mapSchema, renameType } from '@graphql-tools/utils';
+
+import { NAMING_CONVENTIONS, IGNORED_ROOT_FIELD_NAMES, IGNORED_TYPE_NAMES } from './shared';
+
+const isObject = (input: any) => typeof input === 'object' && input !== null && !Array.isArray(input) && true;
+
+// Resolver composer mapping renamed field and arguments
+const defaultResolverComposer =
+  (
+    resolveFn = defaultFieldResolver,
+    originalFieldName: string,
+    argsMap: { [key: string]: string },
+    resultMap: { [key: string]: string }
+  ) =>
+  (root: any, args: any, context: any, info: any) => {
+    const originalResult = resolveFn(
+      root,
+      // map renamed arguments to their original value
+      argsMap
+        ? Object.keys(args).reduce((acc, key: string) => {
+            if (!argsMap[key]) {
+              return { ...acc, [key]: args[key] };
+            }
+
+            const argKey = argsMap[key];
+            const mappedArgKeyIsObject = isObject(argKey);
+            const newArgName = Object.keys(argKey)[0];
+
+            return {
+              ...acc,
+              [mappedArgKeyIsObject ? newArgName : argKey]: mappedArgKeyIsObject
+                ? Object.entries(args[key]).reduce((acc, [key, value]) => {
+                    const oldInputFieldName = argKey[newArgName][key];
+                    return { ...acc, [oldInputFieldName || key]: value };
+                  }, {})
+                : args[key],
+            };
+          }, {})
+        : args,
+      context,
+      // map renamed field name to its original value
+      originalFieldName ? { ...info, fieldName: originalFieldName } : info
+    );
+
+    // map result values from original value to new renamed value
+    return (resultMap && resultMap[originalResult as string]) || originalResult;
+  };
+
+export default class NamingConventionTransform implements MeshTransform {
+  noWrap = true;
+  config: Omit<YamlConfig.NamingConventionTransformConfig, 'mode'>;
+
+  constructor(options: MeshTransformOptions<YamlConfig.NamingConventionTransformConfig>) {
+    this.config = { ...options.config };
+  }
+
+  transformSchema(schema: GraphQLSchema) {
+    return mapSchema(schema, {
+      ...(this.config.typeNames && {
+        [MapperKind.TYPE]: type => {
+          const oldName = type.name;
+          const namingConventionFn = NAMING_CONVENTIONS[this.config.typeNames];
+          const newName = IGNORED_TYPE_NAMES.includes(oldName) ? oldName : namingConventionFn(oldName);
+
+          if (newName !== undefined && newName !== oldName) {
+            return renameType(type, newName);
+          }
+
+          return undefined;
+        },
+      }),
+      ...(this.config.enumValues && {
+        [MapperKind.ENUM_VALUE]: (valueConfig, _typeName, _schema, externalValue) => {
+          const namingConventionFn = NAMING_CONVENTIONS[this.config.enumValues];
+          const newEnumValue = namingConventionFn(externalValue);
+
+          if (newEnumValue === externalValue) {
+            return undefined;
+          }
+
+          return [
+            newEnumValue,
+            {
+              ...valueConfig,
+              value: newEnumValue,
+              astNode: {
+                ...valueConfig.astNode,
+                name: {
+                  ...valueConfig.astNode.name,
+                  value: newEnumValue,
+                },
+              },
+            },
+          ];
+        },
+      }),
+      ...((this.config.fieldNames || this.config.fieldArgumentNames) && {
+        [MapperKind.COMPOSITE_FIELD]: (fieldConfig, fieldName) => {
+          const enumNamingConventionFn = NAMING_CONVENTIONS[this.config.enumValues];
+          const fieldNamingConventionFn = this.config.fieldNames && NAMING_CONVENTIONS[this.config.fieldNames];
+          const argNamingConventionFn =
+            this.config.fieldArgumentNames && NAMING_CONVENTIONS[this.config.fieldArgumentNames];
+          const argsMap = fieldConfig.args && {};
+          const newFieldName =
+            this.config.fieldNames &&
+            !IGNORED_ROOT_FIELD_NAMES.includes(fieldName) &&
+            fieldNamingConventionFn(fieldName);
+          const resultMap =
+            this.config.enumValues &&
+            isEnumType(fieldConfig.type) &&
+            Object.keys(fieldConfig.type.toConfig().values).reduce((map, value) => {
+              if (Number.isFinite(value)) {
+                return map;
+              }
+
+              const newValue = enumNamingConventionFn(value as string);
+              return newValue === value
+                ? map
+                : {
+                    ...map,
+                    [value]: newValue,
+                  };
+            }, {});
+
+          if (fieldConfig.args) {
+            fieldConfig.args = Object.entries(fieldConfig.args).reduce((args, [argName, argConfig]) => {
+              const newArgName = this.config.fieldArgumentNames && argNamingConventionFn(argName);
+              const useArgName = newArgName || argName;
+              const argIsInputObjectType = isInputObjectType(argConfig.type);
+
+              if (argName === newArgName && !argIsInputObjectType) {
+                return args;
+              }
+
+              // take advantage of the loop to map arg name from Old to New
+              argsMap[useArgName] = !argIsInputObjectType
+                ? argName
+                : {
+                    [argName]: Object.keys((argConfig.type as GraphQLInputObjectType).toConfig().fields).reduce(
+                      (inputFields, inputFieldName) => {
+                        if (Number.isFinite(inputFieldName)) return inputFields;
+
+                        const newInputFieldName = fieldNamingConventionFn(inputFieldName as string);
+                        return newInputFieldName === inputFieldName
+                          ? inputFields
+                          : {
+                              ...inputFields,
+                              [fieldNamingConventionFn(inputFieldName as string)]: inputFieldName,
+                            };
+                      },
+                      {}
+                    ),
+                  };
+
+              return {
+                ...args,
+                [useArgName]: argConfig,
+              };
+            }, {});
+          }
+
+          // Wrap resolve fn to handle mapping renamed field and argument names as well as results (for enums)
+          fieldConfig.resolve = defaultResolverComposer(fieldConfig.resolve, fieldName, argsMap, resultMap);
+
+          return [newFieldName || fieldName, fieldConfig];
+        },
+      }),
+      ...(this.config.fieldNames && {
+        [MapperKind.INPUT_OBJECT_FIELD]: (inputFieldConfig, fieldName) => {
+          const namingConventionFn = this.config.fieldNames && NAMING_CONVENTIONS[this.config.fieldNames];
+          const newName = namingConventionFn(fieldName);
+
+          if (newName === fieldName) {
+            return undefined;
+          }
+
+          return [newName, inputFieldConfig];
+        },
+      }),
+    });
+  }
+}

--- a/packages/transforms/naming-convention/src/index.ts
+++ b/packages/transforms/naming-convention/src/index.ts
@@ -1,139 +1,15 @@
-import { GraphQLSchema } from 'graphql';
-import { MeshTransform, YamlConfig, MeshTransformOptions } from '@graphql-mesh/types';
-import {
-  RenameTypes,
-  TransformEnumValues,
-  RenameInterfaceFields,
-  TransformObjectFields,
-  RenameInputObjectFields,
-  RenameObjectFieldArguments,
-} from '@graphql-tools/wrap';
-import { ExecutionResult, ExecutionRequest } from '@graphql-tools/utils';
-import { Transform, SubschemaConfig, DelegationContext } from '@graphql-tools/delegate';
-import { applyRequestTransforms, applyResultTransforms, applySchemaTransforms } from '@graphql-mesh/utils';
+import { YamlConfig, MeshTransformOptions } from '@graphql-mesh/types';
 
-import {
-  camelCase,
-  capitalCase,
-  constantCase,
-  dotCase,
-  headerCase,
-  noCase,
-  paramCase,
-  pascalCase,
-  pathCase,
-  sentenceCase,
-  snakeCase,
-} from 'change-case';
-
-import { upperCase } from 'upper-case';
-import { lowerCase } from 'lower-case';
-import { resolvers as scalarsResolversMap } from 'graphql-scalars';
-
-type NamingConventionFn = (input: string) => string;
-type NamingConventionType = YamlConfig.NamingConventionTransformConfig['typeNames'];
-
-const NAMING_CONVENTIONS: Record<NamingConventionType, NamingConventionFn> = {
-  camelCase,
-  capitalCase,
-  constantCase,
-  dotCase,
-  headerCase,
-  noCase,
-  paramCase,
-  pascalCase,
-  pathCase,
-  sentenceCase,
-  snakeCase,
-  upperCase,
-  lowerCase,
-};
-
-// Ignore fields needed by Federation spec
-const IGNORED_ROOT_FIELD_NAMES = ['_service', '_entities'];
-
-const IGNORED_TYPE_NAMES = [
-  'date',
-  'hostname',
-  'regex',
-  'json-pointer',
-  'relative-json-pointer',
-  'uri-reference',
-  'uri-template',
-  ...Object.keys(scalarsResolversMap),
-];
-
-export default class NamingConventionTransform implements MeshTransform {
-  private transforms: Transform[] = [];
-
-  constructor(options: MeshTransformOptions<YamlConfig.NamingConventionTransformConfig>) {
-    if (options.config.typeNames) {
-      const namingConventionFn = NAMING_CONVENTIONS[options.config.typeNames];
-      this.transforms.push(
-        new RenameTypes(typeName =>
-          IGNORED_TYPE_NAMES.includes(typeName) ? typeName : namingConventionFn(typeName) || typeName
-        ) as any
-      );
-    }
-    if (options.config.fieldNames) {
-      const fieldNamingConventionFn = options.config.fieldNames
-        ? NAMING_CONVENTIONS[options.config.fieldNames]
-        : (s: string) => s;
-      this.transforms.push(
-        new RenameInputObjectFields((_, fieldName) => fieldNamingConventionFn(fieldName) || fieldName) as any,
-        new TransformObjectFields((_, fieldName, fieldConfig) => [
-          IGNORED_ROOT_FIELD_NAMES.includes(fieldName) ? fieldName : fieldNamingConventionFn(fieldName) || fieldName,
-          fieldConfig,
-        ]) as any,
-        new RenameInterfaceFields((_, fieldName) => fieldNamingConventionFn(fieldName) || fieldName) as any
-      );
-    }
-
-    if (options.config.fieldArgumentNames) {
-      const fieldArgNamingConventionFn = options.config.fieldArgumentNames
-        ? NAMING_CONVENTIONS[options.config.fieldArgumentNames]
-        : (s: string) => s;
-
-      this.transforms.push(
-        new RenameObjectFieldArguments((_typeName, _fieldName, argName) => fieldArgNamingConventionFn(argName)) as any
-      );
-    }
-
-    if (options.config.enumValues) {
-      const namingConventionFn = NAMING_CONVENTIONS[options.config.enumValues];
-
-      this.transforms.push(
-        new TransformEnumValues((typeName, externalValue, enumValueConfig) => {
-          const newEnumValue = namingConventionFn(externalValue) || externalValue;
-          return [
-            newEnumValue,
-            {
-              ...enumValueConfig,
-              value: newEnumValue,
-            },
-          ];
-        }) as any
-      );
-    }
-  }
-
-  transformSchema(
-    originalWrappingSchema: GraphQLSchema,
-    subschemaConfig: SubschemaConfig,
-    transformedSchema?: GraphQLSchema
-  ) {
-    return applySchemaTransforms(originalWrappingSchema, subschemaConfig, transformedSchema, this.transforms);
-  }
-
-  transformRequest(
-    originalRequest: ExecutionRequest,
-    delegationContext: DelegationContext,
-    transformationContext: Record<string, any>
-  ) {
-    return applyRequestTransforms(originalRequest, delegationContext, transformationContext, this.transforms);
-  }
-
-  transformResult(originalResult: ExecutionResult, delegationContext: DelegationContext, transformationContext: any) {
-    return applyResultTransforms(originalResult, delegationContext, transformationContext, this.transforms);
-  }
+import WrapNamingConvention from './wrapNamingConvention';
+import BareNamingConvention from './bareNamingConvention';
+interface NamingConventionTransformConstructor {
+  new (options: MeshTransformOptions<YamlConfig.NamingConventionTransformConfig>):
+    | WrapNamingConvention
+    | BareNamingConvention;
 }
+
+export default (function NamingConventionTransform(
+  options: MeshTransformOptions<YamlConfig.NamingConventionTransformConfig>
+) {
+  return options.config.mode === 'bare' ? new BareNamingConvention(options) : new WrapNamingConvention(options);
+} as unknown as NamingConventionTransformConstructor);

--- a/packages/transforms/naming-convention/src/shared.ts
+++ b/packages/transforms/naming-convention/src/shared.ts
@@ -1,0 +1,50 @@
+import {
+  camelCase,
+  capitalCase,
+  constantCase,
+  dotCase,
+  headerCase,
+  noCase,
+  paramCase,
+  pascalCase,
+  pathCase,
+  sentenceCase,
+  snakeCase,
+} from 'change-case';
+import { upperCase } from 'upper-case';
+import { lowerCase } from 'lower-case';
+import { resolvers as scalarsResolversMap } from 'graphql-scalars';
+import { YamlConfig } from '@graphql-mesh/types';
+
+type NamingConventionFn = (input: string) => string;
+type NamingConventionType = YamlConfig.NamingConventionTransformConfig['typeNames'];
+
+export const NAMING_CONVENTIONS: Record<NamingConventionType, NamingConventionFn> = {
+  camelCase,
+  capitalCase,
+  constantCase,
+  dotCase,
+  headerCase,
+  noCase,
+  paramCase,
+  pascalCase,
+  pathCase,
+  sentenceCase,
+  snakeCase,
+  upperCase,
+  lowerCase,
+};
+
+// Ignore fields needed by Federation spec
+export const IGNORED_ROOT_FIELD_NAMES = ['_service', '_entities'];
+
+export const IGNORED_TYPE_NAMES = [
+  'date',
+  'hostname',
+  'regex',
+  'json-pointer',
+  'relative-json-pointer',
+  'uri-reference',
+  'uri-template',
+  ...Object.keys(scalarsResolversMap),
+];

--- a/packages/transforms/naming-convention/src/wrapNamingConvention.ts
+++ b/packages/transforms/naming-convention/src/wrapNamingConvention.ts
@@ -1,0 +1,90 @@
+import { GraphQLSchema } from 'graphql';
+import { MeshTransform, YamlConfig, MeshTransformOptions } from '@graphql-mesh/types';
+import {
+  RenameTypes,
+  TransformEnumValues,
+  RenameInterfaceFields,
+  TransformObjectFields,
+  RenameInputObjectFields,
+  RenameObjectFieldArguments,
+} from '@graphql-tools/wrap';
+import { ExecutionResult, ExecutionRequest } from '@graphql-tools/utils';
+import { Transform, SubschemaConfig, DelegationContext } from '@graphql-tools/delegate';
+import { applyRequestTransforms, applyResultTransforms, applySchemaTransforms } from '@graphql-mesh/utils';
+
+import { NAMING_CONVENTIONS, IGNORED_ROOT_FIELD_NAMES, IGNORED_TYPE_NAMES } from './shared';
+
+export default class NamingConventionTransform implements MeshTransform {
+  private transforms: Transform[] = [];
+
+  constructor(options: MeshTransformOptions<YamlConfig.NamingConventionTransformConfig>) {
+    if (options.config.typeNames) {
+      const namingConventionFn = NAMING_CONVENTIONS[options.config.typeNames];
+      this.transforms.push(
+        new RenameTypes(typeName =>
+          IGNORED_TYPE_NAMES.includes(typeName) ? typeName : namingConventionFn(typeName) || typeName
+        ) as any
+      );
+    }
+    if (options.config.fieldNames) {
+      const fieldNamingConventionFn = options.config.fieldNames
+        ? NAMING_CONVENTIONS[options.config.fieldNames]
+        : (s: string) => s;
+      this.transforms.push(
+        new RenameInputObjectFields((_, fieldName) => fieldNamingConventionFn(fieldName) || fieldName) as any,
+        new TransformObjectFields((_, fieldName, fieldConfig) => [
+          IGNORED_ROOT_FIELD_NAMES.includes(fieldName) ? fieldName : fieldNamingConventionFn(fieldName) || fieldName,
+          fieldConfig,
+        ]) as any,
+        new RenameInterfaceFields((_, fieldName) => fieldNamingConventionFn(fieldName) || fieldName) as any
+      );
+    }
+
+    if (options.config.fieldArgumentNames) {
+      const fieldArgNamingConventionFn = options.config.fieldArgumentNames
+        ? NAMING_CONVENTIONS[options.config.fieldArgumentNames]
+        : (s: string) => s;
+
+      this.transforms.push(
+        new RenameObjectFieldArguments((_typeName, _fieldName, argName) => fieldArgNamingConventionFn(argName)) as any
+      );
+    }
+
+    if (options.config.enumValues) {
+      const namingConventionFn = NAMING_CONVENTIONS[options.config.enumValues];
+
+      this.transforms.push(
+        new TransformEnumValues((typeName, externalValue, enumValueConfig) => {
+          const newEnumValue = namingConventionFn(externalValue) || externalValue;
+          return [
+            newEnumValue,
+            {
+              ...enumValueConfig,
+              value: newEnumValue,
+            },
+          ];
+        }) as any
+      );
+    }
+  }
+
+  transformSchema(
+    originalWrappingSchema: GraphQLSchema,
+    subschemaConfig: SubschemaConfig,
+    transformedSchema?: GraphQLSchema
+  ) {
+    return applySchemaTransforms(originalWrappingSchema, subschemaConfig, transformedSchema, this.transforms);
+  }
+
+  transformRequest(
+    originalRequest: ExecutionRequest,
+    delegationContext: DelegationContext,
+    transformationContext: Record<string, any>
+  ) {
+    return applyRequestTransforms(originalRequest, delegationContext, transformationContext, this.transforms);
+  }
+
+  transformResult(originalResult: ExecutionResult, delegationContext: DelegationContext, transformationContext: any) {
+    return applyResultTransforms(originalResult, delegationContext, transformationContext, this.transforms);
+  }
+}

--- a/packages/transforms/naming-convention/test/__snapshots__/bareNamingConvention.spec.ts.snap
+++ b/packages/transforms/naming-convention/test/__snapshots__/bareNamingConvention.spec.ts.snap
@@ -1,0 +1,24 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`namingConvention - bare should change the name of a types, enums, fields and fieldArguments 1`] = `
+"type Query {
+  user: User!
+  userById(user_id: Id!): User!
+}
+
+"""
+The \`ID\` scalar type represents a unique identifier, often used to refetch an object or as key for a cache. The ID type appears in a JSON response as a String; however, it is not intended to be human-readable. When expected as an input type, any string (such as \`"4"\`) or integer (such as \`4\`) input value will be accepted as an ID.
+"""
+scalar Id
+
+type User {
+  id: Id!
+  type: UserType
+}
+
+enum UserType {
+  ADMIN
+  MODERATOR
+  NEWBIE
+}"
+`;

--- a/packages/transforms/naming-convention/test/__snapshots__/wrapNamingConvention.spec.ts.snap
+++ b/packages/transforms/naming-convention/test/__snapshots__/wrapNamingConvention.spec.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`namingConvention should change the name of a types, enums, fields and fieldArguments 1`] = `
+exports[`namingConvention wrap should change the name of a types, enums, fields and fieldArguments 1`] = `
 "type Query {
   user: User!
   userById(user_id: ID!): User!

--- a/packages/transforms/naming-convention/test/bareNamingConvention.spec.ts
+++ b/packages/transforms/naming-convention/test/bareNamingConvention.spec.ts
@@ -1,0 +1,245 @@
+import NamingConventionTransform from '../src/index';
+import { buildSchema, printSchema, GraphQLObjectType, GraphQLEnumType, execute, parse } from 'graphql';
+import InMemoryLRUCache from '@graphql-mesh/cache-localforage';
+import { ImportFn, MeshPubSub } from '@graphql-mesh/types';
+import { PubSub } from '@graphql-mesh/utils';
+import { makeExecutableSchema } from '@graphql-tools/schema';
+
+describe('namingConvention - bare', () => {
+  const schema = buildSchema(/* GraphQL */ `
+    type Query {
+      user: user!
+      userById(userId: ID!): user!
+    }
+    type user {
+      Id: ID!
+      Type: userType
+    }
+    enum userType {
+      admin
+      moderator
+      newbie
+    }
+  `);
+
+  let cache: InMemoryLRUCache;
+  let pubsub: MeshPubSub;
+  const baseDir: string = undefined;
+  const importFn: ImportFn = m => import(m);
+
+  beforeEach(() => {
+    cache = new InMemoryLRUCache();
+    pubsub = new PubSub();
+  });
+
+  it('should change the name of a types, enums, fields and fieldArguments', () => {
+    const transform = new NamingConventionTransform({
+      config: {
+        mode: 'bare',
+        typeNames: 'pascalCase',
+        enumValues: 'upperCase',
+        fieldNames: 'camelCase',
+        fieldArgumentNames: 'snakeCase',
+      },
+      apiName: '',
+      cache,
+      pubsub,
+      baseDir,
+      importFn,
+    });
+    const newSchema = transform.transformSchema(schema, {} as any);
+
+    expect(newSchema.getType('user')).toBeUndefined();
+    const userObjectType = newSchema.getType('User') as GraphQLObjectType;
+    expect(userObjectType).toBeDefined();
+
+    const userObjectTypeFields = userObjectType.getFields();
+    expect(userObjectTypeFields.Id).toBeUndefined();
+    expect(userObjectTypeFields.id).toBeDefined();
+
+    expect(newSchema.getType('userType')).toBeUndefined();
+    const userTypeEnumType = newSchema.getType('UserType') as GraphQLEnumType;
+    expect(userTypeEnumType).toBeDefined();
+    expect(userTypeEnumType.getValue('Admin')).toBeUndefined();
+    const adminValue = userTypeEnumType.getValue('ADMIN');
+    expect(adminValue).toBeDefined();
+    // expect(adminValue.value).toBe('admin');
+    expect(printSchema(newSchema)).toMatchSnapshot();
+  });
+
+  it('should execute the transformed schema properly', async () => {
+    const schema = makeExecutableSchema({
+      typeDefs: /* GraphQL */ `
+        type Query {
+          user(input: UserSearchInput): User
+          userById(userId: ID!): User
+          userByType(type: UserType!): User
+        }
+        type User {
+          id: ID
+          first_name: String
+          last_name: String
+          Type: UserType
+        }
+        input UserSearchInput {
+          id: ID
+          first_name: String
+          last_name: String
+        }
+        enum UserType {
+          admin
+          moderator
+          newbie
+        }
+      `,
+      resolvers: {
+        Query: {
+          user: (root, args) => {
+            return args.input;
+          },
+          userById: (root, args) => {
+            return { id: args.userId, first_name: 'John', last_name: 'Doe', Type: 'admin' };
+          },
+          userByType: () => {
+            return { first_name: 'John', last_name: 'Smith', Type: 'admin' };
+          },
+        },
+      },
+    });
+    const transform = new NamingConventionTransform({
+      config: {
+        mode: 'bare',
+        enumValues: 'upperCase',
+        fieldNames: 'camelCase',
+        fieldArgumentNames: 'pascalCase',
+      },
+      apiName: '',
+      cache,
+      pubsub,
+      baseDir,
+      importFn,
+    });
+    const newSchema = transform.transformSchema(schema, {} as any);
+
+    const result = await execute({
+      schema: newSchema,
+      document: parse(/* GraphQL */ `
+        {
+          user(Input: { id: "0", firstName: "John", lastName: "Doe" }) {
+            id
+            firstName
+            lastName
+          }
+        }
+      `),
+    });
+    // Pass transformed output to the client
+    expect(result?.data?.user).toEqual({
+      id: '0',
+      firstName: 'John',
+      lastName: 'Doe',
+    });
+
+    const result2 = await execute({
+      schema: newSchema,
+      document: parse(/* GraphQL */ `
+        {
+          userById(UserId: "1") {
+            id
+            firstName
+            lastName
+            type
+          }
+        }
+      `),
+    });
+    // Pass transformed output to the client
+    expect(result2.data?.userById).toEqual({
+      id: '1',
+      firstName: 'John',
+      lastName: 'Doe',
+      type: 'ADMIN',
+    });
+
+    const result3 = await execute({
+      schema: newSchema,
+      document: parse(/* GraphQL */ `
+        {
+          userByType(Type: ADMIN) {
+            firstName
+            lastName
+            type
+          }
+        }
+      `),
+    });
+    // Pass transformed output to the client
+    expect(result3.data?.userByType).toEqual({
+      firstName: 'John',
+      lastName: 'Smith',
+      type: 'ADMIN',
+    });
+  });
+
+  it('should be skipped if the result gonna be empty string', async () => {
+    const schema = makeExecutableSchema({
+      typeDefs: /* GraphQL */ `
+        type Query {
+          _: String!
+        }
+      `,
+      resolvers: {
+        Query: {
+          _: (root, args, context, info) => {
+            return 'test';
+          },
+        },
+      },
+    });
+    const transform = new NamingConventionTransform({
+      config: {
+        mode: 'bare',
+        fieldNames: 'camelCase',
+      },
+      apiName: '',
+      cache,
+      pubsub,
+      baseDir,
+      importFn,
+    });
+    const newSchema = transform.transformSchema(schema, {} as any);
+
+    const { data } = await execute({
+      schema: newSchema,
+      document: parse(/* GraphQL */ `
+        {
+          _
+        }
+      `),
+    });
+    expect(data?._).toEqual('test');
+  });
+
+  it('should skip fields of Federation spec', async () => {
+    const typeDefs = /* GraphQL */ `
+type Query {
+  _service: String!
+  _entities: [String!]!
+}`.trim();
+    const schema = buildSchema(typeDefs);
+    const transform = new NamingConventionTransform({
+      config: {
+        mode: 'bare',
+        fieldNames: 'snakeCase',
+      },
+      apiName: '',
+      cache,
+      pubsub,
+      baseDir,
+      importFn,
+    });
+    const newSchema = transform.transformSchema(schema, {} as any);
+
+    expect(printSchema(newSchema)).toBe(typeDefs);
+  });
+});

--- a/packages/transforms/naming-convention/yaml-config.graphql
+++ b/packages/transforms/naming-convention/yaml-config.graphql
@@ -6,6 +6,10 @@ extend type Transform {
 }
 
 type NamingConventionTransformConfig @md {
+  """
+  Specify to apply naming-convention transforms to bare schema or by wrapping original schema
+  """
+  mode: NamingConventionTransformMode
   typeNames: NamingConventionType
   fieldNames: NamingConventionType
   enumValues: NamingConventionType
@@ -26,4 +30,9 @@ enum NamingConventionType {
   snakeCase
   upperCase
   lowerCase
+}
+
+enum NamingConventionTransformMode {
+  bare
+  wrap
 }

--- a/packages/types/src/config-schema.json
+++ b/packages/types/src/config-schema.json
@@ -3024,6 +3024,11 @@
       "type": "object",
       "title": "NamingConventionTransformConfig",
       "properties": {
+        "mode": {
+          "type": "string",
+          "enum": ["bare", "wrap"],
+          "description": "Specify to apply naming-convention transforms to bare schema or by wrapping original schema (Allowed values: bare, wrap)"
+        },
         "typeNames": {
           "type": "string",
           "enum": [

--- a/packages/types/src/config.ts
+++ b/packages/types/src/config.ts
@@ -1290,6 +1290,10 @@ export interface HoistFieldTransformFieldPathConfigObject {
  */
 export interface NamingConventionTransformConfig {
   /**
+   * Specify to apply naming-convention transforms to bare schema or by wrapping original schema (Allowed values: bare, wrap)
+   */
+  mode?: 'bare' | 'wrap';
+  /**
    * Allowed values: camelCase, capitalCase, constantCase, dotCase, headerCase, noCase, paramCase, pascalCase, pathCase, sentenceCase, snakeCase, upperCase, lowerCase
    */
   typeNames?:

--- a/website/src/generated-markdown/NamingConventionTransformConfig.generated.md
+++ b/website/src/generated-markdown/NamingConventionTransformConfig.generated.md
@@ -1,4 +1,5 @@
 
+* `mode` (type: `String (bare | wrap)`) - Specify to apply naming-convention transforms to bare schema or by wrapping original schema
 * `typeNames` (type: `String (camelCase | capitalCase | constantCase | dotCase | headerCase | noCase | paramCase | pascalCase | pathCase | sentenceCase | snakeCase | upperCase | lowerCase)`)
 * `fieldNames` (type: `String (camelCase | capitalCase | constantCase | dotCase | headerCase | noCase | paramCase | pascalCase | pathCase | sentenceCase | snakeCase | upperCase | lowerCase)`)
 * `enumValues` (type: `String (camelCase | capitalCase | constantCase | dotCase | headerCase | noCase | paramCase | pascalCase | pathCase | sentenceCase | snakeCase | upperCase | lowerCase)`)

--- a/website/src/pages/docs/transforms/naming-convention.mdx
+++ b/website/src/pages/docs/transforms/naming-convention.mdx
@@ -13,11 +13,17 @@ Add the following configuration to your Mesh config file:
 ```yaml
 transforms:
   - namingConvention:
+      mode: bare | wrap
       typeNames: pascalCase
       enumValues: upperCase
       fieldNames: camelCase
       fieldArgumentNames: camelCase
 ```
+
+<Callout>
+  For information about "bare" and "wrap" modes, please read the [dedicated
+  section](/docs/transforms/transforms-introduction#two-different-modes).
+</Callout>
 
 <Callout>
   You can see our gRPC example that uses this transform to see its application. [Click here to open the example on

--- a/website/src/pages/docs/transforms/transforms-introduction.mdx
+++ b/website/src/pages/docs/transforms/transforms-introduction.mdx
@@ -316,7 +316,7 @@ If you have use cases for which you would require to introduce either "bare" or 
 | Federation            |  ❌  |  ✅  |      [docs](/docs/transforms/federation)       |
 | Filter Schema         |  ✅  |  ✅  |     [docs](/docs/transforms/filter-schema)     |
 | Mock                  |  ❌  |  ✅  |         [docs](/docs/transforms/mock)          |
-| Naming Convention     |  ❌  |  ✅  |   [docs](/docs/transforms/naming-convention)   |
+| Naming Convention     |  ✅  |  ✅  |   [docs](/docs/transforms/naming-convention)   |
 | Prefix                |  ✅  |  ✅  |        [docs](/docs/transforms/prefix)         |
 | Rename                |  ✅  |  ✅  |        [docs](/docs/transforms/rename)         |
 | Replace Field         |  ✅  |  ❌  |     [docs](/docs/transforms/replace-field)     |

--- a/yarn.lock
+++ b/yarn.lock
@@ -2456,6 +2456,14 @@
     "@graphql-tools/utils" "8.10.0"
     tslib "^2.4.0"
 
+"@graphql-tools/merge@8.3.5":
+  version "8.3.5"
+  resolved "https://registry.yarnpkg.com/@graphql-tools/merge/-/merge-8.3.5.tgz#6360a05759c05f00a68b18a83295a2663f4b9324"
+  integrity sha512-NunMCiYNK5GVJewhqQKsUnTFKSsScmZX6Lvf/LLxCDwczMH2Xi4ifRtb2GSQaX1+TYV4Rj/BAE8VUvO3tKIUhQ==
+  dependencies:
+    "@graphql-tools/utils" "8.11.0"
+    tslib "^2.4.0"
+
 "@graphql-tools/merge@8.3.6", "@graphql-tools/merge@^8.2.6", "@graphql-tools/merge@^8.3.3":
   version "8.3.6"
   resolved "https://registry.yarnpkg.com/@graphql-tools/merge/-/merge-8.3.6.tgz#97a936d4c8e8f935e58a514bb516c476437b5b2c"
@@ -2515,6 +2523,16 @@
   dependencies:
     "@graphql-tools/merge" "8.3.3"
     "@graphql-tools/utils" "8.10.0"
+    tslib "^2.4.0"
+    value-or-promise "1.0.11"
+
+"@graphql-tools/schema@9.0.3":
+  version "9.0.3"
+  resolved "https://registry.yarnpkg.com/@graphql-tools/schema/-/schema-9.0.3.tgz#2c7e73433b3a792ca74ab08ccbc0755eefbf967f"
+  integrity sha512-nMnrvhxZ/NxpEjiyO72L9ZKbhRlFTwan60v0otYde+tS2Ww/c7y4FL9fQTXev5ZNnSeV/WAeybpis2pMNfTbOA==
+  dependencies:
+    "@graphql-tools/merge" "8.3.5"
+    "@graphql-tools/utils" "8.11.0"
     tslib "^2.4.0"
     value-or-promise "1.0.11"
 


### PR DESCRIPTION
## Description
The naming-convention transform does not currently support bare mode; Tthis PR addresses this.

## Type of change
- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## How Has This Been Tested?
Hi added a coupe of more tests, especially around ENUMS values both in response and request (which covers #4490).
I applied all tests against "bare" and "wrap" mode.

## Checklist:
- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests and linter rules pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

## Further comments
The implementation is a bit complex, but I managed to get all the renames applied through naming-convention across types fields, input objects, and enums handled with a single resolver wrapper. This performs a decent level of logic but overall feels like a significant performance improvement compared to how many resolvers wrappers are created by the equivalent "wrap" mode.