### PR TITLE
Forward headers from subgraph to client via custom fetch & cors.expos…

### DIFF
--- a/packages/legacy/http/src/index.ts
+++ b/packages/legacy/http/src/index.ts
@@ -68,7 +68,7 @@ export function createMeshHTTPHandler<TServerContext>({
               const exposedHeaders = corsConfig?.exposedHeaders?.map((header) => header.toLowerCase())
               if ( headers && exposedHeaders?.length ) {
                   Object.entries(headers).forEach(([name,value])=>{
-                      if ( exposedHeaders.indexOf(name) ) {
+                      if ( exposedHeaders.indexOf(name) !== -1 ) {
                           logger.debug(`Injecting service header ${name} => ${value}`);
                           response.headers.append(name,value);
                       }


### PR DESCRIPTION
## Description

Solution for forwarding headers from a subgraph service(s) back to the client

Problem:
When a service sends its own response headers (e.g. an updated token via Set-Cookie), these headers (and any other headers set by the service) do not reach the client. This happens because GraphQL Mesh generates its own response headers and does not include those coming from the upstream service.

Solution:
Use the customFetch functionality to store service headers in a custom field SERVICE_HEADERS within ctx.req. Then, in the onResponse handler, read this data from serverContext.req.SERVICE_HEADERS and append the required headers to response.headers. Only headers listed in serve.cors.exposedHeaders configuration will be exposed to the client.


Fixes #8788 

## Type of change

- [ ] New feature (non-breaking change which adds functionality)

## Checklist:

- [x ] I have followed the
      [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the
      style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works, and I have added a
      changeset using `yarn changeset` that bumps the version
- [ ] New and existing unit tests and linter rules pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments
