### PR TITLE
enhance(json-schema): handle discriminator mapping

### DIFF
--- a/packages/loaders/json-schema/src/directives.ts
+++ b/packages/loaders/json-schema/src/directives.ts
@@ -90,6 +90,19 @@ export const DiscriminatorDirective = new GraphQLDirective({
   },
 });
 
+export const DiscriminatorMappingDirective = new GraphQLDirective({
+  name: 'discriminatorMapping',
+  locations: [DirectiveLocation.INTERFACE, DirectiveLocation.UNION],
+  args: {
+    value: {
+      type: GraphQLString,
+    },
+    schema: {
+      type: GraphQLString,
+    },
+  },
+});
+
 export function processDiscriminatorAnnotations(
   interfaceType: GraphQLInterfaceType,
   fieldName: string,

--- a/packages/loaders/json-schema/src/getComposerFromJSONSchema.ts
+++ b/packages/loaders/json-schema/src/getComposerFromJSONSchema.ts
@@ -54,6 +54,7 @@ import { sanitizeNameForGraphQL } from '@graphql-mesh/utils';
 import {
   DictionaryDirective,
   DiscriminatorDirective,
+  DiscriminatorMappingDirective,
   EnumDirective,
   ExampleDirective,
   LengthDirective,
@@ -743,6 +744,20 @@ export function getComposerFromJSONSchema(
               field: subSchema.discriminator.propertyName,
             },
           });
+
+          if (subSchema.discriminator.mapping) {
+            schemaComposer.addDirective(DiscriminatorMappingDirective);
+            Object.keys(subSchema.discriminator.mapping).forEach(value => {
+              const mappedSchema = subSchema.discriminator.mapping[value].split('schemas/')[1];
+              directives.push({
+                name: 'discriminatorMapping',
+                args: {
+                  value,
+                  schema: mappedSchema,
+                },
+              });
+            });
+          }
         }
         const output = schemaComposer.createUnionTC({
           name: getValidTypeName({

--- a/packages/loaders/json-schema/src/getTypeResolverFromOutputTCs.ts
+++ b/packages/loaders/json-schema/src/getTypeResolverFromOutputTCs.ts
@@ -4,13 +4,14 @@ import { createGraphQLError } from '@graphql-tools/utils';
 export function getTypeResolverFromOutputTCs(
   possibleTypes: readonly GraphQLObjectType[],
   discriminatorField?: string,
+  discriminatorMapping?: Record<string, string>,
   statusCodeTypeNameMap?: Record<string, string>,
 ): GraphQLTypeResolver<any, any> {
   return function resolveType(data: any) {
     if (data.__typename) {
       return data.__typename;
     } else if (discriminatorField != null && data[discriminatorField]) {
-      return data[discriminatorField];
+      return discriminatorMapping[data[discriminatorField]] || data[discriminatorField];
     }
     if (data.$statusCode && statusCodeTypeNameMap) {
       const typeName =
@@ -19,6 +20,7 @@ export function getTypeResolverFromOutputTCs(
         return typeName;
       }
     }
+
     // const validationErrors: Record<string, ErrorObject[]> = {};
     const dataKeys =
       typeof data === 'object'

--- a/packages/loaders/json-schema/src/getTypeResolverFromOutputTCs.ts
+++ b/packages/loaders/json-schema/src/getTypeResolverFromOutputTCs.ts
@@ -1,17 +1,23 @@
 import { GraphQLObjectType, GraphQLTypeResolver } from 'graphql';
 import { createGraphQLError } from '@graphql-tools/utils';
 
-export function getTypeResolverFromOutputTCs(
-  possibleTypes: readonly GraphQLObjectType[],
-  discriminatorField?: string,
-  discriminatorMapping?: Record<string, string>,
-  statusCodeTypeNameMap?: Record<string, string>,
-): GraphQLTypeResolver<any, any> {
+export function getTypeResolverFromOutputTCs({
+  possibleTypes,
+  discriminatorField,
+  discriminatorMapping,
+  statusCodeTypeNameMap,
+}: {
+  possibleTypes: readonly GraphQLObjectType[];
+  discriminatorField?: string;
+  discriminatorMapping?: Record<string, string>;
+  statusCodeTypeNameMap?: Record<string, string>;
+}): GraphQLTypeResolver<any, any> {
   return function resolveType(data: any) {
     if (data.__typename) {
       return data.__typename;
     } else if (discriminatorField != null && data[discriminatorField]) {
-      return discriminatorMapping[data[discriminatorField]] || data[discriminatorField];
+      const discriminatorValue = data[discriminatorField];
+      return discriminatorMapping?.[discriminatorValue] || discriminatorValue;
     }
     if (data.$statusCode && statusCodeTypeNameMap) {
       const typeName =

--- a/packages/loaders/openapi/package.json
+++ b/packages/loaders/openapi/package.json
@@ -44,6 +44,7 @@
   },
   "devDependencies": {
     "@graphql-tools/utils": "9.2.1",
+    "@whatwg-node/fetch": "0.8.4",
     "@whatwg-node/router": "0.3.0",
     "graphql-yoga": "3.8.0",
     "json-bigint-patch": "0.0.8"

--- a/packages/loaders/openapi/tests/__snapshots__/discriminator.test.ts.snap
+++ b/packages/loaders/openapi/tests/__snapshots__/discriminator.test.ts.snap
@@ -1,0 +1,45 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Discriminator Mapping should generate correct schema: discriminator-mapping 1`] = `
+"schema {
+  query: Query
+}
+
+directive @oneOf on OBJECT | INTERFACE
+
+directive @discriminator(field: String, mapping: ObjMap) on INTERFACE | UNION
+
+directive @globalOptions(sourceName: String, endpoint: String, operationHeaders: ObjMap, queryStringOptions: ObjMap, queryParams: ObjMap) on OBJECT
+
+directive @httpOperation(path: String, operationSpecificHeaders: ObjMap, httpMethod: HTTPMethod, isBinary: Boolean, requestBaseBody: ObjMap, queryParamArgMap: ObjMap, queryStringOptionsByParam: ObjMap) on FIELD_DEFINITION
+
+type Query @globalOptions(sourceName: "test") {
+  pets_by_id(id: String!): Pet @httpOperation(path: "/pets/{args.id}", operationSpecificHeaders: "{\\"accept\\":\\"application/json\\"}", httpMethod: GET)
+}
+
+union Pet @discriminator(field: "petType", mapping: "{\\"Dog\\":\\"DogDifferent\\",\\"Cat\\":\\"Cat\\"}") = Cat | DogDifferent
+
+type Cat {
+  petType: String
+  cat_exclusive: String
+}
+
+type DogDifferent {
+  petType: String
+  dog_exclusive: String
+}
+
+scalar ObjMap
+
+enum HTTPMethod {
+  GET
+  HEAD
+  POST
+  PUT
+  DELETE
+  CONNECT
+  OPTIONS
+  TRACE
+  PATCH
+}"
+`;

--- a/packages/loaders/openapi/tests/discriminator.test.ts
+++ b/packages/loaders/openapi/tests/discriminator.test.ts
@@ -1,0 +1,70 @@
+import { execute, GraphQLSchema, parse } from 'graphql';
+import { printSchemaWithDirectives } from '@graphql-tools/utils';
+import { Response } from '@whatwg-node/fetch';
+import { loadGraphQLSchemaFromOpenAPI } from '../src/loadGraphQLSchemaFromOpenAPI.js';
+
+describe('Discriminator Mapping', () => {
+  let createdSchema: GraphQLSchema;
+  beforeAll(async () => {
+    createdSchema = await loadGraphQLSchemaFromOpenAPI('test', {
+      source: './fixtures/discriminator-mapping.yml',
+      cwd: __dirname,
+      ignoreErrorResponses: true,
+      async fetch(url) {
+        if (url === 'pets/1') {
+          return Response.json({
+            petType: 'Dog',
+            dog_exclusive: 'DOG_EXCLUSIVE',
+          });
+        }
+        if (url === 'pets/2') {
+          return Response.json({
+            petType: 'Cat',
+            cat_exclusive: 'CAT_EXCLUSIVE',
+          });
+        }
+        return new Response(null, {
+          status: 404,
+        });
+      },
+      // It is not possible to provide a union type with File scalar
+    });
+  });
+  it('should generate correct schema', () => {
+    expect(printSchemaWithDirectives(createdSchema)).toMatchSnapshot('discriminator-mapping');
+  });
+  it('should handle discriminator mapping', async () => {
+    const query = /* GraphQL */ `
+      query {
+        dog: pets_by_id(id: "1") {
+          __typename
+          ... on DogDifferent {
+            petType
+          }
+        }
+        cat: pets_by_id(id: "2") {
+          __typename
+          ... on Cat {
+            petType
+          }
+        }
+      }
+    `;
+    const result = await execute({
+      schema: createdSchema,
+      document: parse(query),
+    });
+    expect(result).toEqual({
+      data: {
+        dog: {
+          __typename: 'DogDifferent',
+          petType: 'Dog',
+        },
+        cat: {
+          __typename: 'Cat',
+          petType: 'Cat',
+        },
+      },
+    });
+  });
+});

--- a/packages/loaders/openapi/tests/fixtures/discriminator-mapping.yml
+++ b/packages/loaders/openapi/tests/fixtures/discriminator-mapping.yml
@@ -1,0 +1,47 @@
+openapi: 3.0.0
+info:
+  version: 1.0.0
+  title: Swagger Petstore
+  license:
+    name: MIT
+paths:
+  /pets/{id}:
+    get:
+      parameters:
+        - name: id
+          required: true
+          in: path
+          schema:
+            type: string
+      responses:
+        200:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Pet'
+
+components:
+  schemas:
+    Pet:
+      oneOf:
+        - $ref: '#/components/schemas/Cat'
+        - $ref: '#/components/schemas/DogDifferent'
+      discriminator:
+        propertyName: petType
+        mapping:
+          Dog: '#/components/schemas/DogDifferent'
+          Cat: '#/components/schemas/Cat'
+    Cat:
+      type: object
+      properties:
+        petType:
+          type: string
+        cat_exclusive:
+          type: string
+    DogDifferent:
+      type: object
+      properties:
+        petType:
+          type: string
+        dog_exclusive:
+          type: string

--- a/packages/loaders/openapi/tests/schemas.test.ts
+++ b/packages/loaders/openapi/tests/schemas.test.ts
@@ -22,6 +22,7 @@ const schemas: Record<string, string> = {
   BlockFrost: 'blockfrost.json',
   'Int64 with Defaults': 'int64-with-defaults.yml',
   'Different fields with the same type': 'different-prop-same-type.yaml',
+  DiscriminatorMapping: 'discriminator-mapping.yml',
 };
 
 describe('Schemas', () => {

--- a/packages/loaders/openapi/tests/schemas.test.ts
+++ b/packages/loaders/openapi/tests/schemas.test.ts
@@ -22,7 +22,6 @@ const schemas: Record<string, string> = {
   BlockFrost: 'blockfrost.json',
   'Int64 with Defaults': 'int64-with-defaults.yml',
   'Different fields with the same type': 'different-prop-same-type.yaml',
-  DiscriminatorMapping: 'discriminator-mapping.yml',
 };
 
 describe('Schemas', () => {


### PR DESCRIPTION
🚨 **IMPORTANT: Please do not create a Pull Request without creating an issue first.**

_Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of
the pull request._

## Description

If discriminator mapping has a different name, `getTypeResolverFromOutputTCs` fails to resolve it to the correct schema. This PR adds a DiscriminatorMappingDirective and tags discriminated unions with its mappings if theyre existent.

Fixes # TODO

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
      expected)
- [ ] This change requires a documentation update

## Screenshots/Sandbox (if appropriate/relevant):

Adding links to sandbox or providing screenshots can help us understand more about this PR and take
action on it as appropriate

## How Has This Been Tested?

I've added a schema that should break if you try to query for DifferentDog. Id like to add a test case for `getTypeResolverFromOutputTCs` picking the values for directives but Im not sure how. Would gladly add it with some guidance.

- [ ] Test A
- [ ] Test B

**Test Environment**:

- OS:
- `@graphql-mesh/...`:
- NodeJS:

## Checklist:

- [ ] I have followed the
      [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the
      style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests and linter rules pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose
the solution you did and what alternatives you considered, etc...
