### PR TITLE
Bare abstract

### DIFF
--- a/.changeset/long-carpets-judge.md
+++ b/.changeset/long-carpets-judge.md
@@ -1,0 +1,6 @@
+---
+'@graphql-mesh/transform-rename': minor
+'@graphql-mesh/transform-prefix': patch
+---
+
+Add support to AbstractType in "bare" mode of Rename transform and support async resolveType in "bare" Prefix transform

--- a/packages/transforms/prefix/package.json
+++ b/packages/transforms/prefix/package.json
@@ -27,6 +27,10 @@
   "peerDependencies": {
     "graphql": "*"
   },
+  "devDependencies": {
+    "@graphql-mesh/cache-localforage": "0.6.61",
+    "@graphql-tools/schema": "9.0.10"
+  },
   "dependencies": {
     "@graphql-mesh/types": "0.86.0",
     "@graphql-mesh/utils": "0.42.7",

--- a/packages/transforms/prefix/src/barePrefix.ts
+++ b/packages/transforms/prefix/src/barePrefix.ts
@@ -47,11 +47,11 @@ export default class BarePrefix implements MeshTransform {
         }
         return undefined;
       },
-      [MapperKind.ABSTRACT_TYPE]: (type: GraphQLAbstractType) => {
+      [MapperKind.ABSTRACT_TYPE]: type => {
         if (this.includeTypes && !isSpecifiedScalarType(type)) {
           const existingResolver = type.resolveType;
-          type.resolveType = (data, context, info, abstractType) => {
-            const typeName = existingResolver(data, context, info, abstractType);
+          type.resolveType = async (data, context, info, abstractType) => {
+            const typeName = await existingResolver(data, context, info, abstractType);
             return this.prefix + typeName;
           };
           const currentName = type.name;

--- a/packages/transforms/prefix/test/barePrefix.spec.ts
+++ b/packages/transforms/prefix/test/barePrefix.spec.ts
@@ -1,9 +1,8 @@
 import PrefixTransform from '../src';
-import { buildSchema, printSchema, GraphQLSchema, GraphQLObjectType, execute, parse } from 'graphql';
+import { printSchema, GraphQLSchema, GraphQLObjectType, execute, parse } from 'graphql';
 import InMemoryLRUCache from '@graphql-mesh/cache-localforage';
 import { MeshPubSub } from '@graphql-mesh/types';
 import { PubSub } from '@graphql-mesh/utils';
-import { wrapSchema } from '@graphql-tools/wrap';
 import { makeExecutableSchema } from '@graphql-tools/schema';
 
 describe('barePrefix', () => {

--- a/packages/transforms/prefix/test/wrapPrefix.spec.ts
+++ b/packages/transforms/prefix/test/wrapPrefix.spec.ts
@@ -1,5 +1,5 @@
 import PrefixTransform from '../src';
-import { buildSchema, printSchema, GraphQLSchema, GraphQLObjectType, execute, parse } from 'graphql';
+import { printSchema, GraphQLSchema, GraphQLObjectType, execute, parse } from 'graphql';
 import InMemoryLRUCache from '@graphql-mesh/cache-localforage';
 import { MeshPubSub } from '@graphql-mesh/types';
 import { PubSub } from '@graphql-mesh/utils';

--- a/packages/transforms/rename/test/__snapshots__/wrapRename.spec.ts.snap
+++ b/packages/transforms/rename/test/__snapshots__/wrapRename.spec.ts.snap
@@ -5,7 +5,10 @@ exports[`rename should change the name of a field 1`] = `
   user: MyUser!
   my_book: MyBook!
   profile(profile_id: ID!, role: String, some_argument: String, another_argument: Int): Profile
+  my_node(id: ID!): MyNode
 }
+
+union MyNode = MyUser | MyBook | Profile
 
 type MyUser {
   id: ID!
@@ -28,7 +31,10 @@ exports[`rename should change the name of a type 1`] = `
   my_user: User!
   my_book: MyBook!
   profile(profile_id: ID!, role: String, some_argument: String, another_argument: Int): Profile
+  my_node(id: ID!): MyNode
 }
+
+union MyNode = User | MyBook | Profile
 
 type User {
   id: ID!
@@ -51,7 +57,10 @@ exports[`rename should change the name of multiple fields 1`] = `
   user: MyUser!
   book: MyBook!
   profile(profile_id: ID!, role: String, some_argument: String, another_argument: Int): Profile
+  node(id: ID!): MyNode
 }
+
+union MyNode = MyUser | MyBook | Profile
 
 type MyUser {
   id: ID!
@@ -74,7 +83,10 @@ exports[`rename should change the name of multiple type names 1`] = `
   my_user: User!
   my_book: Book!
   profile(profile_id: ID!, role: String, some_argument: String, another_argument: Int): Profile
+  my_node(id: ID!): Node
 }
+
+union Node = User | Book | Profile
 
 type User {
   id: ID!
@@ -97,7 +109,10 @@ exports[`rename should not rename default Scalar types 1`] = `
   my_user: Prefixed_MyUser!
   my_book: Prefixed_MyBook!
   profile(profile_id: ID!, role: String, some_argument: String, another_argument: Int): Prefixed_Profile
+  my_node(id: ID!): Prefixed_MyNode
 }
+
+union Prefixed_MyNode = Prefixed_MyUser | Prefixed_MyBook | Prefixed_Profile
 
 type Prefixed_MyUser {
   id: ID!
@@ -120,7 +135,10 @@ exports[`rename should only affect field argument only if type and field are spe
   my_user: MyUser!
   my_book: MyBook!
   profile(profile_id: ID!, role: String, some_argument: String, another_argument: Int): Profile
+  my_node(id: ID!): MyNode
 }
+
+union MyNode = MyUser | MyBook | Profile
 
 type MyUser {
   id: ID!
@@ -143,7 +161,10 @@ exports[`rename should only affect specified field argument 1`] = `
   my_user: MyUser!
   my_book: MyBook!
   profile(profileId: ID!, role: String, some_argument: String, another_argument: Int): Profile
+  my_node(id: ID!): MyNode
 }
+
+union MyNode = MyUser | MyBook | Profile
 
 type MyUser {
   id: ID!
@@ -166,7 +187,10 @@ exports[`rename should only affect specified field match argument 1`] = `
   my_user: MyUser!
   my_book: MyBook!
   profile(profileId: ID!, role: String, some_argument: String, another_argument: Int): Profile
+  my_node(id: ID!): MyNode
 }
+
+union MyNode = MyUser | MyBook | Profile
 
 type MyUser {
   id: ID!
@@ -189,7 +213,10 @@ exports[`rename should only affect specified match type and match field argument
   my_user: MyUser!
   my_book: MyBook!
   profile(profileId: ID!, role: String, some_argument: String, another_argument: Int): Profile
+  my_node(id: ID!): MyNode
 }
+
+union MyNode = MyUser | MyBook | Profile
 
 type MyUser {
   id: ID!
@@ -212,7 +239,10 @@ exports[`rename should only affect specified type 1`] = `
   my_user: MyUser!
   my_bok: MyBook!
   prfile(profile_id: ID!, role: String, some_argument: String, another_argument: Int): Profile
+  my_nde(id: ID!): MyNode
 }
+
+union MyNode = MyUser | MyBook | Profile
 
 type MyUser {
   id: ID!
@@ -275,7 +305,10 @@ exports[`rename should replace the first occurrence of a substring in a field 1`
   my_user: MyUser!
   my_bok: MyBook!
   prfile(profile_id: ID!, role: String, some_argument: String, another_argument: Int): Profile
+  my_nde(id: ID!): MyNode
 }
+
+union MyNode = MyUser | MyBook | Profile
 
 type MyUser {
   id: ID!

--- a/packages/transforms/rename/test/bareRename.spec.ts
+++ b/packages/transforms/rename/test/bareRename.spec.ts
@@ -12,7 +12,10 @@ describe('rename', () => {
         my_user: MyUser!
         my_book: MyBook!
         profile(profile_id: ID!, role: String): Profile
+        my_node(id: ID!): MyNode
       }
+
+      union MyNode = MyUser | MyBook | Profile
 
       type MyUser {
         id: ID!
@@ -30,7 +33,22 @@ describe('rename', () => {
       }
     `,
     resolvers: {
-      Query: { my_user: () => ({ id: 'userId' }), profile: (_, args) => ({ id: `profile_${args.profile_id}` }) },
+      Query: {
+        my_user: () => ({ id: 'userId' }),
+        profile: (_, args) => ({ id: `profile_${args.profile_id}` }),
+        my_node: (_, { id }) => ({ id }),
+      },
+      MyNode: {
+        __resolveType({ id }: any) {
+          if (id === '1') {
+            return 'MyUser';
+          } else if (id === '2') {
+            return 'Profile';
+          } else {
+            return 'MyBook';
+          }
+        },
+      },
     },
   });
   let cache: InMemoryLRUCache;
@@ -142,6 +160,68 @@ describe('rename', () => {
     expect(result.data).toMatchObject({ my_user: { userId: 'userId' } });
   });
 
+  it('should resolve correctly Abstract type', async () => {
+    const transform = new RenameTransform({
+      config: {
+        mode: 'bare',
+        renames: [
+          {
+            from: {
+              type: 'My(.*)',
+            },
+            to: {
+              type: '$1',
+            },
+            useRegExpForTypes: true,
+          },
+        ],
+      },
+      apiName: '',
+      cache,
+      pubsub,
+      baseDir,
+      importFn,
+    });
+
+    const transformedSchema = transform.transformSchema(schema, {} as any);
+
+    const result1 = await graphql({
+      schema: transformedSchema,
+      source: /* GraphQL */ `
+        {
+          my_node(id: "1") {
+            __typename
+          }
+        }
+      `,
+    });
+    expect(result1.data).toMatchObject({ my_node: { __typename: 'User' } });
+
+    const result2 = await graphql({
+      schema: transformedSchema,
+      source: /* GraphQL */ `
+        {
+          my_node(id: "2") {
+            __typename
+          }
+        }
+      `,
+    });
+    expect(result2.data).toMatchObject({ my_node: { __typename: 'Profile' } });
+
+    const result3 = await graphql({
+      schema: transformedSchema,
+      source: /* GraphQL */ `
+        {
+          my_node(id: "3") {
+            __typename
+          }
+        }
+      `,
+    });
+    expect(result3.data).toMatchObject({ my_node: { __typename: 'Book' } });
+  });
+
   it('should change the name of multiple type names', () => {
     const transform = new RenameTransform({
       config: {
@@ -167,8 +247,11 @@ describe('rename', () => {
 
     const newSchema = transform.transformSchema(schema, {} as any);
 
+    expect(newSchema.getType('MyNode')).toBeUndefined();
+    expect(newSchema.getType('Node')).toBeDefined();
     expect(newSchema.getType('MyUser')).toBeUndefined();
     expect(newSchema.getType('User')).toBeDefined();
+    expect(newSchema.getType('Profile')).toBeDefined();
     expect(newSchema.getType('MyBook')).toBeUndefined();
     expect(newSchema.getType('Book')).toBeDefined();
   });
@@ -240,6 +323,8 @@ describe('rename', () => {
     const queryType = newSchema.getType('Query') as GraphQLObjectType;
     const fieldMap = queryType.getFields();
 
+    expect(fieldMap.my_node).toBeUndefined();
+    expect(fieldMap.node).toBeDefined();
     expect(fieldMap.my_user).toBeUndefined();
     expect(fieldMap.user).toBeDefined();
     expect(fieldMap.my_book).toBeUndefined();
@@ -275,6 +360,8 @@ describe('rename', () => {
     const queryType = newSchema.getType('Query') as GraphQLObjectType;
     const fieldMap = queryType.getFields();
 
+    expect(fieldMap.my_node).toBeUndefined();
+    expect(fieldMap.my_nde).toBeDefined();
     expect(fieldMap.my_book).toBeUndefined();
     expect(fieldMap.my_bok).toBeDefined();
   });
@@ -474,6 +561,8 @@ describe('rename', () => {
     const queryType = newSchema.getType('Query') as GraphQLObjectType;
     const fieldMap = queryType.getFields();
 
+    expect(fieldMap.my_node).toBeUndefined();
+    expect(fieldMap.my_nde).toBeDefined();
     expect(fieldMap.my_book).toBeUndefined();
     expect(fieldMap.my_bok).toBeDefined();
 


### PR DESCRIPTION
## Description
This PR addresses the following points:

1. Handling of AbstractTypes renames to Rename transform in `bare` mode
2. Add support for async `resolveType` to AbstractTypes in Prefix, `bare` mode

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

I have added test to both `bare` and `wrap` modes of Rename transform.

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests and linter rules pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules