### PR TITLE
fix(deps): add missing graphql peer deps

### DIFF
--- a/.changeset/cold-jobs-walk.md
+++ b/.changeset/cold-jobs-walk.md
@@ -1,0 +1,6 @@
+---
+'@graphql-mesh/cross-helpers': patch
+'json-machete': patch
+---
+
+fix(deps): add missing graphql peer deps

--- a/packages/cross-helpers/package.json
+++ b/packages/cross-helpers/package.json
@@ -13,6 +13,9 @@
   "browser": "browser.js",
   "types": "index.d.ts",
   "typings": "./index.d.ts",
+  "peerDependencies": {
+    "graphql": "*"
+  },
   "dependencies": {
     "@graphql-tools/utils": "9.1.3",
     "path-browserify": "1.0.1",

--- a/packages/json-machete/package.json
+++ b/packages/json-machete/package.json
@@ -28,6 +28,9 @@
     "./package.json": "./package.json"
   },
   "typings": "dist/typings/index.d.ts",
+  "peerDependencies": {
+    "graphql": "*"
+  },
   "dependencies": {
     "@graphql-mesh/cross-helpers": "0.3.0",
     "@graphql-mesh/types": "0.89.2",


### PR DESCRIPTION
## Description

This PR adds missing `graphql` peer dependencies to `@graphql-mesh/cross-helpers` and `json-machete`, which will resolve peer dependency warnings on install, e.g.:
```txt
➤ YN0002: │ @graphql-mesh/cross-helpers@npm:0.2.6 doesn't provide graphql (p306b4), requested by @graphql-tools/utils
➤ YN0002: │ json-machete@npm:0.15.9 doesn't provide graphql (p9f76e), requested by @graphql-tools/utils
```
This relates to https://github.com/Urigo/graphql-mesh/issues/2923, although that issue is old and may not be fully resolved by this.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

N/A

## Checklist:

- [ ] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests and linter rules pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

N/A