### PR TITLE
fix(string-interpolation): operation headers not interpolated when req.headers is a HeaderMap

### DIFF
--- a/packages/string-interpolation/src/resolver-data-factory.ts
+++ b/packages/string-interpolation/src/resolver-data-factory.ts
@@ -65,9 +65,12 @@ export function getInterpolatedStringFactory(
 }
 
 export function getInterpolatedHeadersFactory(
-  nonInterpolatedHeaders: Record<string, string> = {},
+  nonInterpolatedHeaders: Record<string, string> | ResolverDataBasedFactory<Record<string, string>> = {},
 ): ResolverDataBasedFactory<Record<string, string>> {
   return resolverData => {
+    if (typeof nonInterpolatedHeaders === 'function') {
+      return nonInterpolatedHeaders(resolverData);
+    }
     const headers: Record<string, string> = {};
     for (const headerName in nonInterpolatedHeaders) {
       const headerValue = nonInterpolatedHeaders[headerName];


### PR DESCRIPTION
## Description

Considering how to set dynamic header values: https://the-guild.dev/graphql/mesh/docs/guides/headers

This PR allows the mesh config `operationHeaders` to be a function that returns the headers object. It takes the `resolverData` as first argument so we can have access to the `context.req.headers`. This fixes the issues where the `headers` object is a HeaderMap (you need to call `headers.get('key')`) which is not interpolated as expected:

Fixes #5226

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Sandbox

🚀 See it in action by checking out the [`fixed` branch](https://github.com/pmrotule/graphql-mesh-headers-not-interpolated/tree/fixed) of the issue reproduction repo. The changes of this PR has been published on npm under [@pmrotule/graphql-mesh-string-interpolation@0.4.3-beta.2](https://www.npmjs.com/package/@pmrotule/graphql-mesh-string-interpolation).

## How Has This Been Tested?

It has been tested in the issue reproduction repo and our real GraphQL Mesh integration (not tested on production yet). We still need to add test in this PR. Any guidance around tests would be appreciated since I haven't found any test regarding string interpolation.

**Test Environment**:

- OS: MacOS Monterey 12.6.1
- `@graphql-mesh/string-interpolation`: 0.4.2 (latest)
- NodeJS: 18.14.0
- `express`: 4.18.2 (latest)
- `@apollo/server`: 4.5.0 (latest)

## Checklist:

- [x] I have followed the
      [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the
      style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests and linter rules pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

I made the changes in the `string-interpolation` package even though it doesn't perform any string interpolation. It might be better to define it elsewhere, but I would love your feedback on that one.

We also started to get warnings from the JSON Schema validation of the mesh config, but I'm not sure where to update this (is it based on the Typescript types?).

<img width="608" alt="image" src="https://user-images.githubusercontent.com/10983258/225588505-8a49da17-4339-4209-a3f0-0c54d64c2ceb.png">
