### PR TITLE
Fix issue with naming-convention in bare mode and nested Input types

### DIFF
--- a/.changeset/silly-meals-learn.md
+++ b/.changeset/silly-meals-learn.md
@@ -1,0 +1,5 @@
+---
+'@graphql-mesh/transform-naming-convention': patch
+---
+
+Fix issue with nested Input types in bare mode

--- a/packages/transforms/naming-convention/src/bareNamingConvention.ts
+++ b/packages/transforms/naming-convention/src/bareNamingConvention.ts
@@ -13,6 +13,7 @@ import {
   GraphQLSchema,
   isInputObjectType,
   isEnumType,
+  getNamedType,
 } from 'graphql';
 import { MeshTransform, YamlConfig, MeshTransformOptions } from '@graphql-mesh/types';
 import { MapperKind, mapSchema, renameType } from '@graphql-tools/utils';
@@ -50,27 +51,7 @@ const defaultResolverComposer =
     const originalResult = resolveFn(
       root,
       // map renamed arguments to their original value
-      argsMap
-        ? Object.keys(args).reduce((acc, key: string) => {
-            if (!argsMap[key]) {
-              return { ...acc, [key]: args[key] };
-            }
-
-            const argKey = argsMap[key];
-            const mappedArgKeyIsObject = isObject(argKey);
-            const newArgName = Object.keys(argKey)[0];
-
-            return {
-              ...acc,
-              [mappedArgKeyIsObject ? newArgName : argKey]: mappedArgKeyIsObject
-                ? Object.entries(args[key]).reduce((acc, [key, value]) => {
-                    const oldInputFieldName = argKey[newArgName][key];
-                    return { ...acc, [oldInputFieldName || key]: value };
-                  }, {})
-                : args[key],
-            };
-          }, {})
-        : args,
+      argsMap ? argsFromArgMap(argsMap, args) : args,
       context,
       // map renamed field name to its original value
       originalFieldName ? { ...info, fieldName: originalFieldName } : info,
@@ -197,27 +178,16 @@ export default class NamingConventionTransform implements MeshTransform {
                 const useArgName = newArgName || argName;
                 const argIsInputObjectType = isInputObjectType(argConfig.type);
 
-                if (argName !== useArgName || argIsInputObjectType) {
-                  // take advantage of the loop to map arg name from Old to New
-                  argsMap[useArgName] = !argIsInputObjectType
-                    ? argName
-                    : {
-                        [argName]: Object.keys(
-                          (argConfig.type as GraphQLInputObjectType).toConfig().fields,
-                        ).reduce((inputFields, inputFieldName) => {
-                          if (Number.isFinite(inputFieldName)) return inputFields;
-
-                          const newInputFieldName = fieldNamingConventionFn(
-                            inputFieldName as string,
-                          );
-                          return newInputFieldName === inputFieldName
-                            ? inputFields
-                            : {
-                                ...inputFields,
-                                [fieldNamingConventionFn(inputFieldName as string)]: inputFieldName,
-                              };
-                        }, {}),
-                      };
+                if (argIsInputObjectType) {
+                  argsMap[useArgName] = {
+                    name: argName,
+                    fields: generateArgsMapForInput(
+                      argConfig.type as GraphQLInputObjectType,
+                      fieldNamingConventionFn,
+                    ),
+                  };
+                } else if (argName !== useArgName) {
+                  argsMap[useArgName] = argName;
                 }
 
                 return {
@@ -255,4 +225,68 @@ export default class NamingConventionTransform implements MeshTransform {
       }),
     });
   }
+}
+
+interface ArgsMap {
+  [argName: string]:
+    | string
+    | {
+        name: string;
+        fields: ArgsMap;
+      };
+}
+
+function generateArgsMapForInput(
+  input: GraphQLInputObjectType,
+  fieldNamingConventionFn?: null | ((input: string) => string),
+): ArgsMap {
+  const inputConfig = input.toConfig();
+  const inputFields = inputConfig.fields;
+  const argsMap = {};
+
+  Object.keys(inputFields).forEach(argName => {
+    if (typeof argName === 'number') return;
+
+    const newArgName = fieldNamingConventionFn ? fieldNamingConventionFn(argName) : argName;
+    const argConfig = inputFields[argName];
+
+    // Unwind any list
+    const type = getNamedType(argConfig.type);
+
+    const argIsInputObjectType = isInputObjectType(type);
+
+    if (argIsInputObjectType) {
+      argsMap[newArgName] = {
+        name: argName,
+        fields: generateArgsMapForInput(type as GraphQLInputObjectType, fieldNamingConventionFn),
+      };
+    } else {
+      argsMap[newArgName] = argName;
+    }
+  });
+
+  return argsMap;
+}
+
+// Map back from new arg name to the original one
+function argsFromArgMap(argMap: ArgsMap, args: any) {
+  const originalArgs = {};
+  Object.keys(args).forEach(newArgName => {
+    if (typeof newArgName !== 'string') return;
+
+    const argMapVal = argMap[newArgName];
+    const originalArgName = typeof argMapVal === 'string' ? argMapVal : argMapVal.name;
+    const val = args[newArgName];
+    if (Array.isArray(val) && typeof argMapVal !== 'string') {
+      originalArgs[originalArgName] = val.map(v =>
+        isObject(v) ? argsFromArgMap(argMapVal.fields, v) : v,
+      );
+    } else if (isObject(val) && typeof argMapVal !== 'string') {
+      originalArgs[originalArgName] = argsFromArgMap(argMapVal.fields, val);
+    } else {
+      originalArgs[originalArgName] = val;
+    }
+  });
+
+  return originalArgs;
 }

--- a/packages/transforms/naming-convention/test/bareNamingConvention.spec.ts
+++ b/packages/transforms/naming-convention/test/bareNamingConvention.spec.ts
@@ -108,16 +108,28 @@ describe('namingConvention - bare', () => {
           last_name: String
           Type: UserType!
           interests: [UserInterests!]!
+          custom_fields: [UserCustomField!]
         }
         type Post {
           id: ID!
+        }
+        type UserCustomField {
+          field_name: String!
+          value: String
         }
         input UserSearchInput {
           id: ID
           first_name: String
           last_name: String
           type: UserType
+          custom_fields: [UserSearchKeyCustomFieldInput!]
         }
+
+        input UserSearchKeyCustomFieldInput {
+          field_name: String!
+          value: String
+        }
+
         enum UserType {
           admin
           moderator
@@ -137,6 +149,7 @@ describe('namingConvention - bare', () => {
               first_name: args.Input.first_name,
               last_name: args.Input.last_name,
               Type: args.Input.type,
+              custom_fields: args.Input.custom_fields,
             };
           },
           userById: (_, args) => {
@@ -192,11 +205,23 @@ describe('namingConvention - bare', () => {
       schema: newSchema,
       document: parse(/* GraphQL */ `
         {
-          user(Input: { id: "0", firstName: "John", lastName: "Doe", type: ADMIN }) {
+          user(
+            Input: {
+              id: "0"
+              firstName: "John"
+              lastName: "Doe"
+              type: ADMIN
+              customFields: [{ fieldName: "age", value: "30" }]
+            }
+          ) {
             id
             firstName
             lastName
             type
+            customFields {
+              fieldName
+              value
+            }
           }
         }
       `),
@@ -207,6 +232,7 @@ describe('namingConvention - bare', () => {
       firstName: 'John',
       lastName: 'Doe',
       type: 'ADMIN',
+      customFields: [{ fieldName: 'age', value: '30' }],
     });
 
     const result2 = await execute({


### PR DESCRIPTION
## Description

Using the naming-convention transform in "bare" mode, it doesn't correctly transform nested field argument Input types. See #4895 for details.

The code for this transform was only operating at the root level of any Inputs when considering field arguments. This fix adapts the code to fully iterate through any Inputs, including nested ones.

Fixes #4895

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?

Modified the bareNamingConvention spec to include this scenario

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests and linter rules pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
