### PR TITLE
Fix rest transporter error handling when using union types

### DIFF
--- a/.changeset/modern-lights-smash.md
+++ b/.changeset/modern-lights-smash.md
@@ -1,0 +1,5 @@
+---
+'@graphql-mesh/transport-rest': patch
+---
+
+Fix Union type error handling when no error type is present (e.g. `ignoreErrorResponses: true`) is used

--- a/e2e/union-error-handling/__snapshots__/union-error-handling.test.ts.snap
+++ b/e2e/union-error-handling/__snapshots__/union-error-handling.test.ts.snap
@@ -1,0 +1,202 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`OpenAPI rest transport Union Error Handling should compose 1`] = `
+"schema
+    @link(url: "https://specs.apollo.dev/link/v1.0")
+    @link(url: "https://specs.apollo.dev/join/v0.3", for: EXECUTION)
+    
+    
+    
+    
+    
+    
+    @link(
+  url: "https://the-guild.dev/graphql/mesh/spec/v1.0"
+  import: ["@statusCodeTypeName", "@httpOperation", "@transport", "@extraSchemaDefinitionDirective"]
+)
+  {
+    query: Query
+    
+    
+  }
+
+  
+    directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
+
+    directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+    
+      directive @join__field(
+        graph: join__Graph
+        requires: join__FieldSet
+        provides: join__FieldSet
+        type: String
+        external: Boolean
+        override: String
+        usedOverridden: Boolean
+        
+        
+      ) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+    
+    
+
+    directive @join__implements(
+      graph: join__Graph!
+      interface: String!
+    ) repeatable on OBJECT | INTERFACE
+
+    directive @join__type(
+      graph: join__Graph!
+      key: join__FieldSet
+      extension: Boolean! = false
+      resolvable: Boolean! = true
+      isInterfaceObject: Boolean! = false
+    ) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+
+    directive @join__unionMember(
+      graph: join__Graph!
+      member: String!
+    ) repeatable on UNION
+
+    scalar join__FieldSet
+    
+  
+  
+  directive @link(
+    url: String
+    as: String
+    for: link__Purpose
+    import: [link__Import]
+  ) repeatable on SCHEMA
+
+  scalar link__Import
+
+  enum link__Purpose {
+    """
+    \`SECURITY\` features provide metadata necessary to securely resolve fields.
+    """
+    SECURITY
+
+    """
+    \`EXECUTION\` features provide metadata necessary for operation execution.
+    """
+    EXECUTION
+  }
+
+  
+  
+  
+  
+  
+  
+  
+enum join__Graph {
+  ERROR_API @join__graph(name: "ErrorAPI", url: "http://localhost:<ErrorService_port>") 
+}
+
+directive @statusCodeTypeName(subgraph: String, typeName: String, statusCode: String)  repeatable on UNION
+
+directive @httpOperation(
+  subgraph: String
+  path: String
+  operationSpecificHeaders: [[String]]
+  httpMethod: HTTPMethod
+  isBinary: Boolean
+  requestBaseBody: ObjMap
+  queryParamArgMap: ObjMap
+  queryStringOptionsByParam: ObjMap
+  jsonApiFields: Boolean
+  queryStringOptions: ObjMap
+) repeatable on FIELD_DEFINITION
+
+directive @transport(
+  subgraph: String
+  kind: String
+  location: String
+  headers: [[String]]
+  queryStringOptions: ObjMap
+  queryParams: [[String]]
+) repeatable on SCHEMA
+
+directive @extraSchemaDefinitionDirective(directives: _DirectiveExtensions)  repeatable on OBJECT
+
+scalar ObjMap @join__type(graph: ERROR_API) 
+
+scalar _DirectiveExtensions @join__type(graph: ERROR_API) 
+
+type Query @extraSchemaDefinitionDirective(
+  directives: {transport: [{subgraph: "ErrorAPI", kind: "rest", location: "http://localhost:<ErrorService_port>"}]}
+) @join__type(graph: ERROR_API)  {
+  """
+  Get user - direct response type without error handling
+  """
+  getUserNoErrorHandling: User @httpOperation(
+    subgraph: "ErrorAPI"
+    path: "/userNoErrorHandling"
+    operationSpecificHeaders: [["accept", "application/json"]]
+    httpMethod: GET
+  )
+  """
+  Get user - union response type without error handling
+  """
+  getUserUnionNoErrorHandling: getUserUnionNoErrorHandling_response @httpOperation(
+    subgraph: "ErrorAPI"
+    path: "/userUnionNoErrorHandling"
+    operationSpecificHeaders: [["accept", "application/json"]]
+    httpMethod: GET
+  )
+  """
+  Get user - direct response type with error handling
+  """
+  getUserErrorHandling: getUserErrorHandling_response @httpOperation(
+    subgraph: "ErrorAPI"
+    path: "/userErrorHandling"
+    operationSpecificHeaders: [["accept", "application/json"]]
+    httpMethod: GET
+  )
+  """
+  Get user - union response type with error handling
+  """
+  getUserUnionErrorHandling: getUserUnionErrorHandling_response @httpOperation(
+    subgraph: "ErrorAPI"
+    path: "/userUnionErrorHandling"
+    operationSpecificHeaders: [["accept", "application/json"]]
+    httpMethod: GET
+  )
+}
+
+type User @join__type(graph: ERROR_API)  {
+  id: Int!
+  name: String!
+  email: String!
+}
+
+type AsyncJob @join__type(graph: ERROR_API)  {
+  asynchronous_job_id: String!
+  status: String!
+  estimated_completion: String
+}
+
+type Error @join__type(graph: ERROR_API)  {
+  error: String!
+  code: Int!
+}
+
+union getUserUnionNoErrorHandling_response @statusCodeTypeName(subgraph: "ErrorAPI", statusCode: "200", typeName: "User")  @statusCodeTypeName(subgraph: "ErrorAPI", statusCode: "202", typeName: "AsyncJob")  @join__type(graph: ERROR_API)  @join__unionMember(graph: ERROR_API, member: "User")  @join__unionMember(graph: ERROR_API, member: "AsyncJob")  = User | AsyncJob
+
+union getUserErrorHandling_response @statusCodeTypeName(subgraph: "ErrorAPI", statusCode: "200", typeName: "User")  @statusCodeTypeName(subgraph: "ErrorAPI", statusCode: "400", typeName: "Error")  @join__type(graph: ERROR_API)  @join__unionMember(graph: ERROR_API, member: "User")  @join__unionMember(graph: ERROR_API, member: "Error")  = User | Error
+
+union getUserUnionErrorHandling_response @statusCodeTypeName(subgraph: "ErrorAPI", statusCode: "200", typeName: "User")  @statusCodeTypeName(subgraph: "ErrorAPI", statusCode: "202", typeName: "AsyncJob")  @statusCodeTypeName(subgraph: "ErrorAPI", statusCode: "400", typeName: "Error")  @join__type(graph: ERROR_API)  @join__unionMember(graph: ERROR_API, member: "User")  @join__unionMember(graph: ERROR_API, member: "AsyncJob")  @join__unionMember(graph: ERROR_API, member: "Error")  = User | AsyncJob | Error
+
+enum HTTPMethod @join__type(graph: ERROR_API)  {
+  GET @join__enumValue(graph: ERROR_API) 
+  HEAD @join__enumValue(graph: ERROR_API) 
+  POST @join__enumValue(graph: ERROR_API) 
+  PUT @join__enumValue(graph: ERROR_API) 
+  DELETE @join__enumValue(graph: ERROR_API) 
+  CONNECT @join__enumValue(graph: ERROR_API) 
+  OPTIONS @join__enumValue(graph: ERROR_API) 
+  TRACE @join__enumValue(graph: ERROR_API) 
+  PATCH @join__enumValue(graph: ERROR_API) 
+}"
+`;

--- a/e2e/union-error-handling/mesh.config.ts
+++ b/e2e/union-error-handling/mesh.config.ts
@@ -1,0 +1,19 @@
+import { Opts } from '@e2e/opts';
+import { defineConfig as defineComposeConfig } from '@graphql-mesh/compose-cli';
+import { loadOpenAPISubgraph } from '@omnigraph/openapi';
+
+const opts = Opts(process.argv);
+
+const servicePort = opts.getServicePort('ErrorService');
+
+export const composeConfig = defineComposeConfig({
+  subgraphs: [
+    {
+      sourceHandler: loadOpenAPISubgraph('ErrorAPI', {
+        source: `http://localhost:${servicePort}/openapi.json`,
+        endpoint: `http://localhost:${servicePort}`,
+        ignoreErrorResponses: false,
+      }),
+    },
+  ],
+});

--- a/e2e/union-error-handling/package.json
+++ b/e2e/union-error-handling/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@e2e/union-error-handling",
+  "private": true,
+  "dependencies": {
+    "@graphql-mesh/compose-cli": "*",
+    "@omnigraph/openapi": "*",
+    "express": "*"
+  }
+}

--- a/e2e/union-error-handling/services/ErrorService.js
+++ b/e2e/union-error-handling/services/ErrorService.js
@@ -1,0 +1,196 @@
+const { Opts } = require('@e2e/opts');
+const express = require('express');
+const app = express();
+
+const opts = Opts(process.argv);
+const port = opts.getServicePort('ErrorService');
+
+// OpenAPI specification
+const openApiSpec = {
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Union Error Testing API",
+    "version": "1.0.0"
+  },
+  "servers": [
+    {
+      "url": `http://localhost:${port}`
+    }
+  ],
+  "paths": {
+    "/userNoErrorHandling": {
+      "get": {
+        "operationId": "getUserNoErrorHandling",
+        "description": "Get user - direct response type without error handling",
+        "responses": {
+          "200": {
+            "description": "User found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/User"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/userUnionNoErrorHandling": {
+      "get": {
+        "operationId": "getUserUnionNoErrorHandling",
+        "description": "Get user - union response type without error handling",
+        "responses": {
+          "200": {
+            "description": "User data",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/User"
+                }
+              }
+            }
+          },
+          "202": {
+            "description": "Async job created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AsyncJob"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/userErrorHandling": {
+      "get": {
+        "operationId": "getUserErrorHandling",
+        "description": "Get user - direct response type with error handling",
+        "responses": {
+          "200": {
+            "description": "User data",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/User"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/userUnionErrorHandling": {
+      "get": {
+        "operationId": "getUserUnionErrorHandling",
+        "description": "Get user - union response type with error handling",
+        "responses": {
+          "200": {
+            "description": "User data",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/User"
+                }
+              }
+            }
+          },
+          "202": {
+            "description": "Async job created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AsyncJob"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "User": {
+        "type": "object",
+        "properties": {
+          "id": { "type": "integer" },
+          "name": { "type": "string" },
+          "email": { "type": "string" }
+        },
+        "required": ["id", "name", "email"]
+      },
+      "AsyncJob": {
+        "type": "object",
+        "properties": {
+          "asynchronous_job_id": { "type": "string" },
+          "status": { "type": "string" },
+          "estimated_completion": { "type": "string" }
+        },
+        "required": ["asynchronous_job_id", "status"]
+      },
+      "Error": {
+        "type": "object",
+        "properties": {
+          "error": { "type": "string" },
+          "code": { "type": "integer" }
+        },
+        "required": ["error", "code"]
+      }
+    }
+  }
+};
+
+// Serve the OpenAPI spec
+app.get('/openapi.json', (req, res) => {
+  res.json(openApiSpec);
+});
+
+// Endpoints without error handling in OpenAPI schema (but still return errors)
+app.get('/userNoErrorHandling', (req, res) => {
+  res.status(400).json({ error: 'Bad request', code: 400 });
+});
+
+app.get('/userUnionNoErrorHandling', (req, res) => {
+  res.status(400).json({ error: 'Bad request', code: 400 });
+});
+
+// Endpoints with error handling in OpenAPI schema
+app.get('/userErrorHandling', (req, res) => {
+  res.status(400).json({ error: 'User not found', code: 400 });
+});
+
+app.get('/userUnionErrorHandling', (req, res) => {
+  res.status(400).json({ error: 'User union error', code: 400 });
+});
+
+const server = app.listen(port, () => {
+  console.log(`Error Service running at http://localhost:${port}`);
+});
+
+module.exports = server;
+
+process.on('SIGTERM', () => server.close());
+process.on('SIGINT', () => server.close());

--- a/e2e/union-error-handling/union-error-handling.test.ts
+++ b/e2e/union-error-handling/union-error-handling.test.ts
@@ -1,0 +1,142 @@
+import { createTenv, type Service } from '@e2e/tenv';
+
+describe('OpenAPI rest transport Union Error Handling', () => {
+  const { compose, serve, service } = createTenv(__dirname);
+
+  let errorService: Service;
+
+  beforeAll(async () => {
+    errorService = await service('ErrorService');
+  });
+
+  it('should compose', async () => {
+    const { result } = await compose({
+      output: 'graphql',
+      services: [errorService],
+      maskServicePorts: true,
+    });
+    expect(result).toMatchSnapshot();
+  });
+
+  it('should provide consistent error handling for direct and union response types', async () => {
+    const { output } = await compose({
+      output: 'graphql',
+      services: [errorService],
+    });
+
+    const { execute } = await serve({
+      supergraph: output,
+    });
+
+    // Test endpoints WITHOUT error handling in OpenAPI schema - should get GraphQL errors
+    // This is the case when using ignoreErrorResponses: true
+    const noErrorHandlingResult = await execute({
+      query: /* GraphQL */ `
+        query TestNoErrorHandling {
+          getUserNoErrorHandling {
+            id
+            name
+            email
+          }
+          getUserUnionNoErrorHandling {
+            ... on User {
+              id
+              name
+              email
+            }
+            ... on AsyncJob {
+              asynchronous_job_id
+              status
+              estimated_completion
+            }
+          }
+        }
+      `,
+    });
+
+    // Should get GraphQL errors since these endpoints don't have 400 in their OpenAPI spec
+    expect(noErrorHandlingResult.errors).toHaveLength(2);
+    expect(noErrorHandlingResult.errors?.[0].message).toContain('Upstream HTTP Error: 400');
+    expect(noErrorHandlingResult.errors?.[1].message).toContain('Upstream HTTP Error: 400');
+
+    // Check that error extensions are properly populated
+    const firstError = noErrorHandlingResult.errors?.[0];
+    const secondError = noErrorHandlingResult.errors?.[1];
+
+    expect(firstError?.extensions).toBeDefined();
+    expect(firstError?.extensions?.code).toBe('DOWNSTREAM_SERVICE_ERROR');
+    expect(firstError?.extensions?.serviceName).toBe('ErrorAPI');
+    expect(firstError?.extensions?.request?.method).toBe('GET');
+    expect(firstError?.extensions?.response?.status).toBe(400);
+
+    expect(secondError?.extensions).toBeDefined();
+    expect(secondError?.extensions?.code).toBe('DOWNSTREAM_SERVICE_ERROR');
+    expect(secondError?.extensions?.serviceName).toBe('ErrorAPI');
+    expect(secondError?.extensions?.request?.method).toBe('GET');
+    expect(secondError?.extensions?.response?.status).toBe(400);
+  });
+
+  it('should be able to cast error responses to Error type when error handling is in OpenAPI schema', async () => {
+    const { output } = await compose({
+      output: 'graphql',
+      services: [errorService],
+    });
+
+    const { execute } = await serve({
+      supergraph: output,
+    });
+
+    // Test endpoints WITH error handling in OpenAPI schema - should get data with error casting
+    const errorHandlingResult = await execute({
+      query: /* GraphQL */ `
+        query TestErrorHandling {
+          getUserErrorHandling {
+            ... on User {
+              id
+              name
+              email
+            }
+            ... on Error {
+              error
+              code
+            }
+          }
+          getUserUnionErrorHandling {
+            ... on User {
+              id
+              name
+              email
+            }
+            ... on AsyncJob {
+              asynchronous_job_id
+              status
+              estimated_completion
+            }
+            ... on Error {
+              error
+              code
+            }
+          }
+        }
+      `,
+    });
+
+    expect(errorHandlingResult.errors).toBeFalsy();
+
+    // Both direct and union fields should return error data when casting to Error type
+    expect(errorHandlingResult.data?.getUserErrorHandling).toEqual({
+      error: 'User not found',
+      code: 400
+    });
+
+    expect(errorHandlingResult.data?.getUserUnionErrorHandling).toEqual({
+      error: 'User union error',
+      code: 400
+    });
+
+    // Verify that when error handling is in the OpenAPI schema,
+    // the response is returned as data (not GraphQL errors) and contains the expected status code
+    expect(errorHandlingResult.data?.getUserErrorHandling?.code).toBe(400);
+    expect(errorHandlingResult.data?.getUserUnionErrorHandling?.code).toBe(400);
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -4433,6 +4433,16 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@e2e/union-error-handling@workspace:e2e/union-error-handling":
+  version: 0.0.0-use.local
+  resolution: "@e2e/union-error-handling@workspace:e2e/union-error-handling"
+  dependencies:
+    "@graphql-mesh/compose-cli": "npm:*"
+    "@omnigraph/openapi": "npm:*"
+    express: "npm:*"
+  languageName: unknown
+  linkType: soft
+
 "@e2e/utils@workspace:e2e/utils":
   version: 0.0.0-use.local
   resolution: "@e2e/utils@workspace:e2e/utils"


### PR DESCRIPTION
## Description

The current rest transporter [code assumed](https://github.com/ardatan/graphql-mesh/blob/master/packages/transports/rest/src/directives/httpOperation.ts#L368-L392) that if the response was non-2xx and the result was a Union type that there would be an appropriate type to cast the error. However, this is not true when the union type does not contain an error mapping. For example an endpoint that can return 200 or 202 would be represented as union type. This is especially problematic if `ignoreErrorResponses: true` is used in combination with multiple success response codes.

Therefore for non-2xx codes, we check to see if there is a matching directive for the status code. If there is not, we return a general upstream error. 

This ensures consistent error handling for clients whether the return type is direct or a union type.

Fixes #8746

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
      expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Added new e2e test.

## Checklist:

- [x] I have followed the
      [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the
      style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [n/a] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works, and I have added a
      changeset using `yarn changeset` that bumps the version
- [x] New and existing unit tests and linter rules pass locally with my changes
- [n/a] Any dependent changes have been merged and published in downstream modules

## Further comments

n/a
