### PR TITLE
chore(deps): @graphql-tools/stitch / fix pnpm installs

### DIFF
--- a/packages/mergers/stitching/package.json
+++ b/packages/mergers/stitching/package.json
@@ -39,7 +39,7 @@
   "dependencies": {
     "@graphql-tools/delegate": "^9.0.32",
     "@graphql-tools/schema": "^9.0.18",
-    "@graphql-tools/stitch": "^8.7.48",
+    "@graphql-tools/stitch": "^8.7.50",
     "@graphql-tools/stitching-directives": "^2.3.34"
   },
   "publishConfig": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2952,7 +2952,7 @@
     tslib "^2.4.0"
     value-or-promise "1.0.11"
 
-"@graphql-tools/stitch@^8.7.48":
+"@graphql-tools/stitch@^8.7.50":
   version "8.7.50"
   resolved "https://registry.yarnpkg.com/@graphql-tools/stitch/-/stitch-8.7.50.tgz#bcadf4b0dd20e22fb568042e94d711750c10f122"
   integrity sha512-VB1/uZyXjj1P5Wj0c4EKX3q8Q1Maj4dy6uNwodEPaO3EHMpaJU/DqyN0Bvnhxu0ol7RzdY3kgsvsdUjU2QMImw==


### PR DESCRIPTION
## Description

Fix install with pnpm by updating @graphql-tools/stitch to 8.7.50. 

Sorry to not have created an issue. But you'll find an explanation in

- PR: https://github.com/ardatan/graphql-tools/pull/5235
- Issue: https://github.com/ardatan/graphql-tools/issues/5234

Since it has been integrated in the 8.7.50 version https://github.com/ardatan/graphql-tools/releases/tag/release-1683799570488 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots/Sandbox (if appropriate/relevant):

With pnpm 8.5.0, from https://github.com/belgattitude/compare-package-managers/actions/runs/4845333008/jobs/8634183484?pr=14

![image](https://github.com/Urigo/graphql-mesh/assets/259798/bf4ee43b-a055-4b96-a055-63aacda9989e)


## How Has This Been Tested?

- PR: https://github.com/ardatan/graphql-tools/pull/5235

## Checklist:

- [x] I have followed the
      [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the
      style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests and linter rules pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

