### PR TITLE
Add support for type pointers to bare naming convention transform

### DIFF
--- a/.changeset/tasty-apes-leave.md
+++ b/.changeset/tasty-apes-leave.md
@@ -1,0 +1,5 @@
+---
+'@graphql-mesh/transform-naming-convention': patch
+---
+
+Support type pointers

--- a/packages/transforms/naming-convention/test/bareNamingConvention.spec.ts
+++ b/packages/transforms/naming-convention/test/bareNamingConvention.spec.ts
@@ -80,6 +80,7 @@ describe('namingConvention - bare', () => {
           first_name: String
           last_name: String
           Type: UserType!
+          interests: [UserInterests!]!
         }
         input UserSearchInput {
           id: ID
@@ -91,6 +92,11 @@ describe('namingConvention - bare', () => {
           admin
           moderator
           newbie
+        }
+        enum UserInterests {
+          books
+          comics
+          news
         }
       `,
       resolvers: {
@@ -104,10 +110,15 @@ describe('namingConvention - bare', () => {
             };
           },
           userById: (root, args) => {
-            return { id: args.userId, first_name: 'John', last_name: 'Doe', Type: 'admin' };
+            return {
+              id: args.userId,
+              first_name: 'John',
+              last_name: 'Doe',
+              Type: 'admin',
+            };
           },
           userByType: () => {
-            return { first_name: 'John', last_name: 'Smith', Type: 'admin' };
+            return { first_name: 'John', last_name: 'Smith', Type: 'admin', interests: ['books', 'comics'] };
           },
         },
       },
@@ -177,6 +188,7 @@ describe('namingConvention - bare', () => {
             firstName
             lastName
             type
+            interests
           }
         }
       `),
@@ -186,6 +198,7 @@ describe('namingConvention - bare', () => {
       firstName: 'John',
       lastName: 'Smith',
       type: 'ADMIN',
+      interests: ['BOOKS', 'COMICS'],
     });
   });
 

--- a/packages/transforms/naming-convention/test/wrapNamingConvention.spec.ts
+++ b/packages/transforms/naming-convention/test/wrapNamingConvention.spec.ts
@@ -83,6 +83,7 @@ describe('namingConvention wrap', () => {
         first_name: String
         last_name: String
         Type: UserType!
+        interests: [UserInterests!]!
       }
       input UserSearchInput {
         id: ID
@@ -94,6 +95,11 @@ describe('namingConvention wrap', () => {
         admin
         moderator
         newbie
+      }
+      enum UserInterests {
+        books
+        comics
+        news
       }
     `);
     schema = addResolversToSchema({
@@ -109,10 +115,15 @@ describe('namingConvention wrap', () => {
             };
           },
           userById: (root, args) => {
-            return { id: args.userId, first_name: 'John', last_name: 'Doe', Type: 'admin' };
+            return {
+              id: args.userId,
+              first_name: 'John',
+              last_name: 'Doe',
+              Type: 'admin',
+            };
           },
           userByType: () => {
-            return { first_name: 'John', last_name: 'Smith', Type: 'admin' };
+            return { first_name: 'John', last_name: 'Smith', Type: 'admin', interests: ['books', 'comics'] };
           },
         },
       },
@@ -185,6 +196,7 @@ describe('namingConvention wrap', () => {
             firstName
             lastName
             type
+            interests
           }
         }
       `),
@@ -194,6 +206,7 @@ describe('namingConvention wrap', () => {
       firstName: 'John',
       lastName: 'Smith',
       type: 'ADMIN',
+      interests: ['BOOKS', 'COMICS'],
     });
   });
 


### PR DESCRIPTION
## Description
This PR introduces proper support to type pointers on `bare` implementation of naming-convention transform.
More specifically GraphQLList types were not supported when renaming the output value.
To support this scenario a new function to detect the underlying type has been introduced.
Also, the resolver implementation is now able to loop through resolver values to rename those.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
I have introduced new tests to check these more complex scenarios, both in `bare` and `wrap` modes.

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests and linter rules pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules