### PR TITLE
Replace `0.0.0.0` with `localhost` while opening in browser

### DIFF
--- a/.changeset/real-baboons-provide.md
+++ b/.changeset/real-baboons-provide.md
@@ -1,0 +1,5 @@
+---
+"@graphql-mesh/cli": patch
+---
+
+Replace `0.0.0.0` with `localhost` while opening in browser

--- a/packages/cli/src/commands/serve/serve.ts
+++ b/packages/cli/src/commands/serve/serve.ts
@@ -213,7 +213,10 @@ export async function serveMesh(
       .listen(port, hostname, () => {
         const shouldntOpenBrowser = process.env.NODE_ENV?.toLowerCase() === 'production' || browser === false;
         if (!shouldntOpenBrowser) {
-          open(serverUrl, typeof browser === 'string' ? { app: browser } : undefined).catch(() => {});
+          open(
+            serverUrl.replace('0.0.0.0', 'localhost'),
+            typeof browser === 'string' ? { app: browser } : undefined
+          ).catch(() => {});
         }
       })
       .on('error', handleFatalError);


### PR DESCRIPTION
Browsers cannot open `0.0.0.0` because this address means _all_ network interfaces. Instead, even if serving is bound to `0.0.0.0` the browser should open `localhost`.