### PR TITLE
fix: respect settings in applyTo config(#5885)

### DIFF
--- a/.changeset/@graphql-mesh_transform-encapsulate-5886-fix-applyto.md
+++ b/.changeset/@graphql-mesh_transform-encapsulate-5886-fix-applyto.md
@@ -1,0 +1,5 @@
+---
+'@graphql-mesh/transform-encapsulate': patch
+---
+
+respect settings in transform encapsulate applyTo config

--- a/packages/transforms/encapsulate/src/index.ts
+++ b/packages/transforms/encapsulate/src/index.ts
@@ -51,13 +51,15 @@ export default class EncapsulateTransform implements MeshTransform {
     const outerTypeNames = getRootTypeMap(originalWrappingSchema);
 
     for (const operationType in applyTo) {
-      const outerTypeName = outerTypeNames.get(operationType as OperationTypeNode)?.name;
-      if (outerTypeName) {
-        this.transformMap[outerTypeName] = new WrapType(
-          outerTypeName,
-          `${this.name}${OPERATION_TYPE_SUFFIX_MAP[operationType as OperationTypeNode]}`,
-          this.name,
-        ) as any;
+      if (applyTo[operationType as OperationTypeNode] === true) {
+        const outerTypeName = outerTypeNames.get(operationType as OperationTypeNode)?.name;
+        if (outerTypeName) {
+          this.transformMap[outerTypeName] = new WrapType(
+            outerTypeName,
+            `${this.name}${OPERATION_TYPE_SUFFIX_MAP[operationType as OperationTypeNode]}`,
+            this.name,
+          ) as any;
+        }
       }
     }
 

--- a/packages/transforms/encapsulate/test/encapsulate.spec.ts
+++ b/packages/transforms/encapsulate/test/encapsulate.spec.ts
@@ -281,4 +281,33 @@ describe('encapsulate', () => {
         .notifySomething,
     ).toBeDefined();
   });
+
+  it('should respect the settings in applyTo', async () => {
+    const newSchema = wrapSchema({
+      schema,
+      transforms: [
+        new Transform({
+          config: {
+            applyTo: {
+              subscription: false,
+              mutation: false,
+            },
+          },
+          cache,
+          pubsub,
+          baseDir,
+          apiName: 'test',
+          importFn,
+          logger: new DefaultLogger(),
+        }),
+      ],
+    });
+    expect(newSchema.getMutationType().getFields().test).not.toBeDefined();
+    expect(newSchema.getMutationType().getFields().doSomething).toBeDefined();
+    expect(newSchema.getSubscriptionType().getFields().test).not.toBeDefined();
+    expect(newSchema.getSubscriptionType().getFields().notify).toBeDefined();
+    expect(newSchema.getQueryType().getFields().test).toBeDefined();
+    expect(newSchema.getQueryType().getFields().getSomething).not.toBeDefined();
+    expect(newSchema.getQueryType().getFields().test.type.toString()).toBe('testQuery!');
+  });
 });


### PR DESCRIPTION
## Description

Respects the applyTo option in GraphQL Mesh encapsulate transform

Fixes #5885

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can
reproduce. Please also list any relevant details for your test configuration

- [x] Unit test

## Checklist:

- [x] I have followed the
      [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the
      style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests and linter rules pass locally with my changes

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose
the solution you did and what alternatives you considered, etc...
