### PR TITLE
Fix: avoid set lazyConnect in case it's false for cache-redis package

### DIFF
--- a/.changeset/fuzzy-socks-smoke.md
+++ b/.changeset/fuzzy-socks-smoke.md
@@ -1,0 +1,5 @@
+---
+'@graphql-mesh/cache-redis': patch
+---
+
+Avoid setting lazyConnect in case it's set false

--- a/packages/cache/redis/src/index.ts
+++ b/packages/cache/redis/src/index.ts
@@ -27,7 +27,10 @@ export default class RedisCache<V = string> implements KeyValueCache<V> {
         throw new Error('Redis URL must use either redis:// or rediss://');
       }
 
-      lazyConnect && redisUrl.searchParams.set('lazyConnect', 'true');
+      if (lazyConnect) {
+        redisUrl.searchParams.set('lazyConnect', 'true');
+      }
+
       redisUrl.searchParams.set('enableAutoPipelining', 'true');
       redisUrl.searchParams.set('enableOfflineQueue', 'true');
 

--- a/packages/cache/redis/src/index.ts
+++ b/packages/cache/redis/src/index.ts
@@ -27,7 +27,7 @@ export default class RedisCache<V = string> implements KeyValueCache<V> {
         throw new Error('Redis URL must use either redis:// or rediss://');
       }
 
-      redisUrl.searchParams.set('lazyConnect', lazyConnect.toString());
+      lazyConnect && redisUrl.searchParams.set('lazyConnect', 'true');
       redisUrl.searchParams.set('enableAutoPipelining', 'true');
       redisUrl.searchParams.set('enableOfflineQueue', 'true');
 
@@ -43,7 +43,7 @@ export default class RedisCache<V = string> implements KeyValueCache<V> {
           host: parsedHost,
           port: parseInt(parsedPort),
           password: parsedPassword,
-          lazyConnect,
+          ...(lazyConnect ? { lazyConnect: true } : {}),
           enableAutoPipelining: true,
           enableOfflineQueue: true,
         });

--- a/packages/cache/redis/test/cache.spec.ts
+++ b/packages/cache/redis/test/cache.spec.ts
@@ -25,7 +25,7 @@ describe('redis', () => {
       );
     });
 
-    it('passes configuration to redis client with default options, url and lazyConnect case', async () => {
+    it('passes configuration to redis client with default options, url and lazyConnect (=false) case', async () => {
       new RedisCache({
         url: 'redis://password@localhost:6379',
         lazyConnect: false,
@@ -34,7 +34,20 @@ describe('redis', () => {
       });
 
       expect(Redis).toHaveBeenCalledWith(
-        'redis://password@localhost:6379?lazyConnect=false&enableAutoPipelining=true&enableOfflineQueue=true',
+        'redis://password@localhost:6379?enableAutoPipelining=true&enableOfflineQueue=true',
+      );
+    });
+
+    it('passes configuration to redis client with default options, url and lazyConnect (=true) case', async () => {
+      new RedisCache({
+        url: 'redis://password@localhost:6379',
+        lazyConnect: true,
+        pubsub,
+        logger,
+      });
+
+      expect(Redis).toHaveBeenCalledWith(
+        'redis://password@localhost:6379?lazyConnect=true&enableAutoPipelining=true&enableOfflineQueue=true',
       );
     });
 
@@ -51,7 +64,7 @@ describe('redis', () => {
       });
     });
 
-    it('passes configuration to redis client with default options, host, port, password & lazyConnect case', async () => {
+    it('passes configuration to redis client with default options, host, port, password & lazyConnect (=false) case', async () => {
       new RedisCache({
         port: '6379',
         password: 'testpassword',
@@ -65,7 +78,6 @@ describe('redis', () => {
         enableAutoPipelining: true,
         enableOfflineQueue: true,
         host: 'localhost',
-        lazyConnect: false,
         password: 'testpassword',
         port: 6379,
       });


### PR DESCRIPTION
🚨 **IMPORTANT: Please do not create a Pull Request without creating an issue first.**

_Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of
the pull request._

## Description

Please include a summary of the change and which issue is fixed. Please also include relevant
motivation and context. List any dependencies that are required for this change.

Fixes #5962 

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots/Sandbox (if appropriate/relevant):

Adding links to sandbox or providing screenshots can help us understand more about this PR and take
action on it as appropriate

## How Has This Been Tested?
I adopted existing tests and add 1 new test for the cache-redis package.

**Test Environment**:

- OS:
- `@graphql-mesh/...`:
- NodeJS:

## Checklist:

- [x] I have followed the
      [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the
      style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests and linter rules pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose
the solution you did and what alternatives you considered, etc...
