### PR TITLE
feat(redis): make lazyConnect optional in cache-redis plugin

### DIFF
--- a/.changeset/thin-pears-beam.md
+++ b/.changeset/thin-pears-beam.md
@@ -1,6 +1,6 @@
 ---
-'@graphql-mesh/cache-redis': minor
-'@graphql-mesh/types': minor
+'@graphql-mesh/cache-redis': patch
+'@graphql-mesh/types': patch
 ---
 
 Add lazyConnect to cache-redis

--- a/.changeset/thin-pears-beam.md
+++ b/.changeset/thin-pears-beam.md
@@ -1,0 +1,6 @@
+---
+'@graphql-mesh/cache-redis': minor
+'@graphql-mesh/types': minor
+---
+
+Add lazyConnect to cache-redis

--- a/packages/cache/redis/src/index.ts
+++ b/packages/cache/redis/src/index.ts
@@ -18,16 +18,18 @@ export default class RedisCache<V = string> implements KeyValueCache<V> {
   private client: Redis;
 
   constructor(options: YamlConfig.Cache['redis'] & { pubsub: MeshPubSub; logger: Logger }) {
+    const lazyConnect = options.lazyConnect !== false;
+
     if (options.url) {
       const redisUrl = new URL(interpolateStrWithEnv(options.url));
-
-      redisUrl.searchParams.set('lazyConnect', 'true');
-      redisUrl.searchParams.set('enableAutoPipelining', 'true');
-      redisUrl.searchParams.set('enableOfflineQueue', 'true');
 
       if (!['redis:', 'rediss:'].includes(redisUrl.protocol)) {
         throw new Error('Redis URL must use either redis:// or rediss://');
       }
+
+      redisUrl.searchParams.set('lazyConnect', lazyConnect.toString());
+      redisUrl.searchParams.set('enableAutoPipelining', 'true');
+      redisUrl.searchParams.set('enableOfflineQueue', 'true');
 
       options.logger.debug(`Connecting to Redis at ${redisUrl.toString()}`);
       this.client = new Redis(redisUrl?.toString());
@@ -41,7 +43,7 @@ export default class RedisCache<V = string> implements KeyValueCache<V> {
           host: parsedHost,
           port: parseInt(parsedPort),
           password: parsedPassword,
-          lazyConnect: true,
+          lazyConnect,
           enableAutoPipelining: true,
           enableOfflineQueue: true,
         });

--- a/packages/cache/redis/test/cache.spec.ts
+++ b/packages/cache/redis/test/cache.spec.ts
@@ -25,6 +25,14 @@ describe('redis', () => {
       );
     });
 
+    it('passes configuration to redis client with default options, url and lazyConnect case', async () => {
+      new RedisCache({ url: 'redis://password@localhost:6379', lazyConnect: false, pubsub, logger });
+
+      expect(Redis).toHaveBeenCalledWith(
+        'redis://password@localhost:6379?lazyConnect=false&enableAutoPipelining=true&enableOfflineQueue=true',
+      );
+    });
+
     it('passes configuration to redis client with default options, host, port & password case', async () => {
       new RedisCache({ port: '6379', password: 'testpassword', host: 'localhost', pubsub, logger });
 
@@ -33,6 +41,19 @@ describe('redis', () => {
         enableOfflineQueue: true,
         host: 'localhost',
         lazyConnect: true,
+        password: 'testpassword',
+        port: 6379,
+      });
+    });
+
+    it('passes configuration to redis client with default options, host, port, password & lazyConnect case', async () => {
+      new RedisCache({ port: '6379', password: 'testpassword', host: 'localhost', lazyConnect: false, pubsub, logger });
+
+      expect(Redis).toHaveBeenCalledWith({
+        enableAutoPipelining: true,
+        enableOfflineQueue: true,
+        host: 'localhost',
+        lazyConnect: false,
         password: 'testpassword',
         port: 6379,
       });

--- a/packages/cache/redis/yaml-config.graphql
+++ b/packages/cache/redis/yaml-config.graphql
@@ -7,4 +7,10 @@ type RedisConfig @md {
   port: String
   password: String
   url: String
+  """
+  Flag to indicate lazyConnect value for Redis client.
+
+  @default: true
+  """
+  lazyConnect: Boolean
 }

--- a/packages/types/src/config-schema.json
+++ b/packages/types/src/config-schema.json
@@ -89,6 +89,9 @@
         },
         "url": {
           "type": "string"
+        },
+        "lazyConnect": {
+          "type": "boolean"
         }
       }
     },

--- a/packages/types/src/config.ts
+++ b/packages/types/src/config.ts
@@ -1712,6 +1712,7 @@ export interface RedisConfig {
   port?: string;
   password?: string;
   url?: string;
+  lazyConnect?: boolean;
 }
 export interface PubSubConfig {
   name: string;

--- a/website/src/generated-markdown/RedisConfig.generated.md
+++ b/website/src/generated-markdown/RedisConfig.generated.md
@@ -3,3 +3,4 @@
 * `port` (type: `String`)
 * `password` (type: `String`)
 * `url` (type: `String`)
+* `lazyConnect` (type: `Boolean`)


### PR DESCRIPTION
🚨 **IMPORTANT: Please do not create a Pull Request without creating an issue first.**

_Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of
the pull request._

## Description

Please include a summary of the change and which issue is fixed. Please also include relevant
motivation and context. List any dependencies that are required for this change.

Fixes #5962 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Screenshots/Sandbox (if appropriate/relevant):

Adding links to sandbox or providing screenshots can help us understand more about this PR and take
action on it as appropriate

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can
reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Environment**:

- OS:
- `@graphql-mesh/...`:
- NodeJS:

## Checklist:

- [x] I have followed the
      [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the
      style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests and linter rules pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose
the solution you did and what alternatives you considered, etc...
