### PR TITLE
Carry over schema extensions in replaceFederationSDLWithStitchingSDL

### DIFF
--- a/packages/mergers/stitching/src/index.ts
+++ b/packages/mergers/stitching/src/index.ts
@@ -83,6 +83,8 @@ export default class StitchingMerger implements MeshMerger {
       },
     });
 
+    newSchema.extensions = oldSchema.extensions;
+
     return newSchema;
   }
 


### PR DESCRIPTION
🚨 **IMPORTANT: Please do not create a Pull Request without creating an issue first.**

_Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request._

## Description

When a federation schema is converted to stitching `schema.extensions` is lost.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Screenshots/Sandbox (if appropriate/relevant):

Adding links to sandbox or providing screenshots can help us understand more about this PR and take action on it as appropriate

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- I've verified that extensions in schemas are present in a global schema transform.

**Test Environment**:

- OS: macOS
- `@graphql-mesh/...`: master
- NodeJS: 16

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests and linter rules pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

