### PR TITLE
soap: fix creating root value when only mutations present

### DIFF
--- a/.changeset/stupid-planes-reply.md
+++ b/.changeset/stupid-planes-reply.md
@@ -1,0 +1,5 @@
+---
+'@omnigraph/soap': patch
+---
+
+Fix creating soap executor for a service with mutations only

--- a/packages/loaders/soap/src/executor.ts
+++ b/packages/loaders/soap/src/executor.ts
@@ -124,6 +124,11 @@ function createRootValue(schema: GraphQLSchema, fetchFn: MeshFetch) {
     const rootFieldMap = rootType.getFields();
     for (const fieldName in rootFieldMap) {
       const annotations = getDirective(schema, rootFieldMap[fieldName], 'soap');
+      if (!annotations) {
+        // skip fields without @soap directive
+        // we have to skip Query.placeholder field when only mutations were created
+        continue;
+      }
       const soapAnnotations: SoapAnnotations = Object.assign({}, ...annotations);
       rootValue[fieldName] = createRootValueMethod(soapAnnotations, fetchFn);
     }

--- a/packages/loaders/soap/test/__snapshots__/soap.test.ts.snap
+++ b/packages/loaders/soap/test/__snapshots__/soap.test.ts.snap
@@ -1,5 +1,45 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`SOAP Loader should create executor for a service with mutations and query placeholder 1`] = `
+"schema {
+  query: Query
+  mutation: Mutation
+}
+
+directive @soap(elementName: String, bindingNamespace: String, endpoint: String) on FIELD_DEFINITION
+
+type Query {
+  placeholder: Void
+}
+
+"Represents NULL values"
+scalar Void
+
+type Mutation {
+  NumberConversion_NumberConversion_NumberConversionSoap_NumberToWords(NumberToWords: NumberConversion_NumberToWords_Input): NumberConversion_NumberToWordsResponse @soap(elementName: "NumberToWordsResponse", bindingNamespace: "http://www.dataaccess.com/webservicesserver/", endpoint: "https://www.dataaccess.com/webservicesserver/NumberConversion.wso")
+  NumberConversion_NumberConversion_NumberConversionSoap_NumberToDollars(NumberToDollars: NumberConversion_NumberToDollars_Input): NumberConversion_NumberToDollarsResponse @soap(elementName: "NumberToDollarsResponse", bindingNamespace: "http://www.dataaccess.com/webservicesserver/", endpoint: "https://www.dataaccess.com/webservicesserver/NumberConversion.wso")
+}
+
+type NumberConversion_NumberToWordsResponse {
+  NumberToWordsResult: String!
+}
+
+input NumberConversion_NumberToWords_Input {
+  ubiNum: BigInt
+}
+
+"The \`BigInt\` scalar type represents non-fractional signed whole numeric values."
+scalar BigInt
+
+type NumberConversion_NumberToDollarsResponse {
+  NumberToDollarsResult: String!
+}
+
+input NumberConversion_NumberToDollars_Input {
+  dNum: Float
+}"
+`;
+
 exports[`SOAP Loader should generate the schema correctly 1`] = `
 "schema {
   query: Query

--- a/packages/loaders/soap/test/fixtures/greeting.wsdl
+++ b/packages/loaders/soap/test/fixtures/greeting.wsdl
@@ -1,0 +1,91 @@
+<definitions xmlns="http://schemas.xmlsoap.org/wsdl/" xmlns:xs="http://www.w3.org/2001/XMLSchema"
+						 xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/" xmlns:tns="http://www.dataaccess.com/webservicesserver/"
+						 name="NumberConversion" targetNamespace="http://www.dataaccess.com/webservicesserver/">
+	<types>
+		<xs:schema elementFormDefault="qualified" targetNamespace="http://www.dataaccess.com/webservicesserver/">
+			<xs:element name="NumberToWords">
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="ubiNum" type="xs:unsignedLong"/>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="NumberToWordsResponse">
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="NumberToWordsResult" type="xs:string"/>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="NumberToDollars">
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="dNum" type="xs:decimal"/>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="NumberToDollarsResponse">
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="NumberToDollarsResult" type="xs:string"/>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+		</xs:schema>
+	</types>
+	<message name="NumberToWordsSoapRequest">
+		<part name="parameters" element="tns:NumberToWords"/>
+	</message>
+	<message name="NumberToWordsSoapResponse">
+		<part name="parameters" element="tns:NumberToWordsResponse"/>
+	</message>
+	<message name="NumberToDollarsSoapRequest">
+		<part name="parameters" element="tns:NumberToDollars"/>
+	</message>
+	<message name="NumberToDollarsSoapResponse">
+		<part name="parameters" element="tns:NumberToDollarsResponse"/>
+	</message>
+	<portType name="NumberConversionSoapType">
+		<operation name="NumberToWords">
+			<documentation>Returns the word corresponding to the positive number passed as parameter. Limited to
+				quadrillions.
+			</documentation>
+			<input message="tns:NumberToWordsSoapRequest"/>
+			<output message="tns:NumberToWordsSoapResponse"/>
+		</operation>
+		<operation name="NumberToDollars">
+			<documentation>Returns the non-zero dollar amount of the passed number.</documentation>
+			<input message="tns:NumberToDollarsSoapRequest"/>
+			<output message="tns:NumberToDollarsSoapResponse"/>
+		</operation>
+	</portType>
+	<binding name="NumberConversionSoapBinding" type="tns:NumberConversionSoapType">
+		<soap:binding style="document" transport="http://schemas.xmlsoap.org/soap/http"/>
+		<operation name="NumberToWords">
+			<soap:operation soapAction="" style="document"/>
+			<input>
+				<soap:body use="literal"/>
+			</input>
+			<output>
+				<soap:body use="literal"/>
+			</output>
+		</operation>
+		<operation name="NumberToDollars">
+			<soap:operation soapAction="" style="document"/>
+			<input>
+				<soap:body use="literal"/>
+			</input>
+			<output>
+				<soap:body use="literal"/>
+			</output>
+		</operation>
+	</binding>
+	<service name="NumberConversion">
+		<documentation>The Number Conversion Web Service, implemented with Visual DataFlex, provides functions that convert
+			numbers into words or dollar amounts.
+		</documentation>
+		<port name="NumberConversionSoap" binding="tns:NumberConversionSoapBinding">
+			<soap:address location="https://www.dataaccess.com/webservicesserver/NumberConversion.wso"/>
+		</port>
+	</service>
+</definitions>


### PR DESCRIPTION
🚨 **IMPORTANT: Please do not create a Pull Request without creating an issue first.**

_Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of
the pull request._

## Description

When schema generated from service wsdl file contains only mutations we could not create rootValue for the executor cause  `Query.placeholder` field does not contains `@soap` directive


Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
      expected)
- [ ] This change requires a documentation update

## Screenshots/Sandbox (if appropriate/relevant):

Adding links to sandbox or providing screenshots can help us understand more about this PR and take
action on it as appropriate

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can
reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Environment**:

- OS:
- `@graphql-mesh/...`:
- NodeJS:

## Checklist:

- [ ] I have followed the
      [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the
      style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests and linter rules pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose
the solution you did and what alternatives you considered, etc...
