### PR TITLE
feat(compose-cli): `introspectionOptions`

### DIFF
--- a/.changeset/sparkly-lions-make.md
+++ b/.changeset/sparkly-lions-make.md
@@ -1,0 +1,25 @@
+---
+'@graphql-mesh/compose-cli': minor
+---
+
+Add `introspectionOptions` to `loadGraphQLHTTPSubgraph` with some defaults.
+Previously, it was not possible to configure the introspection query options.
+By default it was ignoring deprecated input fields and not including descriptions.
+Now it includes descriptions and deprecated input fields by default.
+And you can still override the defaults by providing your own options.
+
+```ts
+import { loadGraphQLHTTPSubgraph } from '@graphql-mesh/compose-cli';
+
+loadGraphQLHTTPSubgraph('my-subgraph', {
+  source: 'http://my-subgraph/graphql',
+  introspectionOptions: {
+    descriptions: true,
+    specifiedByUrl: false,
+    directiveIsRepeatable: false,
+    schemaDescription: false,
+    inputValueDeprecation: true,
+    oneOf: false, // New in GraphQL 16
+  },
+});
+```

--- a/e2e/deprecated-merging/__snapshots__/deprecated-merging.test.ts.snap
+++ b/e2e/deprecated-merging/__snapshots__/deprecated-merging.test.ts.snap
@@ -1,0 +1,122 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`should compose the appropriate schema 1`] = `
+"schema
+    @link(url: "https://specs.apollo.dev/link/v1.0")
+    @link(url: "https://specs.apollo.dev/join/v0.3", for: EXECUTION)
+    
+    
+    
+    
+    
+    
+    
+  {
+    query: Query
+    
+    
+  }
+
+  
+    directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
+
+    directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+    
+      directive @join__field(
+        graph: join__Graph
+        requires: join__FieldSet
+        provides: join__FieldSet
+        type: String
+        external: Boolean
+        override: String
+        usedOverridden: Boolean
+        
+        
+      ) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+    
+    
+
+    directive @join__implements(
+      graph: join__Graph!
+      interface: String!
+    ) repeatable on OBJECT | INTERFACE
+
+    directive @join__type(
+      graph: join__Graph!
+      key: join__FieldSet
+      extension: Boolean! = false
+      resolvable: Boolean! = true
+      isInterfaceObject: Boolean! = false
+    ) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+
+    directive @join__unionMember(
+      graph: join__Graph!
+      member: String!
+    ) repeatable on UNION
+
+    scalar join__FieldSet
+    
+  
+  
+  directive @link(
+    url: String
+    as: String
+    for: link__Purpose
+    import: [link__Import]
+  ) repeatable on SCHEMA
+
+  scalar link__Import
+
+  enum link__Purpose {
+    """
+    \`SECURITY\` features provide metadata necessary to securely resolve fields.
+    """
+    SECURITY
+
+    """
+    \`EXECUTION\` features provide metadata necessary for operation execution.
+    """
+    EXECUTION
+  }
+
+  
+  
+  
+  
+  
+  
+  
+enum join__Graph {
+  SUBGRAPH_A @join__graph(name: "subgraph-a", url: "http://localhost:<subgraph-a_port>/graphql") 
+}
+
+scalar TransportOptions @join__type(graph: SUBGRAPH_A) 
+
+type Query @join__type(graph: SUBGRAPH_A)  {
+  rootField(
+    deprecatedArg: DeprecatedArgEnum @deprecated(reason: "No longer needed") 
+    otherArg: Int
+  ): RootFieldReturnType
+}
+
+type RootFieldReturnType @join__type(graph: SUBGRAPH_A)  {
+  id: ID!
+}
+
+enum DeprecatedArgEnum @join__type(graph: SUBGRAPH_A)  {
+  VALUE1 @join__enumValue(graph: SUBGRAPH_A) 
+  VALUE2 @join__enumValue(graph: SUBGRAPH_A) 
+}
+"
+`;
+
+exports[`should execute Query rootField 1`] = `
+{
+  "data": {
+    "rootField": {
+      "id": "root",
+    },
+  },
+}
+`;

--- a/e2e/deprecated-merging/deprecated-merging.test.ts
+++ b/e2e/deprecated-merging/deprecated-merging.test.ts
@@ -1,0 +1,31 @@
+import { createTenv, type Container } from '@e2e/tenv';
+
+const { compose, service, serve, container } = createTenv(__dirname);
+
+it('should compose the appropriate schema', async () => {
+  const { result } = await compose({
+    services: [await service('subgraph-a')],
+    maskServicePorts: true,
+  });
+  expect(result).toMatchSnapshot();
+});
+
+it.concurrent.each([
+  {
+    name: 'Query rootField',
+    query: /* GraphQL */ `
+      query {
+        rootField(deprecatedArg: VALUE1, otherArg: 1) {
+          id
+        }
+      }
+    `,
+  },
+])('should execute $name', async ({ query }) => {
+  const { output } = await compose({
+    output: 'graphql',
+    services: [await service('subgraph-a')],
+  });
+  const { execute } = await serve({ supergraph: output });
+  await expect(execute({ query })).resolves.toMatchSnapshot();
+});

--- a/e2e/deprecated-merging/mesh.config.ts
+++ b/e2e/deprecated-merging/mesh.config.ts
@@ -1,0 +1,14 @@
+import { Opts } from '@e2e/opts';
+import { defineConfig, loadGraphQLHTTPSubgraph } from '@graphql-mesh/compose-cli';
+
+const opts = Opts(process.argv);
+
+export const composeConfig = defineConfig({
+  subgraphs: [
+    {
+      sourceHandler: loadGraphQLHTTPSubgraph('subgraph-a', {
+        endpoint: `http://localhost:${opts.getServicePort('subgraph-a')}/graphql`,
+      }),
+    },
+  ],
+});

--- a/e2e/deprecated-merging/package.json
+++ b/e2e/deprecated-merging/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@e2e/deprecated-merging",
+  "private": true,
+  "devDependencies": {
+    "@graphql-hive/gateway": "^2.0.0",
+    "graphql": "^16.9.0",
+    "graphql-yoga": "^5.13.4"
+  }
+}

--- a/e2e/deprecated-merging/services/subgraph-a.ts
+++ b/e2e/deprecated-merging/services/subgraph-a.ts
@@ -1,0 +1,39 @@
+import { createServer } from 'node:http';
+import { createSchema, createYoga } from 'graphql-yoga';
+import { Opts } from '@e2e/opts';
+
+const opts = Opts(process.argv);
+const port = opts.getServicePort('subgraph-a');
+
+createServer(
+  createYoga({
+    schema: createSchema({
+      typeDefs: /* GraphQL */ `
+        type Query {
+          rootField(
+            deprecatedArg: DeprecatedArgEnum @deprecated(reason: "No longer needed")
+            otherArg: Int
+          ): RootFieldReturnType
+        }
+
+        enum DeprecatedArgEnum {
+          VALUE1
+          VALUE2
+        }
+
+        type RootFieldReturnType {
+          id: ID!
+        }
+      `,
+      resolvers: {
+        Query: {
+          rootField: (_parent, _args, _context, _info) => {
+            return { id: 'root' };
+          },
+        },
+      },
+    }),
+  }),
+).listen(port, () => {
+  console.log(`Subgraph A service listening on http://localhost:${port}`);
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -3940,6 +3940,16 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@e2e/deprecated-merging@workspace:e2e/deprecated-merging":
+  version: 0.0.0-use.local
+  resolution: "@e2e/deprecated-merging@workspace:e2e/deprecated-merging"
+  dependencies:
+    "@graphql-hive/gateway": "npm:^2.0.0"
+    graphql: "npm:^16.9.0"
+    graphql-yoga: "npm:^5.13.4"
+  languageName: unknown
+  linkType: soft
+
 "@e2e/esm-config-in-cjs-project@workspace:e2e/esm-config-in-cjs-project":
   version: 0.0.0-use.local
   resolution: "@e2e/esm-config-in-cjs-project@workspace:e2e/esm-config-in-cjs-project"


### PR DESCRIPTION
Add `introspectionOptions` to `loadGraphQLHTTPSubgraph` with some defaults.
Previously, it was not possible to configure the introspection query options.
By default it was ignoring deprecated input fields and not including descriptions.
Now it includes descriptions and deprecated input fields by default.
And you can still override the defaults by providing your own options.

```ts
import { loadGraphQLHTTPSubgraph } from '@graphql-mesh/compose-cli';

loadGraphQLHTTPSubgraph('my-subgraph', {
  source: 'http://my-subgraph/graphql',
  introspectionOptions: {
    descriptions: true,
    specifiedByUrl: false,
    directiveIsRepeatable: false,
    schemaDescription: false,
    inputValueDeprecation: true,
    oneOf: false, // New in GraphQL 16
  },
});
```