### PR TITLE
fix(json-schema): restore support for `explode: true` with strings

### DIFF
--- a/.changeset/smooth-files-hear.md
+++ b/.changeset/smooth-files-hear.md
@@ -1,0 +1,5 @@
+---
+'@omnigraph/json-schema': patch
+---
+
+fix(json-schema): restore support for `explode: true` with strings

--- a/packages/loaders/json-schema/src/addExecutionLogicToComposer.ts
+++ b/packages/loaders/json-schema/src/addExecutionLogicToComposer.ts
@@ -297,7 +297,7 @@ ${operationConfig.description || ''}
                 ...operationConfig.queryStringOptionsByParam?.[queryParamName],
               };
               let queryParamObj = argValue;
-              if (Array.isArray(argValue) || !opts.destructObject) {
+              if (Array.isArray(argValue) || !(typeof argValue === 'object' && opts.destructObject)) {
                 queryParamObj = {
                   [queryParamName]: argValue,
                 };

--- a/packages/loaders/openapi/tests/explode.test.ts
+++ b/packages/loaders/openapi/tests/explode.test.ts
@@ -25,7 +25,11 @@ describe('Explode parameter', () => {
   it('should repeat the params if explode is false', async () => {
     const document = parse(/* GraphQL */ `
       query Test {
-        testExplodeParameterFalse(exploded: ["abc", "def"]) {
+        testExplodeParameterFalse(
+          explodedArray: ["abc", "def"]
+          explodedObject: { key1: "value1", key2: "value2" }
+          explodedString: "ghi"
+        ) {
           url
         }
       }
@@ -39,7 +43,7 @@ describe('Explode parameter', () => {
     expect(result).toEqual({
       data: {
         testExplodeParameterFalse: {
-          url: 'http://localhost:7777/test-false?exploded=abc%2Cdef',
+          url: 'http://localhost:7777/test-false?explodedArray=abc%2Cdef&explodedObject%5Bkey1%5D=value1&explodedObject%5Bkey2%5D=value2&explodedString=ghi',
         },
       },
     });
@@ -47,7 +51,11 @@ describe('Explode parameter', () => {
   it('should repeat the params if explode is true', async () => {
     const document = parse(/* GraphQL */ `
       query Test {
-        testExplodeParameterTrue(exploded: ["abc", "def"]) {
+        testExplodeParameterTrue(
+          explodedArray: ["abc", "def"]
+          explodedObject: { key1: "value1", key2: "value2" }
+          explodedString: "ghi"
+        ) {
           url
         }
       }
@@ -61,7 +69,7 @@ describe('Explode parameter', () => {
     expect(result).toEqual({
       data: {
         testExplodeParameterTrue: {
-          url: 'http://localhost:7777/test-true?exploded=abc&exploded=def',
+          url: 'http://localhost:7777/test-true?explodedArray=abc&explodedArray=def&key1=value1&key2=value2&explodedString=ghi',
         },
       },
     });

--- a/packages/loaders/openapi/tests/fixtures/explode.yml
+++ b/packages/loaders/openapi/tests/fixtures/explode.yml
@@ -16,7 +16,7 @@ paths:
       description: Endpoint that required explode == false params
       operationId: testExplodeParameterFalse
       parameters:
-        - name: exploded
+        - name: explodedArray
           in: query
           required: true
           explode: false
@@ -25,6 +25,25 @@ paths:
             type: array
             items:
               type: string
+        - name: explodedObject
+          in: query
+          required: true
+          explode: false
+          style: form
+          schema:
+            type: object
+            properties:
+              key1:
+                type: string
+              key2:
+                type: string
+        - name: explodedString
+          in: query
+          required: true
+          explode: false
+          style: form
+          schema:
+            type: string
       responses:
         200:
           description: ''
@@ -38,7 +57,7 @@ paths:
       description: Endpoint that required explode == true params
       operationId: testExplodeParameterTrue
       parameters:
-        - name: exploded
+        - name: explodedArray
           in: query
           required: true
           explode: true
@@ -47,6 +66,25 @@ paths:
             type: array
             items:
               type: string
+        - name: explodedObject
+          in: query
+          required: true
+          explode: true
+          style: form
+          schema:
+            type: object
+            properties:
+              key1:
+                type: string
+              key2:
+                type: string
+        - name: explodedString
+          in: query
+          required: true
+          explode: true
+          style: form
+          schema:
+            type: string
       responses:
         200:
           description: ''


### PR DESCRIPTION
## Description

This PR fixes a regression in the query string logic in the `json-schema` loader so that `explode: true` in the `openapi` loader works properly for `type: string` parameters.

Fixes https://github.com/Urigo/graphql-mesh/issues/4677.

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

## Screenshots/Sandbox (if appropriate/relevant):

N/A

## How Has This Been Tested?

This PR updates `explode.test.ts` to include new test cases for `object` and `string` parameters.

See https://github.com/Urigo/graphql-mesh/issues/4677 for reproduction steps.

**Test Environment**:

- OS: MacOS
- `@graphql-mesh/openapi`: `^0.33.26`
- NodeJS: 16.17.1

## Checklist:

- [X] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests and linter rules pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules

## Further comments

N/A