### PR TITLE
fix(deps): add missing `tslib` dependency to `@graphql-mesh/string-interpolation`

### DIFF
--- a/.changeset/giant-dolls-fry.md
+++ b/.changeset/giant-dolls-fry.md
@@ -1,0 +1,5 @@
+---
+'@graphql-mesh/string-interpolation': patch
+---
+
+Added missing `tslib` dependency

--- a/packages/string-interpolation/package.json
+++ b/packages/string-interpolation/package.json
@@ -36,7 +36,8 @@
   "dependencies": {
     "dayjs": "1.11.7",
     "json-pointer": "0.6.2",
-    "lodash.get": "4.4.2"
+    "lodash.get": "4.4.2",
+    "tslib": "^2.4.0"
   },
   "publishConfig": {
     "access": "public",


### PR DESCRIPTION
## Description

This PR adds a missing `tslib` dependency to `@graphql-mesh/string-interpolation`

Fixes https://github.com/Urigo/graphql-mesh/issues/4998

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

## Screenshots/Sandbox (if appropriate/relevant):

N/A

## How Has This Been Tested?

N/A

**Test Environment**:

N/A

## Checklist:

- [X] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests and linter rules pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

N/A