### PR TITLE
Fix issues with bare naming-convention

### DIFF
--- a/.changeset/brave-toys-marry.md
+++ b/.changeset/brave-toys-marry.md
@@ -1,0 +1,5 @@
+---
+'@graphql-mesh/transform-naming-convention': patch
+---
+
+Fix missing arguments when naming-convention resolves to same name as the original

--- a/.changeset/brave-toys-marry.md
+++ b/.changeset/brave-toys-marry.md
@@ -2,4 +2,5 @@
 '@graphql-mesh/transform-naming-convention': patch
 ---
 
-Fix missing arguments when naming-convention resolves to same name as the original
+- Fix missing arguments when naming-convention resolves to same name as the original
+- Fix Enum values mapping with NonNull enums

--- a/packages/transforms/naming-convention/src/bareNamingConvention.ts
+++ b/packages/transforms/naming-convention/src/bareNamingConvention.ts
@@ -130,29 +130,27 @@ export default class NamingConventionTransform implements MeshTransform {
               const useArgName = newArgName || argName;
               const argIsInputObjectType = isInputObjectType(argConfig.type);
 
-              if (argName === newArgName && !argIsInputObjectType) {
-                return args;
+              if (argName !== useArgName) {
+                // take advantage of the loop to map arg name from Old to New
+                argsMap[useArgName] = !argIsInputObjectType
+                  ? argName
+                  : {
+                      [argName]: Object.keys((argConfig.type as GraphQLInputObjectType).toConfig().fields).reduce(
+                        (inputFields, inputFieldName) => {
+                          if (Number.isFinite(inputFieldName)) return inputFields;
+
+                          const newInputFieldName = fieldNamingConventionFn(inputFieldName as string);
+                          return newInputFieldName === inputFieldName
+                            ? inputFields
+                            : {
+                                ...inputFields,
+                                [fieldNamingConventionFn(inputFieldName as string)]: inputFieldName,
+                              };
+                        },
+                        {}
+                      ),
+                    };
               }
-
-              // take advantage of the loop to map arg name from Old to New
-              argsMap[useArgName] = !argIsInputObjectType
-                ? argName
-                : {
-                    [argName]: Object.keys((argConfig.type as GraphQLInputObjectType).toConfig().fields).reduce(
-                      (inputFields, inputFieldName) => {
-                        if (Number.isFinite(inputFieldName)) return inputFields;
-
-                        const newInputFieldName = fieldNamingConventionFn(inputFieldName as string);
-                        return newInputFieldName === inputFieldName
-                          ? inputFields
-                          : {
-                              ...inputFields,
-                              [fieldNamingConventionFn(inputFieldName as string)]: inputFieldName,
-                            };
-                      },
-                      {}
-                    ),
-                  };
 
               return {
                 ...args,

--- a/packages/transforms/naming-convention/src/bareNamingConvention.ts
+++ b/packages/transforms/naming-convention/src/bareNamingConvention.ts
@@ -1,4 +1,11 @@
-import { defaultFieldResolver, GraphQLInputObjectType, GraphQLSchema, isInputObjectType, isEnumType } from 'graphql';
+import {
+  defaultFieldResolver,
+  GraphQLInputObjectType,
+  GraphQLSchema,
+  isInputObjectType,
+  isEnumType,
+  isNonNullType,
+} from 'graphql';
 import { MeshTransform, YamlConfig, MeshTransformOptions } from '@graphql-mesh/types';
 import { MapperKind, mapSchema, renameType } from '@graphql-tools/utils';
 
@@ -107,10 +114,13 @@ export default class NamingConventionTransform implements MeshTransform {
             this.config.fieldNames &&
             !IGNORED_ROOT_FIELD_NAMES.includes(fieldName) &&
             fieldNamingConventionFn(fieldName);
+          const fieldActualType = isNonNullType(fieldConfig.type)
+            ? schema.getType(fieldConfig.type.ofType.toString())
+            : fieldConfig.type;
           const resultMap =
             this.config.enumValues &&
-            isEnumType(fieldConfig.type) &&
-            Object.keys(fieldConfig.type.toConfig().values).reduce((map, value) => {
+            isEnumType(fieldActualType) &&
+            Object.keys(fieldActualType.toConfig().values).reduce((map, value) => {
               if (Number.isFinite(value)) {
                 return map;
               }
@@ -130,7 +140,7 @@ export default class NamingConventionTransform implements MeshTransform {
               const useArgName = newArgName || argName;
               const argIsInputObjectType = isInputObjectType(argConfig.type);
 
-              if (argName !== useArgName) {
+              if (argName !== useArgName || argIsInputObjectType) {
                 // take advantage of the loop to map arg name from Old to New
                 argsMap[useArgName] = !argIsInputObjectType
                   ? argName

--- a/packages/transforms/naming-convention/test/bareNamingConvention.spec.ts
+++ b/packages/transforms/naming-convention/test/bareNamingConvention.spec.ts
@@ -71,7 +71,7 @@ describe('namingConvention - bare', () => {
     const schema = makeExecutableSchema({
       typeDefs: /* GraphQL */ `
         type Query {
-          user(input: UserSearchInput): User
+          user(Input: UserSearchInput): User
           userById(userId: ID!): User
           userByType(type: UserType!): User
         }
@@ -79,12 +79,13 @@ describe('namingConvention - bare', () => {
           id: ID
           first_name: String
           last_name: String
-          Type: UserType
+          Type: UserType!
         }
         input UserSearchInput {
           id: ID
           first_name: String
           last_name: String
+          type: UserType
         }
         enum UserType {
           admin
@@ -95,7 +96,12 @@ describe('namingConvention - bare', () => {
       resolvers: {
         Query: {
           user: (root, args) => {
-            return args.input;
+            return {
+              id: args.Input.id,
+              first_name: args.Input.first_name,
+              last_name: args.Input.last_name,
+              Type: args.Input.type,
+            };
           },
           userById: (root, args) => {
             return { id: args.userId, first_name: 'John', last_name: 'Doe', Type: 'admin' };
@@ -125,10 +131,11 @@ describe('namingConvention - bare', () => {
       schema: newSchema,
       document: parse(/* GraphQL */ `
         {
-          user(Input: { id: "0", firstName: "John", lastName: "Doe" }) {
+          user(Input: { id: "0", firstName: "John", lastName: "Doe", type: ADMIN }) {
             id
             firstName
             lastName
+            type
           }
         }
       `),
@@ -138,6 +145,7 @@ describe('namingConvention - bare', () => {
       id: '0',
       firstName: 'John',
       lastName: 'Doe',
+      type: 'ADMIN',
     });
 
     const result2 = await execute({

--- a/packages/transforms/naming-convention/test/wrapNamingConvention.spec.ts
+++ b/packages/transforms/naming-convention/test/wrapNamingConvention.spec.ts
@@ -74,7 +74,7 @@ describe('namingConvention wrap', () => {
   it('should execute the transformed schema properly', async () => {
     let schema = buildSchema(/* GraphQL */ `
       type Query {
-        user(input: UserSearchInput): User
+        user(Input: UserSearchInput): User
         userById(userId: ID!): User
         userByType(type: UserType!): User
       }
@@ -82,12 +82,13 @@ describe('namingConvention wrap', () => {
         id: ID
         first_name: String
         last_name: String
-        Type: UserType
+        Type: UserType!
       }
       input UserSearchInput {
         id: ID
         first_name: String
         last_name: String
+        type: UserType
       }
       enum UserType {
         admin
@@ -100,7 +101,12 @@ describe('namingConvention wrap', () => {
       resolvers: {
         Query: {
           user: (root, args) => {
-            return args?.input;
+            return {
+              id: args.Input.id,
+              first_name: args.Input.first_name,
+              last_name: args.Input.last_name,
+              Type: args.Input.type,
+            };
           },
           userById: (root, args) => {
             return { id: args.userId, first_name: 'John', last_name: 'Doe', Type: 'admin' };
@@ -133,10 +139,11 @@ describe('namingConvention wrap', () => {
       schema,
       document: parse(/* GraphQL */ `
         {
-          user(Input: { id: "0", firstName: "John", lastName: "Doe" }) {
+          user(Input: { id: "0", firstName: "John", lastName: "Doe", type: ADMIN }) {
             id
             firstName
             lastName
+            type
           }
         }
       `),
@@ -146,6 +153,7 @@ describe('namingConvention wrap', () => {
       id: '0',
       firstName: 'John',
       lastName: 'Doe',
+      type: 'ADMIN',
     });
 
     const result2 = await execute({
@@ -156,6 +164,7 @@ describe('namingConvention wrap', () => {
             id
             firstName
             lastName
+            type
           }
         }
       `),
@@ -165,6 +174,7 @@ describe('namingConvention wrap', () => {
       id: '1',
       firstName: 'John',
       lastName: 'Doe',
+      type: 'ADMIN',
     });
 
     const result3 = await execute({


### PR DESCRIPTION
## Description
This PR fixes two issue happening with `bare` naming convention transform:
1. missing arguments when the applied naming-convention resolves to the same name as the original
2. ENUM values not mapped when the ENUM is wrapped in NonNull type

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests and linter rules pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules