### PR TITLE
Update query fields for openapi-stackexchange example

### DIFF
--- a/examples/openapi-stackexchange/list-questions.query.graphql
+++ b/examples/openapi-stackexchange/list-questions.query.graphql
@@ -3,8 +3,8 @@ query ListQuestions {
     items {
       title
       tags
-      isAnswered
-      answerCount
+      is_answered
+      answer_count
       link
     }
   }

--- a/examples/openapi-stackexchange/test/__snapshots__/openapi-stackexchange.test.ts.snap
+++ b/examples/openapi-stackexchange/test/__snapshots__/openapi-stackexchange.test.ts.snap
@@ -1,0 +1,280 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Stack Exchange should generate correct schema 1`] = `
+"schema {
+  query: Query
+}
+
+type Query {
+  "Gets all the questions on the site.\\nThis method allows you make fairly flexible queries across the entire corpus of questions on a site."
+  listQuestions(fromdate: Int, todate: Int, min: Int, max: Int, tagged: String, order: queryInput_listQuestions_order, sort: queryInput_listQuestions_sort, page: Int, pagesize: Int, site: String! = "stackoverflow"): QuestionsResponse
+  "Gets all the questions on the site.\\nThis method allows you make fairly flexible queries across the entire corpus of questions on a site."
+  listFeaturedQuestions(fromdate: Int, todate: Int, min: Int, max: Int, tagged: String, order: queryInput_listFeaturedQuestions_order, sort: queryInput_listFeaturedQuestions_sort, page: Int, pagesize: Int, site: String! = "stackoverflow"): QuestionsResponse
+  "Returns questions which have received no answers.\\nCompare with /questions/unanswered which merely returns questions that the sites consider insufficiently well answered."
+  listQuestionsWithoutAnswers(fromdate: Int, todate: Int, min: Int, max: Int, tagged: String, order: queryInput_listQuestionsWithoutAnswers_order, sort: queryInput_listQuestionsWithoutAnswers_sort, page: Int, pagesize: Int, site: String! = "stackoverflow"): QuestionsResponse
+  "Gets all the questions on the site.\\nThis method allows you make fairly flexible queries across the entire corpus of questions on a site."
+  listUnansweredQuestions(fromdate: Int, todate: Int, min: Int, max: Int, tagged: String, order: queryInput_listUnansweredQuestions_order, sort: queryInput_listUnansweredQuestions_sort, page: Int, pagesize: Int, site: String! = "stackoverflow"): QuestionsResponse
+  "Returns all users on a site.\\n\\nThis method returns a list of users.\\n\\nThe sorts accepted by this method operate on the following fields of the user object:\\n\\nreputation – reputation\\ncreation – creation_date\\nname – display_name\\nmodified – last_modified_date\\n\\nreputation is the default sort.\\n\\nIt is possible to create moderately complex queries using sort, min, max, fromdate, and todate.\\nThe \`inname\` parameter lets consumers filter the results down to just those users with a certain substring in their display name. For example, \`inname=kevin\` will return all users with both users named simply \\"Kevin\\" or those with Kevin as one of (or part of) their names; such as \\"Kevin Montrose\\"."
+  listUsers(inname: String, fromdate: Int, todate: Int, min: Int, max: Int, sort: queryInput_listUsers_sort, order: queryInput_listUsers_order, page: Int, pagesize: Int, site: String! = "stackoverflow"): UsersResponse
+  "Returns the user associated with the passed access_token.\\n\\nThis method returns a [user](https://api.stackexchange.com/docs/types/user)."
+  getMe(site: String! = "stackoverflow"): UsersResponse
+  "Gets a subset of the reputation changes for users in {ids}.\\nReputation changes are intentionally scrubbed of some data to make it difficult to correlate votes on particular posts with user reputation changes. That being said, this method returns enough data for reasonable display of reputation trends.\\n{ids} can contain up to 100 semicolon delimited ids. To find ids programmatically look for user_id on user or shallow_user objects.\\nThis method returns a list of reputation objects."
+  getUsersReputationChanges(userIds: String!, fromdate: Int, todate: Int, page: Int, pagesize: NonNegativeInt, site: String! = "stackoverflow"): ReputationResponse
+  "Returns the reputation changed for the user associated with the given access_token.\\nThis method returns a list of [reputation changes](https://api.stackexchange.com/docs/types/reputation)."
+  getMyReputation: ReputationResponse
+  "Returns users' public reputation history.\\nThis method returns a list of reputation_history."
+  getUsersReputationHistory(userIds: String!, page: Int, pagesize: Int, site: String! = "stackoverflow"): ReputationHistoryResponse
+  "Returns user's public reputation history.\\n\\nThis method returns a list of [reputation_history](https://api.stackexchange.com/docs/types/reputation-history)."
+  getMyReputationHistory(page: Int, pagesize: Int): ReputationHistoryResponse
+  "Returns a list of [answers](https://api.stackexchange.com/docs/types/answer)."
+  listAnswers(
+    "This parameter can be the full domain name (ie. \\"stackoverflow.com\\"), or a short form identified by api_site_parameter on the site object."
+    site: String
+    "Unix epoch time"
+    fromdate: Int
+    "Unix epoch time"
+    todate: Int
+    "Unix epoch time"
+    min: Int
+    "Unix epoch time"
+    max: Int
+    sort: queryInput_listAnswers_sort
+    order: queryInput_listAnswers_order
+    page: Int
+    pagesize: Int
+  ): AnswersResponse
+}
+
+type QuestionsResponse {
+  "A list of questions."
+  items: [Question]
+  has_more: Boolean
+  quota_max: Int
+  quota_remaining: Int
+}
+
+type Question {
+  tags: [String]
+  owner: QuestionOwner
+  is_answered: Boolean
+  view_count: Int
+  answer_count: Int
+  score: Int
+  last_activity_date: Int
+  creation_date: Int
+  question_id: Int
+  link: String
+  title: String
+}
+
+type QuestionOwner {
+  reputation: Int
+  user_id: Int
+  user_type: String
+  profile_image: String
+  display_name: String
+  link: String
+}
+
+enum queryInput_listQuestions_order {
+  desc
+  asc
+}
+
+enum queryInput_listQuestions_sort {
+  activity
+  votes
+  creation
+  hot
+  week
+  month
+}
+
+enum queryInput_listFeaturedQuestions_order {
+  desc
+  asc
+}
+
+enum queryInput_listFeaturedQuestions_sort {
+  activity
+  votes
+  creation
+}
+
+enum queryInput_listQuestionsWithoutAnswers_order {
+  desc
+  asc
+}
+
+enum queryInput_listQuestionsWithoutAnswers_sort {
+  activity
+  votes
+  creation
+}
+
+enum queryInput_listUnansweredQuestions_order {
+  desc
+  asc
+}
+
+enum queryInput_listUnansweredQuestions_sort {
+  activity
+  votes
+  creation
+}
+
+type UsersResponse {
+  items: [User]
+  has_more: Boolean
+  quote_max: Int
+  quota_remaining: Int
+}
+
+type User {
+  badge_counts: UserBadgeCounts
+  account_id: BigInt
+  is_employee: Boolean
+  last_modified_date: BigInt
+  last_access_date: BigInt
+  reputation_change_year: Int
+  reputation_change_quarter: Int
+  reputation_change_month: Int
+  reputation_change_week: Int
+  reputation_change_day: Int
+  reputation: BigInt
+  creation_date: BigInt
+  user_type: String
+  user_id: BigInt
+  accept_rate: Int
+  location: String
+  website_url: URL
+  link: URL
+  profile_image: URL
+  display_name: String
+}
+
+type UserBadgeCounts {
+  bronze: Int
+  silver: Int
+  gold: Int
+}
+
+"The \`BigInt\` scalar type represents non-fractional signed whole numeric values."
+scalar BigInt
+
+"A field whose value conforms to the standard URL format as specified in RFC3986: https://www.ietf.org/rfc/rfc3986.txt."
+scalar URL
+
+enum queryInput_listUsers_sort {
+  reputation
+  creation
+  name
+  modified
+}
+
+enum queryInput_listUsers_order {
+  desc
+  asc
+}
+
+type ReputationResponse {
+  "A list of reputation_history."
+  items: [ReputationChange]
+  has_more: Boolean
+  quota_max: Int
+  quota_remaining: Int
+}
+
+type ReputationChange {
+  on_date: Int
+  reputation_change: Int
+  vote_type: query_getUsersReputationChanges_items_items_vote_type
+  post_type: String
+  post_id: Int
+  user_id: Int
+}
+
+enum query_getUsersReputationChanges_items_items_vote_type {
+  accepts
+  bounties_won
+  down_votes
+  up_votes
+}
+
+"Integers that will have a value of 0 or more."
+scalar NonNegativeInt
+
+type ReputationHistoryResponse {
+  "A list of reputation_history."
+  items: [ReputationHistory]
+  has_more: Boolean
+  quota_max: Int
+  quota_remaining: Int
+}
+
+type ReputationHistory {
+  reputation_history_type: String
+  reputation_change: Int
+  post_id: Int
+  creation_date: Int
+  user_id: Int
+}
+
+type AnswersResponse {
+  items: [Answer]
+  has_more: Boolean
+  backoff: Int
+  quota_max: Int
+  quota_remaining: Int
+}
+
+type Answer {
+  accepted: Boolean
+  answer_id: Int
+  awarded_bounty_amount: Int
+  awarded_bounty_users: [ShallowUser]
+  body: String
+  body_markdown: String
+  can_flag: Boolean
+  comment_count: Int
+  comments: [Comment]
+  community_owned_date: Int
+  content_license: String
+  creation_date: Int
+  down_vote_count: Int
+  is_accepted: Boolean
+  last_activity_date: Int
+  last_edit_date: Int
+  last_editor: ShallowUser
+  link: String
+  locked_date: Int
+  owner: ShallowUser
+  question_id: Int
+  score: Boolean
+  share_link: Int
+  tags: [String]
+  title: String
+  up_vote_count: Int
+  upvoted: Boolean
+}
+
+type ShallowUser {
+  id: String
+}
+
+type Comment {
+  id: String
+}
+
+"\`activity\` corresponds to \`Answer. last_activity_date\` , \`creation\` to \`Answer.creation_date\` and \`votes\` to \`Answer.score\`"
+enum queryInput_listAnswers_sort {
+  activity
+  creation
+  votes
+}
+
+enum queryInput_listAnswers_order {
+  desc
+  asc
+}"
+`;

--- a/examples/openapi-stackexchange/test/openapi-stackexchange.test.ts
+++ b/examples/openapi-stackexchange/test/openapi-stackexchange.test.ts
@@ -1,0 +1,40 @@
+import { findAndParseConfig } from '@graphql-mesh/cli';
+import { getMesh, MeshInstance } from '@graphql-mesh/runtime';
+import { join } from 'path';
+import { printSchemaWithDirectives } from '@graphql-tools/utils';
+import { readFile } from 'fs/promises';
+
+describe('Stack Exchange', () => {
+  let mesh: MeshInstance;
+  beforeAll(async () => {
+    const config = await findAndParseConfig({
+      dir: join(__dirname, '..'),
+    });
+    mesh = await getMesh(config);
+  });
+  afterAll(() => {
+    mesh.destroy();
+  });
+  it('should generate correct schema', async () => {
+    expect(printSchemaWithDirectives(mesh.schema)).toMatchSnapshot();
+  });
+  it('should return the correct data', async () => {
+    const listQuestionsQuery = await readFile(join(__dirname, '..', 'list-questions.query.graphql'), 'utf-8');
+    const result = await mesh.execute(listQuestionsQuery, {});
+    expect(result).toMatchObject({
+      data: {
+        listUnansweredQuestions: {
+          items: expect.arrayContaining([
+            expect.objectContaining({
+              title: expect.any(String),
+              tags: expect.arrayContaining([expect.any(String)]),
+              is_answered: expect.any(Boolean),
+              answer_count: expect.any(Number),
+              link: expect.any(String),
+            }),
+          ]),
+        },
+      },
+    });
+  });
+});


### PR DESCRIPTION
## Description

openapi-stackexchange example does not seem to build (`mesh build`) due to updated fields from StackExchange  

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- 
## Screenshots/Sandbox (if appropriate/relevant):

<img width="562" alt="Screenshot 2022-09-28 at 18 20 48" src="https://user-images.githubusercontent.com/6880622/192847849-e8e7cf38-7fe6-40e4-9103-ddafd9db833e.png">

## How Has This Been Tested?

I updated the fields and can confirm that `mesh build` was successful

<img width="560" alt="Screenshot 2022-09-28 at 18 21 52" src="https://user-images.githubusercontent.com/6880622/192848048-5b27cbf4-b650-4a10-bd97-2289eeb3022f.png">


**Test Environment**:

- OS: Mac OS
- `@graphql-mesh/...`:
-  `@graphql-mesh/cli: "0.78.25"`
- `@graphql-mesh/openapi": "0.33.20"`
- NodeJS: v16 LTS

## Checklist:

- [] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests and linter rules pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

## Further comments

This is a relatively small change that's why I haven't created an issue. Hope that's alright. 
