### PR TITLE
Handle AbstractTypes in "bare" mode of NamingConvention transform

### DIFF
--- a/.changeset/metal-seahorses-drum.md
+++ b/.changeset/metal-seahorses-drum.md
@@ -1,0 +1,5 @@
+---
+'@graphql-mesh/transform-naming-convention': minor
+---
+
+Handle AbstractTypes in "bare" mode of NamingConvention transform

--- a/packages/transforms/naming-convention/test/__snapshots__/bareNamingConvention.spec.ts.snap
+++ b/packages/transforms/naming-convention/test/__snapshots__/bareNamingConvention.spec.ts.snap
@@ -1,14 +1,21 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`namingConvention - bare should change the name of a types, enums, fields and fieldArguments 1`] = `
+exports[`namingConvention - bare should change the name of types, abstractTypes, enums, fields and fieldArguments 1`] = `
 "type Query {
   user: User!
   userById(user_id: ID!): User!
+  node(id: ID!): Node
 }
+
+union Node = User | Post
 
 type User {
   id: ID!
   type: UserType
+}
+
+type Post {
+  id: ID!
 }
 
 enum UserType {

--- a/packages/transforms/naming-convention/test/__snapshots__/wrapNamingConvention.spec.ts.snap
+++ b/packages/transforms/naming-convention/test/__snapshots__/wrapNamingConvention.spec.ts.snap
@@ -4,11 +4,18 @@ exports[`namingConvention wrap should change the name of a types, enums, fields 
 "type Query {
   user: User!
   userById(user_id: ID!): User!
+  node(id: ID!): Node
 }
+
+union Node = User | Post
 
 type User {
   id: ID!
   type: UserType
+}
+
+type Post {
+  id: ID!
 }
 
 enum UserType {


### PR DESCRIPTION
## Description

As per the title, this PR adds handling of AbstractTypes renames to naming convention transform, `bare` mode.

## Type of change

Please delete options that are not relevant.
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
Tests for the use case have been added to both, the `bare` and `wrap` implementation

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests and linter rules pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules