### PR TITLE
Add additional configuration to disable including req/resp header labels

### DIFF
--- a/.changeset/quiet-icons-poke.md
+++ b/.changeset/quiet-icons-poke.md
@@ -1,0 +1,5 @@
+---
+'@graphql-mesh/plugin-prometheus': minor
+---
+
+`fetchRequestHeaders`, `fetchResponseHeaders`, `httpRequestHeaders` and `httpResponseHeaders`

--- a/packages/plugins/prometheus/src/index.ts
+++ b/packages/plugins/prometheus/src/index.ts
@@ -250,7 +250,7 @@ export default async function useMeshPrometheus(
           const end = Date.now();
           const duration = end - start;
 
-          let labels: Partial<Record<string, string | number>> = {
+          const labels: Partial<Record<string, string | number>> = {
             url,
             method: options.method,
             statusCode: response.status,
@@ -258,16 +258,10 @@ export default async function useMeshPrometheus(
           };
 
           if (pluginOptions.fetchRequestHeaders) {
-            labels = {
-              ...labels,
-              requestHeaders: JSON.stringify(options.headers),
-            };
+            labels.requestHeaders = JSON.stringify(options.headers);
           }
           if (pluginOptions.fetchResponseHeaders) {
-            labels = {
-              ...labels,
-              responseHeaders: JSON.stringify(response.headers),
-            };
+            labels.responseHeaders = JSON.stringify(getHeadersObj(response.headers));
           }
 
           fetchHistogram.observe(labels, duration);

--- a/packages/plugins/prometheus/src/index.ts
+++ b/packages/plugins/prometheus/src/index.ts
@@ -32,17 +32,17 @@ export default async function useMeshPrometheus(
   if (pluginOptions.fetch) {
     const name =
       typeof pluginOptions.fetch === 'string' ? pluginOptions.fetch : 'graphql_mesh_fetch_duration';
+    const labelNames = ['url', 'method', 'statusCode', 'statusText'];
+    if (pluginOptions.fetchRequestHeaders) {
+      labelNames.push('requestHeaders');
+    }
+    if (pluginOptions.fetchResponseHeaders) {
+      labelNames.push('responseHeaders');
+    }
     fetchHistogram = new Histogram({
       name,
       help: 'Time spent on outgoing HTTP calls',
-      labelNames: [
-        'url',
-        'method',
-        'requestHeaders',
-        'statusCode',
-        'statusText',
-        'responseHeaders',
-      ],
+      labelNames,
       registers: [registry],
     });
   }
@@ -65,9 +65,12 @@ export default async function useMeshPrometheus(
   let httpHistogram: HistogramContainer | undefined;
 
   if (pluginOptions.http) {
-    const labelNames = ['url', 'method', 'statusCode', 'statusText', 'responseHeaders'];
+    const labelNames = ['url', 'method', 'statusCode', 'statusText'];
     if (pluginOptions.httpRequestHeaders) {
       labelNames.push('requestHeaders');
+    }
+    if (pluginOptions.httpResponseHeaders) {
+      labelNames.push('responseHeaders');
     }
     const name =
       typeof pluginOptions.http === 'string' ? pluginOptions.http : 'graphql_mesh_http_duration';
@@ -84,10 +87,12 @@ export default async function useMeshPrometheus(
           method: request.method,
           statusCode: response.status,
           statusText: response.statusText,
-          responseHeaders: JSON.stringify(getHeadersObj(response.headers)),
         };
         if (pluginOptions.httpRequestHeaders) {
           labels.requestHeaders = JSON.stringify(getHeadersObj(request.headers));
+        }
+        if (pluginOptions.httpResponseHeaders) {
+          labels.responseHeaders = JSON.stringify(getHeadersObj(response.headers));
         }
         return labels;
       },
@@ -244,17 +249,28 @@ export default async function useMeshPrometheus(
         return ({ response }) => {
           const end = Date.now();
           const duration = end - start;
-          fetchHistogram.observe(
-            {
-              url,
-              method: options.method,
+
+          let labels: Partial<Record<string, string | number>> = {
+            url,
+            method: options.method,
+            statusCode: response.status,
+            statusText: response.statusText,
+          };
+
+          if (pluginOptions.fetchRequestHeaders) {
+            labels = {
+              ...labels,
               requestHeaders: JSON.stringify(options.headers),
-              statusCode: response.status,
-              statusText: response.statusText,
-              responseHeaders: JSON.stringify(getHeadersObj(response.headers)),
-            },
-            duration,
-          );
+            };
+          }
+          if (pluginOptions.fetchResponseHeaders) {
+            labels = {
+              ...labels,
+              responseHeaders: JSON.stringify(response.headers),
+            };
+          }
+
+          fetchHistogram.observe(labels, duration);
         };
       }
       return undefined;

--- a/packages/plugins/prometheus/yaml-config.graphql
+++ b/packages/plugins/prometheus/yaml-config.graphql
@@ -17,13 +17,17 @@ type PrometheusConfig @md {
   registry: String
 
   # Mesh specific flags
+
   delegation: BooleanOrString
   fetch: BooleanOrString
   fetchRequestHeaders: Boolean
+  fetchResponseHeaders: Boolean
 
   # Yoga specific flags
+
   http: BooleanOrString
   httpRequestHeaders: Boolean
+  httpResponseHeaders: Boolean
   """
   The path to the metrics endpoint
   default: `/metrics`

--- a/packages/types/src/config-schema.json
+++ b/packages/types/src/config-schema.json
@@ -2470,6 +2470,9 @@
         "fetchRequestHeaders": {
           "type": "boolean"
         },
+        "fetchResponseHeaders": {
+          "type": "boolean"
+        },
         "http": {
           "description": "Any of: Boolean, String",
           "anyOf": [
@@ -2482,6 +2485,9 @@
           ]
         },
         "httpRequestHeaders": {
+          "type": "boolean"
+        },
+        "httpResponseHeaders": {
           "type": "boolean"
         },
         "endpoint": {

--- a/packages/types/src/config.ts
+++ b/packages/types/src/config.ts
@@ -1969,11 +1969,14 @@ export interface PrometheusConfig {
    */
   fetch?: boolean | string;
   fetchRequestHeaders?: boolean;
+  fetchResponseHeaders?: boolean;
+
   /**
    * Any of: Boolean, String
    */
   http?: boolean | string;
   httpRequestHeaders?: boolean;
+  httpResponseHeaders?: boolean;
   /**
    * The path to the metrics endpoint
    * default: `/metrics`


### PR DESCRIPTION
Issue: [5144](https://github.com/Urigo/graphql-mesh/issues/5144)

## Description
Attempt to add additional flags for controlling the labels of metrics emitted by graphql mesh, specifically to remove any request/response headers, as these are very poor choices for metric labels, as the cause a cardinality explosion as each metric ends up being unique. 

note: I am not a node/javascript/typescript developer, so this may require additional eyes. 

Fixes # (5144)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
      expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] I have followed the
      [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the
      style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works (no existing tests to follow)
- [x] New and existing unit tests and linter rules pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
