### PR TITLE
Fix issue where logger incorrectly trimming line

### DIFF
--- a/packages/utils/src/logger.ts
+++ b/packages/utils/src/logger.ts
@@ -26,7 +26,7 @@ export const titleBold: MessageTransformer = msg => ANSI_CODES.bold + msg + ANSI
 export class DefaultLogger implements Logger {
   constructor(public name?: string) {}
 
-  private getLoggerMessage({ args = [], trim = this.isDebug }: { args: any[]; trim?: boolean }) {
+  private getLoggerMessage({ args = [], trim = !this.isDebug }: { args: any[]; trim?: boolean }) {
     return args
       .flat(Infinity)
       .map(arg => {


### PR DESCRIPTION
🚨 **IMPORTANT: Please do not create a Pull Request without creating an issue first.**

_Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request._

## Description

Updated default default method parameter value to correctly only trim when `isDebug` is false.

Fixes #4609

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
Tested locally on my own machine

**Test Environment**:

- OS: MacOS Monterey
- `@graphql-mesh/cli@0.78.25`:
- NodeJS: 16.14.0

## Checklist:
- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests and linter rules pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
