### PR TITLE
Fix headers logic in json-schema loader

### DIFF
--- a/.changeset/sharp-brooms-guess.md
+++ b/.changeset/sharp-brooms-guess.md
@@ -1,0 +1,6 @@
+---
+'@omnigraph/json-schema': patch
+'@graphql-mesh/string-interpolation': patch
+---
+
+Fix headers logic in json-schema loader

--- a/packages/loaders/json-schema/src/addExecutionLogicToComposer.ts
+++ b/packages/loaders/json-schema/src/addExecutionLogicToComposer.ts
@@ -158,8 +158,8 @@ ${operationConfig.description || ''}
             ? await operationHeaders(interpolationData, operationConfig)
             : operationHeaders;
         const nonInterpolatedHeaders = {
-          ...operationHeadersObj,
-          ...operationConfig?.headers,
+          ...operationConfig?.headers, // default headers defined in schema
+          ...operationHeadersObj, // headers defined in handler config, these must override default headers
         };
         const headers: Record<string, any> = {};
         for (const headerName in nonInterpolatedHeaders) {

--- a/packages/string-interpolation/src/interpolator.js
+++ b/packages/string-interpolation/src/interpolator.js
@@ -85,7 +85,9 @@ export class Interpolator {
   getAlternativeText(str) {
     if (str.indexOf(':') > 0) {
       const altText = this.removeDelimiter(this.extractAfter(str, ':'));
-      if (altText.indexOf('|') > 0) {
+      if (altText === 'undefined') {
+        return '';
+      } else if (altText.indexOf('|') > 0) {
         return this.removeAfter(altText, '|');
       }
       return altText;


### PR DESCRIPTION
## Description

I've noticed two issues with json-schema loader that affect the functionality of network request resolvers.

1. The headers defined in the schema have precedence over the headers defined in the Mesh handler config
2. Interpolated headers are attached with an "undefined" value

Point 1 means that if a user defines in the source handler that a header value should come from a specific variable (e.g. from context), this will be ignored because the default header defined in the schema overrides this by always applying the header value from `args`.

Point 2 means that headers with an interpolated value that resolves to "undefined" are sent to the underlying API, which might well reject the request because of an unexpected header value (e.g. "api-version: undefined"). Headers with this value should simply not be sent to the server.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests and linter rules pass locally with my changes