### PR TITLE
fix grpc handler for nested messages with name 'Input'

### DIFF
--- a/.changeset/cuddly-spoons-confess.md
+++ b/.changeset/cuddly-spoons-confess.md
@@ -1,0 +1,13 @@
+---
+'@graphql-mesh/grpc': minor
+'grpc-example': minor
+---
+
+Change the generation rules of GraphQL type names to allow nested messages with name "Input"
+
+**BREAKING CHANGE:**
+  Nested messages (messages in packages or nested) type names are
+  now seperated by `__` instead of `_`.
+
+  Example for message `google.protobuf.Timestamp`:
+  `google_protobuf_Timestamp` => `google__protobuf__Timestamp`

--- a/.changeset/cuddly-spoons-confess.md
+++ b/.changeset/cuddly-spoons-confess.md
@@ -1,6 +1,5 @@
 ---
 '@graphql-mesh/grpc': minor
-'grpc-example': minor
 ---
 
 Change the generation rules of GraphQL type names to allow nested messages with name "Input"

--- a/examples/grpc-example/tests/__snapshots__/grpc.test.ts.snap
+++ b/examples/grpc-example/tests/__snapshots__/grpc.test.ts.snap
@@ -116,14 +116,14 @@ type Movie {
   rating: Float
   "list of cast"
   cast: [String]
-  time: google_protobuf_Timestamp
+  time: google__protobuf__Timestamp
   genre: Genre
 }
 
 "The \`BigInt\` scalar type represents non-fractional signed whole numeric values."
 scalar BigInt
 
-type google_protobuf_Timestamp {
+type google__protobuf__Timestamp {
   seconds: BigInt
   nanos: Int
 }
@@ -145,11 +145,11 @@ input Movie_Input {
   rating: Float
   "list of cast"
   cast: [String]
-  time: google_protobuf_Timestamp_Input
+  time: google__protobuf__Timestamp_Input
   genre: Genre
 }
 
-input google_protobuf_Timestamp_Input {
+input google__protobuf__Timestamp_Input {
   seconds: BigInt
   nanos: Int
 }

--- a/packages/handlers/grpc/src/index.ts
+++ b/packages/handlers/grpc/src/index.ts
@@ -494,7 +494,7 @@ export default class GrpcHandler implements MeshHandler {
         });
       }
     }
-    const typeName = pathWithName.join('_');
+    const typeName = pathWithName.join('__');
     if ('values' in nested) {
       const enumValues: Record<string, EnumTypeComposerValueConfigDefinition> = {};
       const commentMap = (nested as any).comments;

--- a/packages/handlers/grpc/src/utils.ts
+++ b/packages/handlers/grpc/src/utils.ts
@@ -19,7 +19,7 @@ export function getTypeName(
   isInput: boolean,
 ) {
   if (pathWithName?.length) {
-    const baseTypeName = pathWithName.filter(Boolean).join('_');
+    const baseTypeName = pathWithName.filter(Boolean).join('__');
     if (isScalarType(baseTypeName)) {
       return getGraphQLScalar(baseTypeName);
     }

--- a/packages/handlers/grpc/test/__snapshots__/handler.spec.ts.snap
+++ b/packages/handlers/grpc/test/__snapshots__/handler.spec.ts.snap
@@ -24,17 +24,17 @@ directive @stream(
 
 type Query @grpcRootJson(name: "Root0", rootJson: "{\\"nested\\":{\\"foo\\":{\\"nested\\":{\\"SampleService\\":{\\"methods\\":{\\"CreateSample\\":{\\"requestType\\":\\"CreateSampleRequest\\",\\"responseType\\":\\"SampleResponse\\",\\"comment\\":\\"Comment 1: This is a comment with two slashes\\"},\\"GetSample\\":{\\"requestType\\":\\"GetSampleRequest\\",\\"responseType\\":\\"SampleResponse\\",\\"comment\\":\\"Comment 2: This is a comment with initial slash star and final star slash (all on one line)\\"},\\"UpdateSample\\":{\\"requestType\\":\\"UpdateSampleRequest\\",\\"responseType\\":\\"SampleResponse\\",\\"comment\\":\\"Comment 3: This is a comment with initial slash star star and final star slash (all on one line\\"},\\"DeleteSample\\":{\\"requestType\\":\\"DeleteSampleRequest\\",\\"responseType\\":\\"SampleResponse\\",\\"comment\\":\\"Comment 4: This is a comment on multiple lines, initial slash star star\\\\nat beginning of the line.\\"}},\\"comment\\":null},\\"SampleResponse\\":{\\"fields\\":{\\"sample_id\\":{\\"type\\":\\"string\\",\\"id\\":1,\\"comment\\":null}},\\"comment\\":\\"Comment 5: This is a comment on one line, delimiters slash star star at beginning of the line. Trailing comment delimiter at beginning of next line after comment.\\"},\\"CreateSampleRequest\\":{\\"fields\\":{\\"description\\":{\\"type\\":\\"string\\",\\"id\\":1,\\"comment\\":\\"Comment 6: This is a comment with slash followed by two stars at the beginning. The first comment delimiter is at the beginning of the line. Trailing comment delimiter on same line as text.\\"},\\"type\\":{\\"type\\":\\"string\\",\\"id\\":2,\\"comment\\":null}},\\"comment\\":null},\\"GetSampleRequest\\":{\\"fields\\":{\\"sample_id\\":{\\"type\\":\\"string\\",\\"id\\":1,\\"comment\\":\\"Comment 8: This is a comment with slash star delimiter on the same line as a field definition.\\"}},\\"comment\\":\\"Comment 7: This is a comment with slash followed by two stars at the beginning. The first comment delimiter is not at the beginning of the line.\\"},\\"UpdateSampleRequest\\":{\\"fields\\":{\\"sample_id\\":{\\"type\\":\\"string\\",\\"id\\":1,\\"comment\\":\\"Comment 10: This is a comment with slash star star delimiter on the same line as a field definition.\\"}},\\"comment\\":null},\\"DeleteSampleRequest\\":{\\"fields\\":{\\"sample_id\\":{\\"type\\":\\"string\\",\\"id\\":1,\\"comment\\":\\"Comment 12: This is a two-slash comment on the same line as a field definition.\\"}},\\"comment\\":null}}},\\"google\\":{\\"nested\\":{\\"protobuf\\":{\\"nested\\":{\\"Timestamp\\":{\\"fields\\":{\\"seconds\\":{\\"type\\":\\"int64\\",\\"id\\":1},\\"nanos\\":{\\"type\\":\\"int32\\",\\"id\\":2}},\\"comment\\":null}}}}}}}") {
   "Comment 2: This is a comment with initial slash star and final star slash (all on one line)"
-  foo_SampleService_GetSample(input: foo_GetSampleRequest_Input): foo_SampleResponse @grpcMethod(rootJsonName: "Root0", objPath: "foo.SampleService", methodName: "GetSample", responseStream: false)
+  foo_SampleService_GetSample(input: foo__GetSampleRequest_Input): foo__SampleResponse @grpcMethod(rootJsonName: "Root0", objPath: "foo.SampleService", methodName: "GetSample", responseStream: false)
   foo_SampleService_connectivityState(tryToConnect: Boolean): ConnectivityState @grpcConnectivityState(rootJsonName: "Root0", objPath: "foo.SampleService")
 }
 
 "Comment 5: This is a comment on one line, delimiters slash star star at beginning of the line. Trailing comment delimiter at beginning of next line after comment."
-type foo_SampleResponse {
+type foo__SampleResponse {
   sample_id: String
 }
 
 "Comment 7: This is a comment with slash followed by two stars at the beginning. The first comment delimiter is not at the beginning of the line."
-input foo_GetSampleRequest_Input {
+input foo__GetSampleRequest_Input {
   "Comment 8: This is a comment with slash star delimiter on the same line as a field definition."
   sample_id: String
 }
@@ -49,25 +49,25 @@ enum ConnectivityState {
 
 type Mutation {
   "Comment 1: This is a comment with two slashes"
-  foo_SampleService_CreateSample(input: foo_CreateSampleRequest_Input): foo_SampleResponse @grpcMethod(rootJsonName: "Root0", objPath: "foo.SampleService", methodName: "CreateSample", responseStream: false)
+  foo_SampleService_CreateSample(input: foo__CreateSampleRequest_Input): foo__SampleResponse @grpcMethod(rootJsonName: "Root0", objPath: "foo.SampleService", methodName: "CreateSample", responseStream: false)
   "Comment 3: This is a comment with initial slash star star and final star slash (all on one line"
-  foo_SampleService_UpdateSample(input: foo_UpdateSampleRequest_Input): foo_SampleResponse @grpcMethod(rootJsonName: "Root0", objPath: "foo.SampleService", methodName: "UpdateSample", responseStream: false)
+  foo_SampleService_UpdateSample(input: foo__UpdateSampleRequest_Input): foo__SampleResponse @grpcMethod(rootJsonName: "Root0", objPath: "foo.SampleService", methodName: "UpdateSample", responseStream: false)
   "Comment 4: This is a comment on multiple lines, initial slash star star\\nat beginning of the line."
-  foo_SampleService_DeleteSample(input: foo_DeleteSampleRequest_Input): foo_SampleResponse @grpcMethod(rootJsonName: "Root0", objPath: "foo.SampleService", methodName: "DeleteSample", responseStream: false)
+  foo_SampleService_DeleteSample(input: foo__DeleteSampleRequest_Input): foo__SampleResponse @grpcMethod(rootJsonName: "Root0", objPath: "foo.SampleService", methodName: "DeleteSample", responseStream: false)
 }
 
-input foo_CreateSampleRequest_Input {
+input foo__CreateSampleRequest_Input {
   "Comment 6: This is a comment with slash followed by two stars at the beginning. The first comment delimiter is at the beginning of the line. Trailing comment delimiter on same line as text."
   description: String
   type: String
 }
 
-input foo_UpdateSampleRequest_Input {
+input foo__UpdateSampleRequest_Input {
   "Comment 10: This is a comment with slash star star delimiter on the same line as a field definition."
   sample_id: String
 }
 
-input foo_DeleteSampleRequest_Input {
+input foo__DeleteSampleRequest_Input {
   "Comment 12: This is a two-slash comment on the same line as a field definition."
   sample_id: String
 }
@@ -97,27 +97,27 @@ directive @stream(
 ) on FIELD
 
 type Query @grpcRootJson(name: "Root0", rootJson: "{\\"nested\\":{\\"foos\\":{\\"nested\\":{\\"BamService\\":{\\"methods\\":{\\"GetW\\":{\\"requestType\\":\\"GetBamRequest\\",\\"responseType\\":\\"GetFoosResponse\\",\\"comment\\":null}},\\"comment\\":null},\\"GetBamRequest\\":{\\"fields\\":{\\"id\\":{\\"type\\":\\"int32\\",\\"id\\":1,\\"comment\\":null},\\"abcd\\":{\\"type\\":\\"Bam\\",\\"id\\":2,\\"comment\\":null}},\\"comment\\":null},\\"Bam\\":{\\"fields\\":{\\"id\\":{\\"type\\":\\"int64\\",\\"id\\":1,\\"comment\\":null}},\\"comment\\":null},\\"GetFoosResponse\\":{\\"fields\\":{\\"abcd\\":{\\"type\\":\\"Bam\\",\\"id\\":1,\\"comment\\":null}},\\"comment\\":null}}}}}") {
-  foos_BamService_GetW(input: foos_GetBamRequest_Input): foos_GetFoosResponse @grpcMethod(rootJsonName: "Root0", objPath: "foos.BamService", methodName: "GetW", responseStream: false)
+  foos_BamService_GetW(input: foos__GetBamRequest_Input): foos__GetFoosResponse @grpcMethod(rootJsonName: "Root0", objPath: "foos.BamService", methodName: "GetW", responseStream: false)
   foos_BamService_connectivityState(tryToConnect: Boolean): ConnectivityState @grpcConnectivityState(rootJsonName: "Root0", objPath: "foos.BamService")
 }
 
-type foos_GetFoosResponse {
-  abcd: foos_Bam
+type foos__GetFoosResponse {
+  abcd: foos__Bam
 }
 
-type foos_Bam {
+type foos__Bam {
   id: BigInt
 }
 
 "The \`BigInt\` scalar type represents non-fractional signed whole numeric values."
 scalar BigInt
 
-input foos_GetBamRequest_Input {
+input foos__GetBamRequest_Input {
   id: Int
-  abcd: foos_Bam_Input
+  abcd: foos__Bam_Input
 }
 
-input foos_Bam_Input {
+input foos__Bam_Input {
   id: BigInt
 }
 
@@ -154,22 +154,22 @@ directive @stream(
 ) on FIELD
 
 type Query @grpcRootJson(name: "Root0", rootJson: "{\\"nested\\":{\\"foo\\":{\\"nested\\":{\\"BamService\\":{\\"methods\\":{\\"GetFOOs\\":{\\"requestType\\":\\"GetFOOsRequest\\",\\"responseType\\":\\"GetFOOsResponse\\",\\"comment\\":null}},\\"comment\\":null},\\"GetFOOsRequest\\":{\\"fields\\":{\\"id\\":{\\"type\\":\\"int32\\",\\"id\\":1,\\"comment\\":null}},\\"comment\\":null},\\"FOO\\":{\\"fields\\":{\\"id\\":{\\"type\\":\\"int64\\",\\"id\\":1,\\"comment\\":null}},\\"comment\\":null},\\"GetFOOsResponse\\":{\\"fields\\":{\\"foos\\":{\\"rule\\":\\"repeated\\",\\"type\\":\\"FOO\\",\\"id\\":1,\\"comment\\":null}},\\"comment\\":null}}}}}") {
-  foo_BamService_GetFOOs(input: foo_GetFOOsRequest_Input): foo_GetFOOsResponse @grpcMethod(rootJsonName: "Root0", objPath: "foo.BamService", methodName: "GetFOOs", responseStream: false)
+  foo_BamService_GetFOOs(input: foo__GetFOOsRequest_Input): foo__GetFOOsResponse @grpcMethod(rootJsonName: "Root0", objPath: "foo.BamService", methodName: "GetFOOs", responseStream: false)
   foo_BamService_connectivityState(tryToConnect: Boolean): ConnectivityState @grpcConnectivityState(rootJsonName: "Root0", objPath: "foo.BamService")
 }
 
-type foo_GetFOOsResponse {
-  foos: [foo_FOO]
+type foo__GetFOOsResponse {
+  foos: [foo__FOO]
 }
 
-type foo_FOO {
+type foo__FOO {
   id: BigInt
 }
 
 "The \`BigInt\` scalar type represents non-fractional signed whole numeric values."
 scalar BigInt
 
-input foo_GetFOOsRequest_Input {
+input foo__GetFOOsRequest_Input {
   id: Int
 }
 
@@ -209,36 +209,36 @@ directive @stream(
 
 type Query @grpcRootJson(name: "Root0", rootJson: "{\\"nested\\":{\\"io\\":{\\"nested\\":{\\"xtech\\":{\\"nested\\":{\\"Genre\\":{\\"values\\":{\\"UNSPECIFIED\\":0,\\"ACTION\\":1,\\"DRAMA\\":2},\\"comment\\":null,\\"comments\\":{\\"UNSPECIFIED\\":null,\\"ACTION\\":null,\\"DRAMA\\":null}},\\"Movie\\":{\\"fields\\":{\\"name\\":{\\"type\\":\\"string\\",\\"id\\":1,\\"comment\\":null},\\"year\\":{\\"type\\":\\"int32\\",\\"id\\":2,\\"comment\\":null},\\"rating\\":{\\"type\\":\\"float\\",\\"id\\":3,\\"comment\\":null},\\"cast\\":{\\"rule\\":\\"repeated\\",\\"type\\":\\"string\\",\\"id\\":4,\\"comment\\":\\"list of cast\\"},\\"time\\":{\\"type\\":\\"google.protobuf.Timestamp\\",\\"id\\":5,\\"comment\\":null},\\"genre\\":{\\"type\\":\\"Genre\\",\\"id\\":6,\\"comment\\":null}},\\"comment\\":\\"movie message payload\\"},\\"EmptyRequest\\":{\\"fields\\":{},\\"comment\\":null},\\"MovieRequest\\":{\\"fields\\":{\\"movie\\":{\\"type\\":\\"Movie\\",\\"id\\":1,\\"comment\\":null}},\\"comment\\":null},\\"SearchByCastRequest\\":{\\"fields\\":{\\"castName\\":{\\"type\\":\\"string\\",\\"id\\":1,\\"comment\\":null}},\\"comment\\":null},\\"MoviesResult\\":{\\"fields\\":{\\"result\\":{\\"rule\\":\\"repeated\\",\\"type\\":\\"Movie\\",\\"id\\":1,\\"comment\\":\\"list of movies\\"}},\\"comment\\":\\"movie result message, contains list of movies\\"},\\"Example\\":{\\"methods\\":{\\"GetMovies\\":{\\"requestType\\":\\"MovieRequest\\",\\"responseType\\":\\"MoviesResult\\",\\"comment\\":\\"get all movies\\"},\\"GetEmpty\\":{\\"requestType\\":\\"MovieRequest\\",\\"responseType\\":\\"EmptyRequest\\",\\"comment\\":null},\\"SearchMoviesByCast\\":{\\"requestType\\":\\"SearchByCastRequest\\",\\"responseType\\":\\"Movie\\",\\"responseStream\\":true,\\"comment\\":\\"search movies by the name of the cast\\"}},\\"comment\\":null},\\"AnotherExample\\":{\\"methods\\":{\\"GetMovies\\":{\\"requestType\\":\\"MovieRequest\\",\\"responseType\\":\\"MoviesResult\\",\\"comment\\":\\"get all movies\\"},\\"SearchMoviesByCast\\":{\\"requestType\\":\\"SearchByCastRequest\\",\\"responseType\\":\\"Movie\\",\\"responseStream\\":true,\\"comment\\":\\"search movies by the name of the cast\\"}},\\"comment\\":null}}}}},\\"google\\":{\\"nested\\":{\\"protobuf\\":{\\"nested\\":{\\"Timestamp\\":{\\"fields\\":{\\"seconds\\":{\\"type\\":\\"int64\\",\\"id\\":1},\\"nanos\\":{\\"type\\":\\"int32\\",\\"id\\":2}},\\"comment\\":null}}}}}}}") {
   "get all movies"
-  io_xtech_Example_GetMovies(input: io_xtech_MovieRequest_Input): io_xtech_MoviesResult @grpcMethod(rootJsonName: "Root0", objPath: "io.xtech.Example", methodName: "GetMovies", responseStream: false)
-  io_xtech_Example_GetEmpty(input: io_xtech_MovieRequest_Input): io_xtech_EmptyRequest @grpcMethod(rootJsonName: "Root0", objPath: "io.xtech.Example", methodName: "GetEmpty", responseStream: false)
+  io_xtech_Example_GetMovies(input: io__xtech__MovieRequest_Input): io__xtech__MoviesResult @grpcMethod(rootJsonName: "Root0", objPath: "io.xtech.Example", methodName: "GetMovies", responseStream: false)
+  io_xtech_Example_GetEmpty(input: io__xtech__MovieRequest_Input): io__xtech__EmptyRequest @grpcMethod(rootJsonName: "Root0", objPath: "io.xtech.Example", methodName: "GetEmpty", responseStream: false)
   "search movies by the name of the cast"
-  io_xtech_Example_SearchMoviesByCast(input: io_xtech_SearchByCastRequest_Input): [io_xtech_Movie] @grpcMethod(rootJsonName: "Root0", objPath: "io.xtech.Example", methodName: "SearchMoviesByCast", responseStream: true)
+  io_xtech_Example_SearchMoviesByCast(input: io__xtech__SearchByCastRequest_Input): [io__xtech__Movie] @grpcMethod(rootJsonName: "Root0", objPath: "io.xtech.Example", methodName: "SearchMoviesByCast", responseStream: true)
   io_xtech_Example_connectivityState(tryToConnect: Boolean): ConnectivityState @grpcConnectivityState(rootJsonName: "Root0", objPath: "io.xtech.Example")
   "get all movies"
-  io_xtech_AnotherExample_GetMovies(input: io_xtech_MovieRequest_Input): io_xtech_MoviesResult @grpcMethod(rootJsonName: "Root0", objPath: "io.xtech.AnotherExample", methodName: "GetMovies", responseStream: false)
+  io_xtech_AnotherExample_GetMovies(input: io__xtech__MovieRequest_Input): io__xtech__MoviesResult @grpcMethod(rootJsonName: "Root0", objPath: "io.xtech.AnotherExample", methodName: "GetMovies", responseStream: false)
   "search movies by the name of the cast"
-  io_xtech_AnotherExample_SearchMoviesByCast(input: io_xtech_SearchByCastRequest_Input): [io_xtech_Movie] @grpcMethod(rootJsonName: "Root0", objPath: "io.xtech.AnotherExample", methodName: "SearchMoviesByCast", responseStream: true)
+  io_xtech_AnotherExample_SearchMoviesByCast(input: io__xtech__SearchByCastRequest_Input): [io__xtech__Movie] @grpcMethod(rootJsonName: "Root0", objPath: "io.xtech.AnotherExample", methodName: "SearchMoviesByCast", responseStream: true)
   io_xtech_AnotherExample_connectivityState(tryToConnect: Boolean): ConnectivityState @grpcConnectivityState(rootJsonName: "Root0", objPath: "io.xtech.AnotherExample")
 }
 
 "movie result message, contains list of movies"
-type io_xtech_MoviesResult {
+type io__xtech__MoviesResult {
   "list of movies"
-  result: [io_xtech_Movie]
+  result: [io__xtech__Movie]
 }
 
 "movie message payload"
-type io_xtech_Movie {
+type io__xtech__Movie {
   name: String
   year: Int
   rating: Float
   "list of cast"
   cast: [String]
-  time: google_protobuf_Timestamp
-  genre: io_xtech_Genre
+  time: google__protobuf__Timestamp
+  genre: io__xtech__Genre
 }
 
-type google_protobuf_Timestamp {
+type google__protobuf__Timestamp {
   seconds: BigInt
   nanos: Int
 }
@@ -246,35 +246,35 @@ type google_protobuf_Timestamp {
 "The \`BigInt\` scalar type represents non-fractional signed whole numeric values."
 scalar BigInt
 
-enum io_xtech_Genre {
+enum io__xtech__Genre {
   UNSPECIFIED @enum(value: "0")
   ACTION @enum(value: "1")
   DRAMA @enum(value: "2")
 }
 
-input io_xtech_MovieRequest_Input {
-  movie: io_xtech_Movie_Input
+input io__xtech__MovieRequest_Input {
+  movie: io__xtech__Movie_Input
 }
 
 "movie message payload"
-input io_xtech_Movie_Input {
+input io__xtech__Movie_Input {
   name: String
   year: Int
   rating: Float
   "list of cast"
   cast: [String]
-  time: google_protobuf_Timestamp_Input
-  genre: io_xtech_Genre
+  time: google__protobuf__Timestamp_Input
+  genre: io__xtech__Genre
 }
 
-input google_protobuf_Timestamp_Input {
+input google__protobuf__Timestamp_Input {
   seconds: BigInt
   nanos: Int
 }
 
-scalar io_xtech_EmptyRequest @specifiedBy(url: "http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf")
+scalar io__xtech__EmptyRequest @specifiedBy(url: "http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf")
 
-input io_xtech_SearchByCastRequest_Input {
+input io__xtech__SearchByCastRequest_Input {
   castName: String
 }
 
@@ -313,28 +313,28 @@ directive @stream(
 ) on FIELD
 
 type Query @grpcRootJson(name: "Root0", rootJson: "{\\"nested\\":{\\"io\\":{\\"nested\\":{\\"xtech\\":{\\"nested\\":{\\"OrganizationStateProto\\":{\\"values\\":{\\"UNKNOWN\\":0,\\"ACTIVE\\":1,\\"PENDING_PAYMENT\\":2,\\"SUSPENDED\\":3},\\"comment\\":null,\\"comments\\":{\\"UNKNOWN\\":null,\\"ACTIVE\\":null,\\"PENDING_PAYMENT\\":null,\\"SUSPENDED\\":null}},\\"OrganizationProto\\":{\\"fields\\":{\\"id\\":{\\"type\\":\\"string\\",\\"id\\":1,\\"comment\\":null},\\"owner\\":{\\"type\\":\\"string\\",\\"id\\":2,\\"comment\\":null},\\"name\\":{\\"type\\":\\"string\\",\\"id\\":3,\\"comment\\":null},\\"description\\":{\\"type\\":\\"string\\",\\"id\\":4,\\"comment\\":null},\\"image_url\\":{\\"type\\":\\"string\\",\\"id\\":5,\\"comment\\":null},\\"state\\":{\\"type\\":\\"OrganizationStateProto\\",\\"id\\":6,\\"comment\\":null},\\"default_org\\":{\\"type\\":\\"bool\\",\\"id\\":7,\\"comment\\":null}},\\"comment\\":null},\\"EmptyRequest\\":{\\"fields\\":{},\\"comment\\":null},\\"OrganizationService\\":{\\"methods\\":{\\"GetOrganization\\":{\\"requestType\\":\\"EmptyRequest\\",\\"responseType\\":\\"OrganizationProto\\",\\"comment\\":null}},\\"comment\\":null}}}}}}}") {
-  io_xtech_OrganizationService_GetOrganization(input: io_xtech_EmptyRequest_Input): io_xtech_OrganizationProto @grpcMethod(rootJsonName: "Root0", objPath: "io.xtech.OrganizationService", methodName: "GetOrganization", responseStream: false)
+  io_xtech_OrganizationService_GetOrganization(input: io__xtech__EmptyRequest_Input): io__xtech__OrganizationProto @grpcMethod(rootJsonName: "Root0", objPath: "io.xtech.OrganizationService", methodName: "GetOrganization", responseStream: false)
   io_xtech_OrganizationService_connectivityState(tryToConnect: Boolean): ConnectivityState @grpcConnectivityState(rootJsonName: "Root0", objPath: "io.xtech.OrganizationService")
 }
 
-type io_xtech_OrganizationProto {
+type io__xtech__OrganizationProto {
   id: String
   owner: String
   name: String
   description: String
   image_url: String
-  state: io_xtech_OrganizationStateProto
+  state: io__xtech__OrganizationStateProto
   default_org: Boolean
 }
 
-enum io_xtech_OrganizationStateProto {
+enum io__xtech__OrganizationStateProto {
   UNKNOWN @enum(value: "0")
   ACTIVE @enum(value: "1")
   PENDING_PAYMENT @enum(value: "2")
   SUSPENDED @enum(value: "3")
 }
 
-scalar io_xtech_EmptyRequest_Input @specifiedBy(url: "http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf")
+scalar io__xtech__EmptyRequest_Input @specifiedBy(url: "http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf")
 
 enum ConnectivityState {
   IDLE
@@ -369,27 +369,76 @@ directive @stream(
 ) on FIELD
 
 type Query @grpcRootJson(name: "Root0", rootJson: "{\\"nested\\":{\\"io\\":{\\"nested\\":{\\"xtech\\":{\\"nested\\":{\\"outer\\":{\\"nested\\":{\\"Example\\":{\\"methods\\":{\\"Get\\":{\\"requestType\\":\\"io.xtech.TopLevel.Nested\\",\\"responseType\\":\\"io.xtech.Result\\",\\"comment\\":null}},\\"comment\\":null}}},\\"Item\\":{\\"fields\\":{\\"name\\":{\\"type\\":\\"string\\",\\"id\\":1,\\"comment\\":null}},\\"comment\\":null},\\"TopLevel\\":{\\"fields\\":{\\"value\\":{\\"type\\":\\"string\\",\\"id\\":1,\\"comment\\":null},\\"nested_usage\\":{\\"type\\":\\"Nested\\",\\"id\\":3,\\"comment\\":null}},\\"nested\\":{\\"Nested\\":{\\"fields\\":{\\"movie\\":{\\"type\\":\\"Item\\",\\"id\\":2,\\"comment\\":null}},\\"comment\\":null}},\\"comment\\":null},\\"Result\\":{\\"fields\\":{\\"result\\":{\\"rule\\":\\"repeated\\",\\"type\\":\\"Item\\",\\"id\\":1,\\"comment\\":null}},\\"comment\\":null},\\"Example\\":{\\"methods\\":{\\"Get\\":{\\"requestType\\":\\"TopLevel.Nested\\",\\"responseType\\":\\"Result\\",\\"comment\\":null}},\\"comment\\":null}}}}}}}") {
-  io_xtech_outer_Example_Get(input: io_xtech_TopLevel_Nested_Input): io_xtech_Result @grpcMethod(rootJsonName: "Root0", objPath: "io.xtech.outer.Example", methodName: "Get", responseStream: false)
+  io_xtech_outer_Example_Get(input: io__xtech__TopLevel__Nested_Input): io__xtech__Result @grpcMethod(rootJsonName: "Root0", objPath: "io.xtech.outer.Example", methodName: "Get", responseStream: false)
   io_xtech_outer_Example_connectivityState(tryToConnect: Boolean): ConnectivityState @grpcConnectivityState(rootJsonName: "Root0", objPath: "io.xtech.outer.Example")
-  io_xtech_Example_Get(input: io_xtech_TopLevel_Nested_Input): io_xtech_Result @grpcMethod(rootJsonName: "Root0", objPath: "io.xtech.Example", methodName: "Get", responseStream: false)
+  io_xtech_Example_Get(input: io__xtech__TopLevel__Nested_Input): io__xtech__Result @grpcMethod(rootJsonName: "Root0", objPath: "io.xtech.Example", methodName: "Get", responseStream: false)
   io_xtech_Example_connectivityState(tryToConnect: Boolean): ConnectivityState @grpcConnectivityState(rootJsonName: "Root0", objPath: "io.xtech.Example")
 }
 
-type io_xtech_Result {
-  result: [io_xtech_Item]
+type io__xtech__Result {
+  result: [io__xtech__Item]
 }
 
-type io_xtech_Item {
+type io__xtech__Item {
   name: String
 }
 
-input io_xtech_TopLevel_Nested_Input {
-  movie: io_xtech_Item_Input
+input io__xtech__TopLevel__Nested_Input {
+  movie: io__xtech__Item_Input
 }
 
-input io_xtech_Item_Input {
+input io__xtech__Item_Input {
   name: String
 }
+
+enum ConnectivityState {
+  IDLE
+  CONNECTING
+  READY
+  TRANSIENT_FAILURE
+  SHUTDOWN
+}
+
+scalar ObjMap"
+`;
+
+exports[`gRPC Handler Interpreting Protos should load the Input bug 5880 proto 1`] = `
+"schema {
+  query: Query
+}
+
+directive @grpcMethod(rootJsonName: String, objPath: String, methodName: String, responseStream: Boolean) on FIELD_DEFINITION
+
+directive @grpcConnectivityState(rootJsonName: String, objPath: String) on FIELD_DEFINITION
+
+directive @grpcRootJson(name: String, rootJson: ObjMap, loadOptions: ObjMap) repeatable on OBJECT
+
+"Directs the executor to stream plural fields when the \`if\` argument is true or undefined."
+directive @stream(
+  """Stream when true or undefined."""
+  if: Boolean! = true
+  """Unique name"""
+  label: String
+  """Number of items to return immediately"""
+  initialCount: Int = 0
+) on FIELD
+
+type Query @grpcRootJson(name: "Root0", rootJson: "{\\"nested\\":{\\"TestMessage\\":{\\"fields\\":{\\"input\\":{\\"type\\":\\"Input\\",\\"id\\":1,\\"comment\\":null}},\\"nested\\":{\\"Input\\":{\\"fields\\":{},\\"comment\\":null}},\\"comment\\":null},\\"TestService\\":{\\"methods\\":{\\"Get\\":{\\"requestType\\":\\"TestMessage\\",\\"responseType\\":\\"TestMessage\\",\\"comment\\":null}},\\"comment\\":null}}}") {
+  TestService_Get(input: TestMessage_Input): TestMessage @grpcMethod(rootJsonName: "Root0", objPath: "TestService", methodName: "Get", responseStream: false)
+  TestService_connectivityState(tryToConnect: Boolean): ConnectivityState @grpcConnectivityState(rootJsonName: "Root0", objPath: "TestService")
+}
+
+type TestMessage {
+  input: TestMessage__Input
+}
+
+scalar TestMessage__Input @specifiedBy(url: "http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf")
+
+input TestMessage_Input {
+  input: TestMessage__Input_Input
+}
+
+scalar TestMessage__Input_Input @specifiedBy(url: "http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf")
 
 enum ConnectivityState {
   IDLE
@@ -424,18 +473,18 @@ directive @stream(
 ) on FIELD
 
 type Query @grpcRootJson(name: "Root0", rootJson: "{\\"nested\\":{\\"io\\":{\\"nested\\":{\\"xtech\\":{\\"nested\\":{\\"MapRequest\\":{\\"fields\\":{\\"map\\":{\\"keyType\\":\\"string\\",\\"type\\":\\"string\\",\\"id\\":1,\\"comment\\":null}},\\"comment\\":null},\\"MapResponse\\":{\\"fields\\":{\\"map\\":{\\"keyType\\":\\"string\\",\\"type\\":\\"string\\",\\"id\\":1,\\"comment\\":null}},\\"comment\\":null},\\"MapService\\":{\\"methods\\":{\\"GetMap\\":{\\"requestType\\":\\"MapRequest\\",\\"responseType\\":\\"MapResponse\\",\\"comment\\":null}},\\"comment\\":null}}}}}}}") {
-  io_xtech_MapService_GetMap(input: io_xtech_MapRequest_Input): io_xtech_MapResponse @grpcMethod(rootJsonName: "Root0", objPath: "io.xtech.MapService", methodName: "GetMap", responseStream: false)
+  io_xtech_MapService_GetMap(input: io__xtech__MapRequest_Input): io__xtech__MapResponse @grpcMethod(rootJsonName: "Root0", objPath: "io.xtech.MapService", methodName: "GetMap", responseStream: false)
   io_xtech_MapService_connectivityState(tryToConnect: Boolean): ConnectivityState @grpcConnectivityState(rootJsonName: "Root0", objPath: "io.xtech.MapService")
 }
 
-type io_xtech_MapResponse {
+type io__xtech__MapResponse {
   map: JSON
 }
 
 "The \`JSON\` scalar type represents JSON values as specified by [ECMA-404](http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf)."
 scalar JSON @specifiedBy(url: "http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf")
 
-input io_xtech_MapRequest_Input {
+input io__xtech__MapRequest_Input {
   map: JSON
 }
 
@@ -475,35 +524,35 @@ directive @stream(
 
 type Query @grpcRootJson(name: "Root0", rootJson: "{\\"nested\\":{\\"io\\":{\\"nested\\":{\\"xtech\\":{\\"nested\\":{\\"Genre\\":{\\"values\\":{\\"UNSPECIFIED\\":0,\\"ACTION\\":1,\\"DRAMA\\":2},\\"comment\\":null,\\"comments\\":{\\"UNSPECIFIED\\":null,\\"ACTION\\":null,\\"DRAMA\\":null}},\\"Movie\\":{\\"fields\\":{\\"name\\":{\\"type\\":\\"string\\",\\"id\\":1,\\"comment\\":null},\\"year\\":{\\"type\\":\\"int32\\",\\"id\\":2,\\"comment\\":null},\\"rating\\":{\\"type\\":\\"float\\",\\"id\\":3,\\"comment\\":null},\\"cast\\":{\\"rule\\":\\"repeated\\",\\"type\\":\\"string\\",\\"id\\":4,\\"comment\\":\\"list of cast\\"},\\"time\\":{\\"type\\":\\"google.protobuf.Timestamp\\",\\"id\\":5,\\"comment\\":null},\\"genre\\":{\\"type\\":\\"Genre\\",\\"id\\":6,\\"comment\\":null}},\\"comment\\":\\"movie message payload\\"},\\"EmptyRequest\\":{\\"fields\\":{},\\"comment\\":null},\\"MovieRequest\\":{\\"fields\\":{\\"movie\\":{\\"type\\":\\"Movie\\",\\"id\\":1,\\"comment\\":null}},\\"comment\\":null},\\"SearchByCastRequest\\":{\\"fields\\":{\\"castName\\":{\\"type\\":\\"string\\",\\"id\\":1,\\"comment\\":null}},\\"comment\\":null},\\"MoviesResult\\":{\\"fields\\":{\\"result\\":{\\"rule\\":\\"repeated\\",\\"type\\":\\"Movie\\",\\"id\\":1,\\"comment\\":\\"list of movies\\"}},\\"comment\\":\\"movie result message, contains list of movies\\"},\\"Example\\":{\\"methods\\":{\\"GetMovies\\":{\\"requestType\\":\\"MovieRequest\\",\\"responseType\\":\\"MoviesResult\\",\\"comment\\":\\"get all movies\\"},\\"SearchMoviesByCast\\":{\\"requestType\\":\\"SearchByCastRequest\\",\\"responseType\\":\\"Movie\\",\\"responseStream\\":true,\\"comment\\":\\"search movies by the name of the cast\\"}},\\"comment\\":null},\\"AnotherExample\\":{\\"methods\\":{\\"GetMovies\\":{\\"requestType\\":\\"MovieRequest\\",\\"responseType\\":\\"MoviesResult\\",\\"comment\\":\\"get all movies\\"},\\"SearchMoviesByCast\\":{\\"requestType\\":\\"SearchByCastRequest\\",\\"responseType\\":\\"Movie\\",\\"responseStream\\":true,\\"comment\\":\\"search movies by the name of the cast\\"}},\\"comment\\":null}}}}},\\"google\\":{\\"nested\\":{\\"protobuf\\":{\\"nested\\":{\\"Timestamp\\":{\\"fields\\":{\\"seconds\\":{\\"type\\":\\"int64\\",\\"id\\":1},\\"nanos\\":{\\"type\\":\\"int32\\",\\"id\\":2}},\\"comment\\":null}}}}}}}") {
   "get all movies"
-  io_xtech_Example_GetMovies(input: io_xtech_MovieRequest_Input): io_xtech_MoviesResult @grpcMethod(rootJsonName: "Root0", objPath: "io.xtech.Example", methodName: "GetMovies", responseStream: false)
+  io_xtech_Example_GetMovies(input: io__xtech__MovieRequest_Input): io__xtech__MoviesResult @grpcMethod(rootJsonName: "Root0", objPath: "io.xtech.Example", methodName: "GetMovies", responseStream: false)
   "search movies by the name of the cast"
-  io_xtech_Example_SearchMoviesByCast(input: io_xtech_SearchByCastRequest_Input): [io_xtech_Movie] @grpcMethod(rootJsonName: "Root0", objPath: "io.xtech.Example", methodName: "SearchMoviesByCast", responseStream: true)
+  io_xtech_Example_SearchMoviesByCast(input: io__xtech__SearchByCastRequest_Input): [io__xtech__Movie] @grpcMethod(rootJsonName: "Root0", objPath: "io.xtech.Example", methodName: "SearchMoviesByCast", responseStream: true)
   io_xtech_Example_connectivityState(tryToConnect: Boolean): ConnectivityState @grpcConnectivityState(rootJsonName: "Root0", objPath: "io.xtech.Example")
   "get all movies"
-  io_xtech_AnotherExample_GetMovies(input: io_xtech_MovieRequest_Input): io_xtech_MoviesResult @grpcMethod(rootJsonName: "Root0", objPath: "io.xtech.AnotherExample", methodName: "GetMovies", responseStream: false)
+  io_xtech_AnotherExample_GetMovies(input: io__xtech__MovieRequest_Input): io__xtech__MoviesResult @grpcMethod(rootJsonName: "Root0", objPath: "io.xtech.AnotherExample", methodName: "GetMovies", responseStream: false)
   "search movies by the name of the cast"
-  io_xtech_AnotherExample_SearchMoviesByCast(input: io_xtech_SearchByCastRequest_Input): [io_xtech_Movie] @grpcMethod(rootJsonName: "Root0", objPath: "io.xtech.AnotherExample", methodName: "SearchMoviesByCast", responseStream: true)
+  io_xtech_AnotherExample_SearchMoviesByCast(input: io__xtech__SearchByCastRequest_Input): [io__xtech__Movie] @grpcMethod(rootJsonName: "Root0", objPath: "io.xtech.AnotherExample", methodName: "SearchMoviesByCast", responseStream: true)
   io_xtech_AnotherExample_connectivityState(tryToConnect: Boolean): ConnectivityState @grpcConnectivityState(rootJsonName: "Root0", objPath: "io.xtech.AnotherExample")
 }
 
 "movie result message, contains list of movies"
-type io_xtech_MoviesResult {
+type io__xtech__MoviesResult {
   "list of movies"
-  result: [io_xtech_Movie]
+  result: [io__xtech__Movie]
 }
 
 "movie message payload"
-type io_xtech_Movie {
+type io__xtech__Movie {
   name: String
   year: Int
   rating: Float
   "list of cast"
   cast: [String]
-  time: google_protobuf_Timestamp
-  genre: io_xtech_Genre
+  time: google__protobuf__Timestamp
+  genre: io__xtech__Genre
 }
 
-type google_protobuf_Timestamp {
+type google__protobuf__Timestamp {
   seconds: BigInt
   nanos: Int
 }
@@ -511,33 +560,33 @@ type google_protobuf_Timestamp {
 "The \`BigInt\` scalar type represents non-fractional signed whole numeric values."
 scalar BigInt
 
-enum io_xtech_Genre {
+enum io__xtech__Genre {
   UNSPECIFIED @enum(value: "0")
   ACTION @enum(value: "1")
   DRAMA @enum(value: "2")
 }
 
-input io_xtech_MovieRequest_Input {
-  movie: io_xtech_Movie_Input
+input io__xtech__MovieRequest_Input {
+  movie: io__xtech__Movie_Input
 }
 
 "movie message payload"
-input io_xtech_Movie_Input {
+input io__xtech__Movie_Input {
   name: String
   year: Int
   rating: Float
   "list of cast"
   cast: [String]
-  time: google_protobuf_Timestamp_Input
-  genre: io_xtech_Genre
+  time: google__protobuf__Timestamp_Input
+  genre: io__xtech__Genre
 }
 
-input google_protobuf_Timestamp_Input {
+input google__protobuf__Timestamp_Input {
   seconds: BigInt
   nanos: Int
 }
 
-input io_xtech_SearchByCastRequest_Input {
+input io__xtech__SearchByCastRequest_Input {
   castName: String
 }
 
@@ -574,23 +623,23 @@ directive @stream(
 ) on FIELD
 
 type Query @grpcRootJson(name: "Root0", rootJson: "{\\"nested\\":{\\"io\\":{\\"nested\\":{\\"xtech\\":{\\"nested\\":{\\"Item\\":{\\"fields\\":{\\"name\\":{\\"type\\":\\"string\\",\\"id\\":1,\\"comment\\":null}},\\"comment\\":null},\\"TopLevel\\":{\\"fields\\":{\\"value\\":{\\"type\\":\\"string\\",\\"id\\":1,\\"comment\\":null},\\"nested_usage\\":{\\"type\\":\\"Nested\\",\\"id\\":3,\\"comment\\":null}},\\"nested\\":{\\"Nested\\":{\\"fields\\":{\\"movie\\":{\\"type\\":\\"Item\\",\\"id\\":2,\\"comment\\":null}},\\"comment\\":null}},\\"comment\\":null},\\"Result\\":{\\"fields\\":{\\"result\\":{\\"rule\\":\\"repeated\\",\\"type\\":\\"Item\\",\\"id\\":1,\\"comment\\":null}},\\"comment\\":null},\\"Example\\":{\\"methods\\":{\\"Get\\":{\\"requestType\\":\\"TopLevel.Nested\\",\\"responseType\\":\\"Result\\",\\"comment\\":null}},\\"comment\\":null}}}}}}}") {
-  io_xtech_Example_Get(input: io_xtech_TopLevel_Nested_Input): io_xtech_Result @grpcMethod(rootJsonName: "Root0", objPath: "io.xtech.Example", methodName: "Get", responseStream: false)
+  io_xtech_Example_Get(input: io__xtech__TopLevel__Nested_Input): io__xtech__Result @grpcMethod(rootJsonName: "Root0", objPath: "io.xtech.Example", methodName: "Get", responseStream: false)
   io_xtech_Example_connectivityState(tryToConnect: Boolean): ConnectivityState @grpcConnectivityState(rootJsonName: "Root0", objPath: "io.xtech.Example")
 }
 
-type io_xtech_Result {
-  result: [io_xtech_Item]
+type io__xtech__Result {
+  result: [io__xtech__Item]
 }
 
-type io_xtech_Item {
+type io__xtech__Item {
   name: String
 }
 
-input io_xtech_TopLevel_Nested_Input {
-  movie: io_xtech_Item_Input
+input io__xtech__TopLevel__Nested_Input {
+  movie: io__xtech__Item_Input
 }
 
-input io_xtech_Item_Input {
+input io__xtech__Item_Input {
   name: String
 }
 
@@ -627,7 +676,7 @@ directive @stream(
 ) on FIELD
 
 type Query @grpcRootJson(name: "Root0", rootJson: "{\\"nested\\":{\\"Item\\":{\\"fields\\":{\\"name\\":{\\"type\\":\\"string\\",\\"id\\":1,\\"comment\\":null}},\\"comment\\":null},\\"TopLevel\\":{\\"fields\\":{\\"value\\":{\\"type\\":\\"string\\",\\"id\\":1,\\"comment\\":null},\\"nested_usage\\":{\\"type\\":\\"Nested\\",\\"id\\":3,\\"comment\\":null}},\\"nested\\":{\\"Nested\\":{\\"fields\\":{\\"movie\\":{\\"type\\":\\"Item\\",\\"id\\":2,\\"comment\\":null}},\\"comment\\":null}},\\"comment\\":null},\\"Result\\":{\\"fields\\":{\\"result\\":{\\"rule\\":\\"repeated\\",\\"type\\":\\"Item\\",\\"id\\":1,\\"comment\\":null}},\\"comment\\":null},\\"Example\\":{\\"methods\\":{\\"Get\\":{\\"requestType\\":\\"TopLevel.Nested\\",\\"responseType\\":\\"Result\\",\\"comment\\":null}},\\"comment\\":null}}}") {
-  Example_Get(input: TopLevel_Nested_Input): Result @grpcMethod(rootJsonName: "Root0", objPath: "Example", methodName: "Get", responseStream: false)
+  Example_Get(input: TopLevel__Nested_Input): Result @grpcMethod(rootJsonName: "Root0", objPath: "Example", methodName: "Get", responseStream: false)
   Example_connectivityState(tryToConnect: Boolean): ConnectivityState @grpcConnectivityState(rootJsonName: "Root0", objPath: "Example")
 }
 
@@ -639,7 +688,7 @@ type Item {
   name: String
 }
 
-input TopLevel_Nested_Input {
+input TopLevel__Nested_Input {
   movie: Item_Input
 }
 
@@ -682,36 +731,36 @@ directive @stream(
 ) on FIELD
 
 type Query @grpcRootJson(name: "Root0", rootJson: "{\\"nested\\":{\\"io\\":{\\"nested\\":{\\"outside\\":{\\"nested\\":{\\"MovieRequest\\":{\\"fields\\":{\\"movie\\":{\\"type\\":\\"io.xtech.Movie\\",\\"id\\":1,\\"comment\\":null}},\\"comment\\":null},\\"MoviesResult\\":{\\"fields\\":{\\"result\\":{\\"rule\\":\\"repeated\\",\\"type\\":\\"io.xtech.Movie\\",\\"id\\":1,\\"comment\\":null}},\\"comment\\":null},\\"Example\\":{\\"methods\\":{\\"GetMovies\\":{\\"requestType\\":\\"MovieRequest\\",\\"responseType\\":\\"MoviesResult\\",\\"comment\\":null}},\\"comment\\":null}}},\\"xtech\\":{\\"nested\\":{\\"Genre\\":{\\"values\\":{\\"UNSPECIFIED\\":0,\\"ACTION\\":1,\\"DRAMA\\":2},\\"comment\\":null,\\"comments\\":{\\"UNSPECIFIED\\":null,\\"ACTION\\":null,\\"DRAMA\\":null}},\\"Movie\\":{\\"fields\\":{\\"name\\":{\\"type\\":\\"string\\",\\"id\\":1,\\"comment\\":null},\\"year\\":{\\"type\\":\\"int32\\",\\"id\\":2,\\"comment\\":null},\\"rating\\":{\\"type\\":\\"float\\",\\"id\\":3,\\"comment\\":null},\\"cast\\":{\\"rule\\":\\"repeated\\",\\"type\\":\\"string\\",\\"id\\":4,\\"comment\\":\\"list of cast\\"},\\"time\\":{\\"type\\":\\"google.protobuf.Timestamp\\",\\"id\\":5,\\"comment\\":null},\\"genre\\":{\\"type\\":\\"Genre\\",\\"id\\":6,\\"comment\\":null}},\\"comment\\":\\"movie message payload\\"},\\"EmptyRequest\\":{\\"fields\\":{},\\"comment\\":null},\\"MovieRequest\\":{\\"fields\\":{\\"movie\\":{\\"type\\":\\"Movie\\",\\"id\\":1,\\"comment\\":null}},\\"comment\\":null},\\"SearchByCastRequest\\":{\\"fields\\":{\\"castName\\":{\\"type\\":\\"string\\",\\"id\\":1,\\"comment\\":null}},\\"comment\\":null},\\"MoviesResult\\":{\\"fields\\":{\\"result\\":{\\"rule\\":\\"repeated\\",\\"type\\":\\"Movie\\",\\"id\\":1,\\"comment\\":\\"list of movies\\"}},\\"comment\\":\\"movie result message, contains list of movies\\"},\\"Example\\":{\\"methods\\":{\\"GetMovies\\":{\\"requestType\\":\\"MovieRequest\\",\\"responseType\\":\\"MoviesResult\\",\\"comment\\":\\"get all movies\\"},\\"SearchMoviesByCast\\":{\\"requestType\\":\\"SearchByCastRequest\\",\\"responseType\\":\\"Movie\\",\\"responseStream\\":true,\\"comment\\":\\"search movies by the name of the cast\\"}},\\"comment\\":null},\\"AnotherExample\\":{\\"methods\\":{\\"GetMovies\\":{\\"requestType\\":\\"MovieRequest\\",\\"responseType\\":\\"MoviesResult\\",\\"comment\\":\\"get all movies\\"},\\"SearchMoviesByCast\\":{\\"requestType\\":\\"SearchByCastRequest\\",\\"responseType\\":\\"Movie\\",\\"responseStream\\":true,\\"comment\\":\\"search movies by the name of the cast\\"}},\\"comment\\":null}}}}},\\"google\\":{\\"nested\\":{\\"protobuf\\":{\\"nested\\":{\\"Timestamp\\":{\\"fields\\":{\\"seconds\\":{\\"type\\":\\"int64\\",\\"id\\":1},\\"nanos\\":{\\"type\\":\\"int32\\",\\"id\\":2}},\\"comment\\":null}}}}}}}") {
-  io_outside_Example_GetMovies(input: io_outside_MovieRequest_Input): io_outside_MoviesResult @grpcMethod(rootJsonName: "Root0", objPath: "io.outside.Example", methodName: "GetMovies", responseStream: false)
+  io_outside_Example_GetMovies(input: io__outside__MovieRequest_Input): io__outside__MoviesResult @grpcMethod(rootJsonName: "Root0", objPath: "io.outside.Example", methodName: "GetMovies", responseStream: false)
   io_outside_Example_connectivityState(tryToConnect: Boolean): ConnectivityState @grpcConnectivityState(rootJsonName: "Root0", objPath: "io.outside.Example")
   "get all movies"
-  io_xtech_Example_GetMovies(input: io_xtech_MovieRequest_Input): io_xtech_MoviesResult @grpcMethod(rootJsonName: "Root0", objPath: "io.xtech.Example", methodName: "GetMovies", responseStream: false)
+  io_xtech_Example_GetMovies(input: io__xtech__MovieRequest_Input): io__xtech__MoviesResult @grpcMethod(rootJsonName: "Root0", objPath: "io.xtech.Example", methodName: "GetMovies", responseStream: false)
   "search movies by the name of the cast"
-  io_xtech_Example_SearchMoviesByCast(input: io_xtech_SearchByCastRequest_Input): [io_xtech_Movie] @grpcMethod(rootJsonName: "Root0", objPath: "io.xtech.Example", methodName: "SearchMoviesByCast", responseStream: true)
+  io_xtech_Example_SearchMoviesByCast(input: io__xtech__SearchByCastRequest_Input): [io__xtech__Movie] @grpcMethod(rootJsonName: "Root0", objPath: "io.xtech.Example", methodName: "SearchMoviesByCast", responseStream: true)
   io_xtech_Example_connectivityState(tryToConnect: Boolean): ConnectivityState @grpcConnectivityState(rootJsonName: "Root0", objPath: "io.xtech.Example")
   "get all movies"
-  io_xtech_AnotherExample_GetMovies(input: io_xtech_MovieRequest_Input): io_xtech_MoviesResult @grpcMethod(rootJsonName: "Root0", objPath: "io.xtech.AnotherExample", methodName: "GetMovies", responseStream: false)
+  io_xtech_AnotherExample_GetMovies(input: io__xtech__MovieRequest_Input): io__xtech__MoviesResult @grpcMethod(rootJsonName: "Root0", objPath: "io.xtech.AnotherExample", methodName: "GetMovies", responseStream: false)
   "search movies by the name of the cast"
-  io_xtech_AnotherExample_SearchMoviesByCast(input: io_xtech_SearchByCastRequest_Input): [io_xtech_Movie] @grpcMethod(rootJsonName: "Root0", objPath: "io.xtech.AnotherExample", methodName: "SearchMoviesByCast", responseStream: true)
+  io_xtech_AnotherExample_SearchMoviesByCast(input: io__xtech__SearchByCastRequest_Input): [io__xtech__Movie] @grpcMethod(rootJsonName: "Root0", objPath: "io.xtech.AnotherExample", methodName: "SearchMoviesByCast", responseStream: true)
   io_xtech_AnotherExample_connectivityState(tryToConnect: Boolean): ConnectivityState @grpcConnectivityState(rootJsonName: "Root0", objPath: "io.xtech.AnotherExample")
 }
 
-type io_outside_MoviesResult {
-  result: [io_xtech_Movie]
+type io__outside__MoviesResult {
+  result: [io__xtech__Movie]
 }
 
 "movie message payload"
-type io_xtech_Movie {
+type io__xtech__Movie {
   name: String
   year: Int
   rating: Float
   "list of cast"
   cast: [String]
-  time: google_protobuf_Timestamp
-  genre: io_xtech_Genre
+  time: google__protobuf__Timestamp
+  genre: io__xtech__Genre
 }
 
-type google_protobuf_Timestamp {
+type google__protobuf__Timestamp {
   seconds: BigInt
   nanos: Int
 }
@@ -719,28 +768,28 @@ type google_protobuf_Timestamp {
 "The \`BigInt\` scalar type represents non-fractional signed whole numeric values."
 scalar BigInt
 
-enum io_xtech_Genre {
+enum io__xtech__Genre {
   UNSPECIFIED @enum(value: "0")
   ACTION @enum(value: "1")
   DRAMA @enum(value: "2")
 }
 
-input io_outside_MovieRequest_Input {
-  movie: io_xtech_Movie_Input
+input io__outside__MovieRequest_Input {
+  movie: io__xtech__Movie_Input
 }
 
 "movie message payload"
-input io_xtech_Movie_Input {
+input io__xtech__Movie_Input {
   name: String
   year: Int
   rating: Float
   "list of cast"
   cast: [String]
-  time: google_protobuf_Timestamp_Input
-  genre: io_xtech_Genre
+  time: google__protobuf__Timestamp_Input
+  genre: io__xtech__Genre
 }
 
-input google_protobuf_Timestamp_Input {
+input google__protobuf__Timestamp_Input {
   seconds: BigInt
   nanos: Int
 }
@@ -754,16 +803,16 @@ enum ConnectivityState {
 }
 
 "movie result message, contains list of movies"
-type io_xtech_MoviesResult {
+type io__xtech__MoviesResult {
   "list of movies"
-  result: [io_xtech_Movie]
+  result: [io__xtech__Movie]
 }
 
-input io_xtech_MovieRequest_Input {
-  movie: io_xtech_Movie_Input
+input io__xtech__MovieRequest_Input {
+  movie: io__xtech__Movie_Input
 }
 
-input io_xtech_SearchByCastRequest_Input {
+input io__xtech__SearchByCastRequest_Input {
   castName: String
 }
 
@@ -881,35 +930,35 @@ directive @stream(
 
 type Query @grpcRootJson(name: "Root0", rootJson: "{\\"nested\\":{\\"io\\":{\\"nested\\":{\\"xtech\\":{\\"nested\\":{\\"Genre\\":{\\"values\\":{\\"UNSPECIFIED\\":0,\\"ACTION\\":1,\\"DRAMA\\":2},\\"comment\\":null,\\"comments\\":{\\"UNSPECIFIED\\":null,\\"ACTION\\":null,\\"DRAMA\\":null}},\\"Movie\\":{\\"fields\\":{\\"name\\":{\\"type\\":\\"string\\",\\"id\\":1,\\"comment\\":null},\\"year\\":{\\"type\\":\\"int32\\",\\"id\\":2,\\"comment\\":null},\\"rating\\":{\\"type\\":\\"float\\",\\"id\\":3,\\"comment\\":null},\\"cast\\":{\\"rule\\":\\"repeated\\",\\"type\\":\\"string\\",\\"id\\":4,\\"comment\\":\\"list of cast\\"},\\"time\\":{\\"type\\":\\"google.protobuf.Timestamp\\",\\"id\\":5,\\"comment\\":null},\\"genre\\":{\\"type\\":\\"Genre\\",\\"id\\":6,\\"comment\\":null}},\\"comment\\":\\"movie message payload\\"},\\"EmptyRequest\\":{\\"fields\\":{},\\"comment\\":null},\\"movie_request\\":{\\"fields\\":{\\"movie\\":{\\"type\\":\\"Movie\\",\\"id\\":1,\\"comment\\":null}},\\"comment\\":null},\\"SearchByCastRequest\\":{\\"fields\\":{\\"castName\\":{\\"type\\":\\"string\\",\\"id\\":1,\\"comment\\":null}},\\"comment\\":null},\\"MoviesResult\\":{\\"fields\\":{\\"result\\":{\\"rule\\":\\"repeated\\",\\"type\\":\\"Movie\\",\\"id\\":1,\\"comment\\":\\"list of movies\\"}},\\"comment\\":\\"movie result message, contains list of movies\\"},\\"Example\\":{\\"methods\\":{\\"GetMovies\\":{\\"requestType\\":\\"movie_request\\",\\"responseType\\":\\"MoviesResult\\",\\"comment\\":\\"get all movies\\"},\\"SearchMoviesByCast\\":{\\"requestType\\":\\"SearchByCastRequest\\",\\"responseType\\":\\"Movie\\",\\"responseStream\\":true,\\"comment\\":\\"search movies by the name of the cast\\"}},\\"comment\\":null},\\"AnotherExample\\":{\\"methods\\":{\\"GetMovies\\":{\\"requestType\\":\\"movie_request\\",\\"responseType\\":\\"MoviesResult\\",\\"comment\\":\\"get all movies\\"},\\"SearchMoviesByCast\\":{\\"requestType\\":\\"SearchByCastRequest\\",\\"responseType\\":\\"Movie\\",\\"responseStream\\":true,\\"comment\\":\\"search movies by the name of the cast\\"}},\\"comment\\":null}}}}},\\"google\\":{\\"nested\\":{\\"protobuf\\":{\\"nested\\":{\\"Timestamp\\":{\\"fields\\":{\\"seconds\\":{\\"type\\":\\"int64\\",\\"id\\":1},\\"nanos\\":{\\"type\\":\\"int32\\",\\"id\\":2}},\\"comment\\":null}}}}}}}") {
   "get all movies"
-  io_xtech_Example_GetMovies(input: io_xtech_movie_request_Input): io_xtech_MoviesResult @grpcMethod(rootJsonName: "Root0", objPath: "io.xtech.Example", methodName: "GetMovies", responseStream: false)
+  io_xtech_Example_GetMovies(input: io__xtech__movie_request_Input): io__xtech__MoviesResult @grpcMethod(rootJsonName: "Root0", objPath: "io.xtech.Example", methodName: "GetMovies", responseStream: false)
   "search movies by the name of the cast"
-  io_xtech_Example_SearchMoviesByCast(input: io_xtech_SearchByCastRequest_Input): [io_xtech_Movie] @grpcMethod(rootJsonName: "Root0", objPath: "io.xtech.Example", methodName: "SearchMoviesByCast", responseStream: true)
+  io_xtech_Example_SearchMoviesByCast(input: io__xtech__SearchByCastRequest_Input): [io__xtech__Movie] @grpcMethod(rootJsonName: "Root0", objPath: "io.xtech.Example", methodName: "SearchMoviesByCast", responseStream: true)
   io_xtech_Example_connectivityState(tryToConnect: Boolean): ConnectivityState @grpcConnectivityState(rootJsonName: "Root0", objPath: "io.xtech.Example")
   "get all movies"
-  io_xtech_AnotherExample_GetMovies(input: io_xtech_movie_request_Input): io_xtech_MoviesResult @grpcMethod(rootJsonName: "Root0", objPath: "io.xtech.AnotherExample", methodName: "GetMovies", responseStream: false)
+  io_xtech_AnotherExample_GetMovies(input: io__xtech__movie_request_Input): io__xtech__MoviesResult @grpcMethod(rootJsonName: "Root0", objPath: "io.xtech.AnotherExample", methodName: "GetMovies", responseStream: false)
   "search movies by the name of the cast"
-  io_xtech_AnotherExample_SearchMoviesByCast(input: io_xtech_SearchByCastRequest_Input): [io_xtech_Movie] @grpcMethod(rootJsonName: "Root0", objPath: "io.xtech.AnotherExample", methodName: "SearchMoviesByCast", responseStream: true)
+  io_xtech_AnotherExample_SearchMoviesByCast(input: io__xtech__SearchByCastRequest_Input): [io__xtech__Movie] @grpcMethod(rootJsonName: "Root0", objPath: "io.xtech.AnotherExample", methodName: "SearchMoviesByCast", responseStream: true)
   io_xtech_AnotherExample_connectivityState(tryToConnect: Boolean): ConnectivityState @grpcConnectivityState(rootJsonName: "Root0", objPath: "io.xtech.AnotherExample")
 }
 
 "movie result message, contains list of movies"
-type io_xtech_MoviesResult {
+type io__xtech__MoviesResult {
   "list of movies"
-  result: [io_xtech_Movie]
+  result: [io__xtech__Movie]
 }
 
 "movie message payload"
-type io_xtech_Movie {
+type io__xtech__Movie {
   name: String
   year: Int
   rating: Float
   "list of cast"
   cast: [String]
-  time: google_protobuf_Timestamp
-  genre: io_xtech_Genre
+  time: google__protobuf__Timestamp
+  genre: io__xtech__Genre
 }
 
-type google_protobuf_Timestamp {
+type google__protobuf__Timestamp {
   seconds: BigInt
   nanos: Int
 }
@@ -917,33 +966,33 @@ type google_protobuf_Timestamp {
 "The \`BigInt\` scalar type represents non-fractional signed whole numeric values."
 scalar BigInt
 
-enum io_xtech_Genre {
+enum io__xtech__Genre {
   UNSPECIFIED @enum(value: "0")
   ACTION @enum(value: "1")
   DRAMA @enum(value: "2")
 }
 
-input io_xtech_movie_request_Input {
-  movie: io_xtech_Movie_Input
+input io__xtech__movie_request_Input {
+  movie: io__xtech__Movie_Input
 }
 
 "movie message payload"
-input io_xtech_Movie_Input {
+input io__xtech__Movie_Input {
   name: String
   year: Int
   rating: Float
   "list of cast"
   cast: [String]
-  time: google_protobuf_Timestamp_Input
-  genre: io_xtech_Genre
+  time: google__protobuf__Timestamp_Input
+  genre: io__xtech__Genre
 }
 
-input google_protobuf_Timestamp_Input {
+input google__protobuf__Timestamp_Input {
   seconds: BigInt
   nanos: Int
 }
 
-input io_xtech_SearchByCastRequest_Input {
+input io__xtech__SearchByCastRequest_Input {
   castName: String
 }
 
@@ -984,35 +1033,35 @@ directive @stream(
 
 type Query @grpcRootJson(name: "Root0", rootJson: "{\\"nested\\":{\\"io\\":{\\"nested\\":{\\"xtech\\":{\\"nested\\":{\\"Genre\\":{\\"values\\":{\\"UNSPECIFIED\\":0,\\"ACTION\\":1,\\"DRAMA\\":2},\\"comment\\":null,\\"comments\\":{\\"UNSPECIFIED\\":null,\\"ACTION\\":null,\\"DRAMA\\":null}},\\"Movie\\":{\\"fields\\":{\\"name\\":{\\"type\\":\\"string\\",\\"id\\":1,\\"comment\\":null},\\"year\\":{\\"type\\":\\"int32\\",\\"id\\":2,\\"comment\\":null},\\"rating\\":{\\"type\\":\\"float\\",\\"id\\":3,\\"comment\\":null},\\"cast\\":{\\"rule\\":\\"repeated\\",\\"type\\":\\"string\\",\\"id\\":4,\\"comment\\":\\"list of cast\\"},\\"time\\":{\\"type\\":\\"google.protobuf.Timestamp\\",\\"id\\":5,\\"comment\\":null},\\"genre\\":{\\"type\\":\\"Genre\\",\\"id\\":6,\\"comment\\":null}},\\"comment\\":\\"movie message payload\\"},\\"EmptyRequest\\":{\\"fields\\":{},\\"comment\\":null},\\"movie_request\\":{\\"fields\\":{\\"movie\\":{\\"type\\":\\"Movie\\",\\"id\\":1,\\"comment\\":null}},\\"comment\\":null},\\"movie_request_by_ids\\":{\\"fields\\":{\\"movieIds\\":{\\"rule\\":\\"repeated\\",\\"type\\":\\"string\\",\\"id\\":1,\\"comment\\":null}},\\"comment\\":null},\\"SearchByCastRequest\\":{\\"fields\\":{\\"castName\\":{\\"type\\":\\"string\\",\\"id\\":1,\\"comment\\":null}},\\"comment\\":null},\\"MoviesResult\\":{\\"fields\\":{\\"result\\":{\\"rule\\":\\"repeated\\",\\"type\\":\\"Movie\\",\\"id\\":1,\\"comment\\":\\"list of movies\\"}},\\"comment\\":\\"movie result message, contains list of movies\\"},\\"Example\\":{\\"methods\\":{\\"GetMovies\\":{\\"requestType\\":\\"movie_request\\",\\"responseType\\":\\"MoviesResult\\",\\"comment\\":\\"get all movies\\"},\\"RetrieveMovies\\":{\\"requestType\\":\\"movie_request_by_ids\\",\\"responseType\\":\\"MoviesResult\\",\\"comment\\":\\"get movies\\"},\\"SearchMoviesByCast\\":{\\"requestType\\":\\"SearchByCastRequest\\",\\"responseType\\":\\"Movie\\",\\"responseStream\\":true,\\"comment\\":\\"search movies by the name of the cast\\"}},\\"comment\\":null},\\"AnotherExample\\":{\\"methods\\":{\\"GetMovies\\":{\\"requestType\\":\\"movie_request\\",\\"responseType\\":\\"MoviesResult\\",\\"comment\\":\\"get all movies\\"},\\"RetrieveMovies\\":{\\"requestType\\":\\"movie_request_by_ids\\",\\"responseType\\":\\"MoviesResult\\",\\"comment\\":\\"get movies\\"},\\"SearchMoviesByCast\\":{\\"requestType\\":\\"SearchByCastRequest\\",\\"responseType\\":\\"Movie\\",\\"responseStream\\":true,\\"comment\\":\\"search movies by the name of the cast\\"}},\\"comment\\":null}}}}},\\"google\\":{\\"nested\\":{\\"protobuf\\":{\\"nested\\":{\\"Timestamp\\":{\\"fields\\":{\\"seconds\\":{\\"type\\":\\"int64\\",\\"id\\":1},\\"nanos\\":{\\"type\\":\\"int32\\",\\"id\\":2}},\\"comment\\":null}}}}}}}") {
   "get all movies"
-  io_xtech_Example_GetMovies(input: io_xtech_movie_request_Input): io_xtech_MoviesResult @grpcMethod(rootJsonName: "Root0", objPath: "io.xtech.Example", methodName: "GetMovies", responseStream: false)
+  io_xtech_Example_GetMovies(input: io__xtech__movie_request_Input): io__xtech__MoviesResult @grpcMethod(rootJsonName: "Root0", objPath: "io.xtech.Example", methodName: "GetMovies", responseStream: false)
   "get movies"
-  io_xtech_Example_RetrieveMovies(input: io_xtech_movie_request_by_ids_Input): io_xtech_MoviesResult @grpcMethod(rootJsonName: "Root0", objPath: "io.xtech.Example", methodName: "RetrieveMovies", responseStream: false)
+  io_xtech_Example_RetrieveMovies(input: io__xtech__movie_request_by_ids_Input): io__xtech__MoviesResult @grpcMethod(rootJsonName: "Root0", objPath: "io.xtech.Example", methodName: "RetrieveMovies", responseStream: false)
   io_xtech_Example_connectivityState(tryToConnect: Boolean): ConnectivityState @grpcConnectivityState(rootJsonName: "Root0", objPath: "io.xtech.Example")
   "get all movies"
-  io_xtech_AnotherExample_GetMovies(input: io_xtech_movie_request_Input): io_xtech_MoviesResult @grpcMethod(rootJsonName: "Root0", objPath: "io.xtech.AnotherExample", methodName: "GetMovies", responseStream: false)
+  io_xtech_AnotherExample_GetMovies(input: io__xtech__movie_request_Input): io__xtech__MoviesResult @grpcMethod(rootJsonName: "Root0", objPath: "io.xtech.AnotherExample", methodName: "GetMovies", responseStream: false)
   "get movies"
-  io_xtech_AnotherExample_RetrieveMovies(input: io_xtech_movie_request_by_ids_Input): io_xtech_MoviesResult @grpcMethod(rootJsonName: "Root0", objPath: "io.xtech.AnotherExample", methodName: "RetrieveMovies", responseStream: false)
+  io_xtech_AnotherExample_RetrieveMovies(input: io__xtech__movie_request_by_ids_Input): io__xtech__MoviesResult @grpcMethod(rootJsonName: "Root0", objPath: "io.xtech.AnotherExample", methodName: "RetrieveMovies", responseStream: false)
   io_xtech_AnotherExample_connectivityState(tryToConnect: Boolean): ConnectivityState @grpcConnectivityState(rootJsonName: "Root0", objPath: "io.xtech.AnotherExample")
 }
 
 "movie result message, contains list of movies"
-type io_xtech_MoviesResult {
+type io__xtech__MoviesResult {
   "list of movies"
-  result: [io_xtech_Movie]
+  result: [io__xtech__Movie]
 }
 
 "movie message payload"
-type io_xtech_Movie {
+type io__xtech__Movie {
   name: String
   year: Int
   rating: Float
   "list of cast"
   cast: [String]
-  time: google_protobuf_Timestamp
-  genre: io_xtech_Genre
+  time: google__protobuf__Timestamp
+  genre: io__xtech__Genre
 }
 
-type google_protobuf_Timestamp {
+type google__protobuf__Timestamp {
   seconds: BigInt
   nanos: Int
 }
@@ -1020,33 +1069,33 @@ type google_protobuf_Timestamp {
 "The \`BigInt\` scalar type represents non-fractional signed whole numeric values."
 scalar BigInt
 
-enum io_xtech_Genre {
+enum io__xtech__Genre {
   UNSPECIFIED @enum(value: "0")
   ACTION @enum(value: "1")
   DRAMA @enum(value: "2")
 }
 
-input io_xtech_movie_request_Input {
-  movie: io_xtech_Movie_Input
+input io__xtech__movie_request_Input {
+  movie: io__xtech__Movie_Input
 }
 
 "movie message payload"
-input io_xtech_Movie_Input {
+input io__xtech__Movie_Input {
   name: String
   year: Int
   rating: Float
   "list of cast"
   cast: [String]
-  time: google_protobuf_Timestamp_Input
-  genre: io_xtech_Genre
+  time: google__protobuf__Timestamp_Input
+  genre: io__xtech__Genre
 }
 
-input google_protobuf_Timestamp_Input {
+input google__protobuf__Timestamp_Input {
   seconds: BigInt
   nanos: Int
 }
 
-input io_xtech_movie_request_by_ids_Input {
+input io__xtech__movie_request_by_ids_Input {
   movieIds: [String]
 }
 
@@ -1060,12 +1109,12 @@ enum ConnectivityState {
 
 type Mutation {
   "search movies by the name of the cast"
-  io_xtech_Example_SearchMoviesByCast(input: io_xtech_SearchByCastRequest_Input): [io_xtech_Movie] @grpcMethod(rootJsonName: "Root0", objPath: "io.xtech.Example", methodName: "SearchMoviesByCast", responseStream: true)
+  io_xtech_Example_SearchMoviesByCast(input: io__xtech__SearchByCastRequest_Input): [io__xtech__Movie] @grpcMethod(rootJsonName: "Root0", objPath: "io.xtech.Example", methodName: "SearchMoviesByCast", responseStream: true)
   "search movies by the name of the cast"
-  io_xtech_AnotherExample_SearchMoviesByCast(input: io_xtech_SearchByCastRequest_Input): [io_xtech_Movie] @grpcMethod(rootJsonName: "Root0", objPath: "io.xtech.AnotherExample", methodName: "SearchMoviesByCast", responseStream: true)
+  io_xtech_AnotherExample_SearchMoviesByCast(input: io__xtech__SearchByCastRequest_Input): [io__xtech__Movie] @grpcMethod(rootJsonName: "Root0", objPath: "io.xtech.AnotherExample", methodName: "SearchMoviesByCast", responseStream: true)
 }
 
-input io_xtech_SearchByCastRequest_Input {
+input io__xtech__SearchByCastRequest_Input {
   castName: String
 }
 

--- a/packages/handlers/grpc/test/fixtures/proto-tests/input_bug_5880.proto
+++ b/packages/handlers/grpc/test/fixtures/proto-tests/input_bug_5880.proto
@@ -1,0 +1,11 @@
+syntax = "proto3";
+message TestMessage {
+  Input input = 1;
+
+  message Input {
+  }
+}
+
+service TestService {
+  rpc Get(TestMessage) returns (TestMessage) {}
+}

--- a/packages/handlers/grpc/test/handler.spec.ts
+++ b/packages/handlers/grpc/test/handler.spec.ts
@@ -40,6 +40,7 @@ describe('gRPC Handler', () => {
     ['Comments', 'comments.proto'],
     ['Map', 'map.proto'],
     ['Enums', 'enums.proto'],
+    ['Input bug 5880', 'input_bug_5880.proto'],
   ])('Interpreting Protos', (name, file) => {
     test(`should load the ${name} proto`, async () => {
       const config: YamlConfig.GrpcHandler = {


### PR DESCRIPTION
## Description

GRPC allows to nest message type definition. Since GraphQL doesn't have this possibility, Mesh generate schema wide uniq names for nested types by joining parent types names with an `_` character. This leads to a conflict with the way input types are generated by adding `_Input` when a nested message is named `Input`.

One way to solve this ambiguity is to replace to have to different seperators for nested type names and for input type names.

This PR replaces the joining character for nested types from `_` to `__`.

I've chosen to modify the nested type names generation since I think it will probably have less impact than modifying the inputs name generation. Not every type or schemas are using nesting feature while every schema will need input types.

Fixes #5880 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as
      expected)

> Type names generation changes, so any schema extension relying on generated type with nested messages will break

## How Has This Been Tested?

Added a unit test

