### PR TITLE
fix auto-incremented columns marked as required fields

### DIFF
--- a/.changeset/tasty-maps-know.md
+++ b/.changeset/tasty-maps-know.md
@@ -1,0 +1,5 @@
+---
+'@graphql-mesh/mysql': patch
+---
+
+Fix fields wrongly marked as required when column has a default value or is auto-incremented

--- a/packages/handlers/mysql/src/mysql.d.ts
+++ b/packages/handlers/mysql/src/mysql.d.ts
@@ -90,5 +90,6 @@ declare module 'mysql' {
     update(tableName: string, input: any, where: any, callback: Callback<{ affectedRows: any }>);
     delete(tableName: string, where: any, callback: Callback<{ affectedRows: any }>);
     count(tableName: string, where: any, callback: Callback<number>);
+    queryKeyValue(query: string, field: string[], callback: Callback<Record<string, any>>);
   }
 }


### PR DESCRIPTION
## Description

The MySQL handler was marking auto-incremented columns as required fields in the GraphQL schema.
It's wrong since you can provide `NULL` or omit auto-incremented fields even if they are marked as `NOT NULL`.
It was also marking as required fields `NOT NULL` columns with defined default, which is wrong for the same reason.

Fixes #5350
Fixes #2182

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

