### PR TITLE
Parse json into object before passing to fromJson

### DIFF
--- a/packages/handlers/grpc/src/index.ts
+++ b/packages/handlers/grpc/src/index.ts
@@ -283,7 +283,7 @@ export default class GrpcHandler implements MeshHandler {
     loadOptions: LoadOptions;
     rootLogger: Logger;
   }) {
-    const packageDefinition = fromJSON(rootJson, loadOptions);
+    const packageDefinition = fromJSON(JSON.parse(rootJson), loadOptions);
 
     rootLogger.debug(`Creating service client for package definition`);
     const grpcObject = loadPackageDefinition(packageDefinition);


### PR DESCRIPTION
## Description
Fixes a bug which prevents gRPC schemas from being generated with 'mesh start'. the fromJSON function provided by the package `@grpc/proto-loader` expects an object and not a string, confusingly.

This pr was the change that initially impacted the gRPC functionality: https://github.com/Urigo/graphql-mesh/pull/5420

Fixes # (issue)
Parse the schemas JSON into an object before invoking fromJSON.

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
      expected)
- [ ] This change requires a documentation update

## Screenshots/Sandbox (if appropriate/relevant):

Adding links to sandbox or providing screenshots can help us understand more about this PR and take
action on it as appropriate

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can
reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Environment**:

- OS: Mac OSX
- `@graphql-mesh/grpc`: 0.94.2
- NodeJS: 18.6

## Checklist:

- [ ] I have followed the
      [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the
      style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests and linter rules pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

