### PR TITLE
fix: OpenApi enums serialization

### DIFF
--- a/.changeset/eighty-islands-dress.md
+++ b/.changeset/eighty-islands-dress.md
@@ -1,0 +1,6 @@
+---
+'@omnigraph/json-schema': patch
+'@omnigraph/openapi': patch
+---
+
+Fix plain string json encoding of enums

--- a/packages/loaders/json-schema/src/addRootFieldResolver.ts
+++ b/packages/loaders/json-schema/src/addRootFieldResolver.ts
@@ -194,7 +194,7 @@ export function addHTTPRootFieldResolver(
           }
           requestInit.body = formData;
         } else {
-          requestInit.body = typeof input === 'object' ? JSON.stringify(input) : input;
+          requestInit.body = JSON.stringify(input);
         }
       }
     }

--- a/packages/loaders/json-schema/src/addRootFieldResolver.ts
+++ b/packages/loaders/json-schema/src/addRootFieldResolver.ts
@@ -193,6 +193,8 @@ export function addHTTPRootFieldResolver(
             }
           }
           requestInit.body = formData;
+        } else if (contentType?.startsWith('text/plain')) {
+          requestInit.body = input;
         } else {
           requestInit.body = JSON.stringify(input);
         }
@@ -201,7 +203,6 @@ export function addHTTPRootFieldResolver(
     if (globalQueryParams) {
       for (const queryParamName in globalQueryParams) {
         if (
-          args != null &&
           queryParamArgMap != null &&
           queryParamName in queryParamArgMap &&
           queryParamArgMap[queryParamName] in args

--- a/packages/loaders/openapi/tests/oneof-without-descriminator.test.ts
+++ b/packages/loaders/openapi/tests/oneof-without-descriminator.test.ts
@@ -16,7 +16,7 @@ describe('oneOf without discriminator', () => {
             return Response.json({
               B: 'Value',
             });
-          case 'A':
+          case '"A"':
             return Response.json('A');
           default:
             return new Response(null, {


### PR DESCRIPTION
🚨 **IMPORTANT: Please do not create a Pull Request without creating an issue first.**

_Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of
the pull request._

## Description

When you have an enum in the open api
```graphql
enum A_const @typescript(type: "\"A\"") @example(value: "\"A\"") {
  A @enum(value: "\"A\"")
}
```

When it is used in the input
```graphql
input TestType_Input {
  A_const: A_const
}
```

It will be serialized as
```json
A
```
which is an invalid json

While correct json string should be quoted

```json
"A"
```

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
      expected)
- [ ] This change requires a documentation update

## Screenshots/Sandbox (if appropriate/relevant):

Adding links to sandbox or providing screenshots can help us understand more about this PR and take
action on it as appropriate

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can
reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Environment**:

- OS:
- `@graphql-mesh/...`:
- NodeJS:

## Checklist:

- [ ] I have followed the
      [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the
      style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests and linter rules pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose
the solution you did and what alternatives you considered, etc...
