### PR TITLE
Fix openapi: nested one of with lists inside

### DIFF
--- a/packages/loaders/json-schema/src/getUnionTypeComposers.ts
+++ b/packages/loaders/json-schema/src/getUnionTypeComposers.ts
@@ -4,6 +4,7 @@ import {
   Directive,
   InputTypeComposer,
   isSomeInputTypeComposer,
+  ListComposer,
   ObjectTypeComposer,
   SchemaComposer,
   UnionTypeComposer,
@@ -40,6 +41,17 @@ export function getContainerTC(schemaComposer: SchemaComposer, output: ComposeIn
   );
 }
 
+export function getListContainerTC(schemaComposer: SchemaComposer, output: ListComposer) {
+  const containerTypeName = `${output.ofType.getTypeName()}_list`;
+  return schemaComposer.getOrCreateOTC(containerTypeName, otc =>
+    otc.addFields({
+      items: {
+        type: output as any,
+      },
+    }),
+  );
+}
+
 export function getUnionTypeComposers({
   schemaComposer,
   typeComposersList,
@@ -53,7 +65,9 @@ export function getUnionTypeComposers({
   const outputTypeComposers: (ObjectTypeComposer<any> | UnionTypeComposer<any>)[] = [];
   typeComposersList.forEach(typeComposers => {
     const { input, output } = typeComposers;
-    if (isSomeInputTypeComposer(output)) {
+    if (output instanceof ListComposer) {
+      outputTypeComposers.push(getListContainerTC(schemaComposer, output));
+    } else if (isSomeInputTypeComposer(output)) {
       outputTypeComposers.push(getContainerTC(schemaComposer, output));
     } else {
       outputTypeComposers.push(output);

--- a/packages/loaders/openapi/tests/fixtures/algolia-subset-nested-one-of.yml
+++ b/packages/loaders/openapi/tests/fixtures/algolia-subset-nested-one-of.yml
@@ -6,14 +6,17 @@ info:
 components:
   schemas:
     searchFiltersArrayString:
+      description: Search filters array of string
       type: array
       items:
         type: string
     mixedSearchFilters:
+      description: Mixed search filters. Array of strings or string.
       oneOf:
         - $ref: '#/components/schemas/searchFiltersArrayString'
         - type: string
     listOfSearchFilters:
+      description: List of search filters.
       type: array
       items:
         $ref: '#/components/schemas/mixedSearchFilters'

--- a/packages/loaders/openapi/tests/fixtures/algolia-subset-nested-one-of.yml
+++ b/packages/loaders/openapi/tests/fixtures/algolia-subset-nested-one-of.yml
@@ -1,0 +1,88 @@
+openapi: 3.0.2
+info:
+  title: Search API
+  description: API powering the Search feature of Algolia.
+  version: 1.0.0
+components:
+  schemas:
+    searchFiltersArrayString:
+      type: array
+      items:
+        type: string
+    mixedSearchFilters:
+      oneOf:
+        - $ref: '#/components/schemas/searchFiltersArrayString'
+        - type: string
+    listOfSearchFilters:
+      type: array
+      items:
+        $ref: '#/components/schemas/mixedSearchFilters'
+    facetFilters:
+      description: Filter hits by facet value.
+      oneOf:
+        - $ref: '#/components/schemas/listOfSearchFilters'
+        - type: string
+      x-categories:
+        - Filtering
+    baseSearchParamsWithoutQuery:
+      type: object
+      additionalProperties: false
+      properties:
+        facetFilters:
+          $ref: '#/components/schemas/facetFilters'
+    consequenceParams:
+      allOf:
+        - $ref: '#/components/schemas/baseSearchParamsWithoutQuery'
+    consequence:
+      type: object
+      description: Consequence of the Rule.
+      additionalProperties: false
+      properties:
+        params:
+          $ref: '#/components/schemas/consequenceParams'
+    rule:
+      type: object
+      description: Rule object.
+      additionalProperties: false
+      properties:
+        consequence:
+          $ref: '#/components/schemas/consequence'
+servers:
+  - url: https://{appId}.algolia.net
+    variables:
+      appId:
+        default: myAppId
+paths:
+  /1/indexes/:
+    get:
+      tags:
+        - search
+      operationId: getRule
+      summary: Get a rule.
+      description: Retrieve the Rule with the specified objectID.
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/rule'
+    put:
+      tags:
+        - search
+      operationId: saveRule
+      summary: Save/Update a rule.
+      description: Create or update the Rule with the specified objectID.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/rule'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: string

--- a/packages/loaders/openapi/tests/nested-one-of.test.ts
+++ b/packages/loaders/openapi/tests/nested-one-of.test.ts
@@ -41,10 +41,19 @@ describe('Algolia schema with nested one Of', () => {
       }
 
       "Filter hits by facet value."
-      union facetFilters = String_container_list | String_container
+      union facetFilters = listOfSearchFilters | String_container
 
-      type String_container_list {
-        items: [String_container]
+      "List of search filters"
+      type listOfSearchFilters {
+        items: [mixedSearchFilters]
+      }
+
+      "Mixed search filters. Array of strings or string." 
+      union mixedSearchFilters = searchFiltersArrayString | String_container
+
+      "Search filters array of string"
+      type searchFiltersArrayString {
+        items: [String]
       }
 
       type String_container {
@@ -67,11 +76,16 @@ describe('Algolia schema with nested one Of', () => {
       }
 
       input consequenceParams_Input {
-        facetFilters: [facetFilters_Input]
+        facetFilters: facetFilters_Input
       }
 
       input facetFilters_Input @oneOf {
-        [String]: [String]
+        listOfSearchFilters: [mixedSearchFilters_Input]
+        String: String
+      }
+      
+      input mixedSearchFilters_Input @oneOf {
+        searchFiltersArrayString: [String]
         String: String
       }
 

--- a/packages/loaders/openapi/tests/nested-one-of.test.ts
+++ b/packages/loaders/openapi/tests/nested-one-of.test.ts
@@ -1,0 +1,93 @@
+import { printSchemaWithDirectives } from '@graphql-tools/utils';
+import loadGraphQLSchemaFromOpenAPI from '../src/index.js';
+
+describe('Algolia schema with nested one Of', () => {
+  it('should generate the correct schema', async () => {
+    const schema = await loadGraphQLSchemaFromOpenAPI('algolia-nested-one-of', {
+      source: `./fixtures/algolia-subset-nested-one-of.yml`,
+      cwd: __dirname,
+    });
+    expect(printSchemaWithDirectives(schema)).toMatchInlineSnapshot(`
+      "schema {
+        query: Query
+        mutation: Mutation
+      }
+
+      directive @oneOf on OBJECT | INTERFACE | INPUT_OBJECT
+
+      directive @resolveRoot on FIELD_DEFINITION
+
+      directive @globalOptions(sourceName: String, endpoint: String, operationHeaders: ObjMap, queryStringOptions: ObjMap, queryParams: ObjMap) on OBJECT
+
+      directive @httpOperation(path: String, operationSpecificHeaders: ObjMap, httpMethod: HTTPMethod, isBinary: Boolean, requestBaseBody: ObjMap, queryParamArgMap: ObjMap, queryStringOptionsByParam: ObjMap) on FIELD_DEFINITION
+
+      type Query @globalOptions(sourceName: "algolia-nested-one-of", endpoint: "https://{args.appId:myAppId}.algolia.net") {
+        "Retrieve the Rule with the specified objectID."
+        getRule(appId: String = "myAppId"): rule @httpOperation(path: "/1/indexes/", operationSpecificHeaders: "{\\"accept\\":\\"application/json\\"}", httpMethod: GET)
+      }
+
+      "Rule object."
+      type rule {
+        consequence: consequence
+      }
+
+      "Consequence of the Rule."
+      type consequence {
+        params: consequenceParams
+      }
+
+      type consequenceParams {
+        facetFilters: [facetFilters]
+      }
+
+      "Filter hits by facet value."
+      union facetFilters = String_container_list | String_container
+
+      type String_container_list {
+        items: [String_container]
+      }
+
+      type String_container {
+        String: String @resolveRoot
+      }
+
+      type Mutation {
+        "Create or update the Rule with the specified objectID."
+        saveRule(appId: String = "myAppId", input: rule_Input): String @httpOperation(path: "/1/indexes/", operationSpecificHeaders: "{\\"Content-Type\\":\\"application/json\\",\\"accept\\":\\"application/json\\"}", httpMethod: PUT)
+      }
+
+      "Rule object."
+      input rule_Input {
+        consequence: consequence_Input
+      }
+
+      "Consequence of the Rule."
+      input consequence_Input {
+        params: consequenceParams_Input
+      }
+
+      input consequenceParams_Input {
+        facetFilters: [facetFilters_Input]
+      }
+
+      input facetFilters_Input @oneOf {
+        [String]: [String]
+        String: String
+      }
+
+      scalar ObjMap
+
+      enum HTTPMethod {
+        GET
+        HEAD
+        POST
+        PUT
+        DELETE
+        CONNECT
+        OPTIONS
+        TRACE
+        PATCH
+      }"
+    `);
+  });
+});


### PR DESCRIPTION
🚨 **IMPORTANT: Please do not create a Pull Request without creating an issue first.**

## Description

PR solves next problems:
- [ ] Nested oneOf produces incorrect schema for both input/output
- [ ] Probably StringContainer should not have resolveRoot directive when it is nested

Example of oneOf nesting:
```yaml
    facetFilters:
      description: Filter hits by facet value.
      oneOf:
        - type: array
          items:
            oneOf:
              - type: array
                items:
                  type: string
              - type: string
        - type: string
```

After partial fix for output types produces schema:
```graphql
union facetFilters = String_container_list | String_container

type String_container_list {
  items: [String_container]
}

type String_container {
  String: String @resolveRoot
}
```

Before partial fix it was not possible to generate schema

The desired schema should look more like this
```graphql
union facetFilters = filtersUnion_container_list | String_container

type filtersUnion_container_list {
  items: [filtersUnion]
}

union filtersUnion = String_array_container | String_container

type String_array_container {
  items: [String]
}

type String_container {
  String: String @resolveRoot
}
```

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
      expected)
- [ ] This change requires a documentation update

## Screenshots/Sandbox (if appropriate/relevant):

Adding links to sandbox or providing screenshots can help us understand more about this PR and take
action on it as appropriate

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can
reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Environment**:

- OS:
- `@graphql-mesh/...`:
- NodeJS:

## Checklist:

- [ ] I have followed the
      [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the
      style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests and linter rules pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose
the solution you did and what alternatives you considered, etc...
