### PR TITLE
Fix to fork if and only if in production

### DIFF
--- a/packages/cli/src/commands/serve/serve.ts
+++ b/packages/cli/src/commands/serve/serve.ts
@@ -54,7 +54,7 @@ export async function serveMesh(
   cliParams: GraphQLMeshCLIParams,
 ) {
   const {
-    fork: configFork = process.env.NODE_ENV?.toLowerCase() !== 'production',
+    fork: configFork = process.env.NODE_ENV?.toLowerCase() === 'production',
     port: configPort,
     hostname = os.platform() === 'win32' ||
     // is WSL?


### PR DESCRIPTION
Fixes #5778

🚨 **IMPORTANT: Please do not create a Pull Request without creating an issue first.**

_Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of
the pull request._

## Description

I believe this is a one-line fix for forking when running in a production environment.

Fixes #5778 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

## Screenshots/Sandbox (if appropriate/relevant):

n/a

## How Has This Been Tested?

Tested with `mesh dev` (no forking) and `mesh start` (8 forks) locally.

**Test Environment**:

- OS: Linux
- `@graphql-mesh/...`: 0.86.0
- NodeJS: v18.16.1

## Checklist:

- [ ] I have followed the
      [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the
      style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests and linter rules pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose
the solution you did and what alternatives you considered, etc...
