### PR TITLE
fix(soap): scope anonymous inline complex type names to parent type

### DIFF
--- a/.changeset/soap-anonymous-inline-type-names.md
+++ b/.changeset/soap-anonymous-inline-type-names.md
@@ -1,0 +1,5 @@
+---
+"@omnigraph/soap": patch
+---
+
+Fix anonymous inline complex type name collisions when multiple parent types define same-named inline fields

--- a/packages/loaders/soap/src/SOAPLoader.ts
+++ b/packages/loaders/soap/src/SOAPLoader.ts
@@ -827,10 +827,15 @@ export class SOAPLoader {
                       this.aliasMap.set(simpleTypeObj, aliasMap);
                       // Inherit the name from elementObj, scoped to the parent type name
                       // to avoid collisions when sibling types share an inline field name.
+                      // Skip scoping when complexTypeName already equals the namespace prefix
+                      // (i.e. it is a top-level-element anonymous type) to avoid double-prefixing
+                      // like ByNameDataSet_ByNameDataSet_ByName.
                       simpleTypeObj.attributes = simpleTypeObj.attributes || ({} as any);
                       simpleTypeObj.attributes.name =
                         simpleTypeObj.attributes.name ||
-                        `${complexTypeName}_${elementObj.attributes.name}`;
+                        (complexTypeName !== prefix
+                          ? `${complexTypeName}_${elementObj.attributes.name}`
+                          : elementObj.attributes.name);
                       let finalTC: AnyTypeComposer<any> = this.getTypeForSimpleType(
                         simpleTypeObj,
                         complexTypeNamespace,
@@ -851,10 +856,14 @@ export class SOAPLoader {
                       this.aliasMap.set(complexTypeObj, aliasMap);
                       // Inherit the name from elementObj, scoped to the parent type name
                       // to avoid collisions when sibling types share an inline field name.
+                      // Skip scoping when complexTypeName already equals the namespace prefix
+                      // (i.e. it is a top-level-element anonymous type) to avoid double-prefixing.
                       complexTypeObj.attributes = complexTypeObj.attributes || ({} as any);
                       complexTypeObj.attributes.name =
                         complexTypeObj.attributes.name ||
-                        `${complexTypeName}_${elementObj.attributes.name}`;
+                        (complexTypeName !== prefix
+                          ? `${complexTypeName}_${elementObj.attributes.name}`
+                          : elementObj.attributes.name);
                       let finalTC: AnyTypeComposer<any> = this.getInputTypeForComplexType(
                         complexTypeObj,
                         complexTypeNamespace,
@@ -991,11 +1000,16 @@ export class SOAPLoader {
         this.aliasMap.set(simpleTypeObj, aliasMap);
         // Inherit the name from elementObj, scoped to the parent type name
         // to avoid collisions when sibling types share an inline field name.
+        // Skip scoping when parentTypeName already equals the namespace prefix
+        // (i.e. it is a top-level-element anonymous type) to avoid double-prefixing.
+        const nsPrefix = this.namespaceTypePrefixMap.get(namespace);
+        const effectiveParentName =
+          parentTypeName && parentTypeName !== nsPrefix ? parentTypeName : null;
         simpleTypeObj.attributes = simpleTypeObj.attributes || ({} as any);
         simpleTypeObj.attributes.name =
           simpleTypeObj.attributes.name ||
-          (parentTypeName
-            ? `${parentTypeName}_${elementObj.attributes.name}`
+          (effectiveParentName
+            ? `${effectiveParentName}_${elementObj.attributes.name}`
             : elementObj.attributes.name);
         const outputTC = this.getTypeForSimpleType(simpleTypeObj, namespace);
         return outputTC;
@@ -1008,11 +1022,16 @@ export class SOAPLoader {
         this.aliasMap.set(complexTypeObj, aliasMap);
         // Inherit the name from elementObj, scoped to the parent type name
         // to avoid collisions when sibling types share an inline field name.
+        // Skip scoping when parentTypeName already equals the namespace prefix
+        // (i.e. it is a top-level-element anonymous type) to avoid double-prefixing.
+        const nsPrefix = this.namespaceTypePrefixMap.get(namespace);
+        const effectiveParentName =
+          parentTypeName && parentTypeName !== nsPrefix ? parentTypeName : null;
         complexTypeObj.attributes = complexTypeObj.attributes || ({} as any);
         complexTypeObj.attributes.name =
           complexTypeObj.attributes.name ||
-          (parentTypeName
-            ? `${parentTypeName}_${elementObj.attributes.name}`
+          (effectiveParentName
+            ? `${effectiveParentName}_${elementObj.attributes.name}`
             : elementObj.attributes.name);
         const outputTC = this.getOutputTypeForComplexType(complexTypeObj, namespace);
         return outputTC;

--- a/packages/loaders/soap/src/SOAPLoader.ts
+++ b/packages/loaders/soap/src/SOAPLoader.ts
@@ -825,10 +825,12 @@ export class SOAPLoader {
                       // Dynamically defined simple type
                       // So we need to define alias map for this type
                       this.aliasMap.set(simpleTypeObj, aliasMap);
-                      // Inherit the name from elementObj
+                      // Inherit the name from elementObj, scoped to the parent type name
+                      // to avoid collisions when sibling types share an inline field name.
                       simpleTypeObj.attributes = simpleTypeObj.attributes || ({} as any);
                       simpleTypeObj.attributes.name =
-                        simpleTypeObj.attributes.name || elementObj.attributes.name;
+                        simpleTypeObj.attributes.name ||
+                        `${complexTypeName}_${elementObj.attributes.name}`;
                       let finalTC: AnyTypeComposer<any> = this.getTypeForSimpleType(
                         simpleTypeObj,
                         complexTypeNamespace,
@@ -847,10 +849,12 @@ export class SOAPLoader {
                       // Dynamically defined type
                       // So we need to define alias map for this type
                       this.aliasMap.set(complexTypeObj, aliasMap);
-                      // Inherit the name from elementObj
+                      // Inherit the name from elementObj, scoped to the parent type name
+                      // to avoid collisions when sibling types share an inline field name.
                       complexTypeObj.attributes = complexTypeObj.attributes || ({} as any);
                       complexTypeObj.attributes.name =
-                        complexTypeObj.attributes.name || elementObj.attributes.name;
+                        complexTypeObj.attributes.name ||
+                        `${complexTypeName}_${elementObj.attributes.name}`;
                       let finalTC: AnyTypeComposer<any> = this.getInputTypeForComplexType(
                         complexTypeObj,
                         complexTypeNamespace,
@@ -961,6 +965,7 @@ export class SOAPLoader {
     elementObj: XSElement,
     aliasMap: Map<string, string>,
     namespace: string,
+    parentTypeName?: string,
   ) {
     if (elementObj.attributes?.type) {
       const [typeNamespaceAlias, typeName] = elementObj.attributes.type.split(':') as [
@@ -984,9 +989,14 @@ export class SOAPLoader {
         // Dynamically defined simple type
         // So we need to define alias map for this type
         this.aliasMap.set(simpleTypeObj, aliasMap);
-        // Inherit the name from elementObj
+        // Inherit the name from elementObj, scoped to the parent type name
+        // to avoid collisions when sibling types share an inline field name.
         simpleTypeObj.attributes = simpleTypeObj.attributes || ({} as any);
-        simpleTypeObj.attributes.name = simpleTypeObj.attributes.name || elementObj.attributes.name;
+        simpleTypeObj.attributes.name =
+          simpleTypeObj.attributes.name ||
+          (parentTypeName
+            ? `${parentTypeName}_${elementObj.attributes.name}`
+            : elementObj.attributes.name);
         const outputTC = this.getTypeForSimpleType(simpleTypeObj, namespace);
         return outputTC;
       }
@@ -996,10 +1006,14 @@ export class SOAPLoader {
         // Dynamically defined type
         // So we need to define alias map for this type
         this.aliasMap.set(complexTypeObj, aliasMap);
-        // Inherit the name from elementObj
+        // Inherit the name from elementObj, scoped to the parent type name
+        // to avoid collisions when sibling types share an inline field name.
         complexTypeObj.attributes = complexTypeObj.attributes || ({} as any);
         complexTypeObj.attributes.name =
-          complexTypeObj.attributes.name || elementObj.attributes.name;
+          complexTypeObj.attributes.name ||
+          (parentTypeName
+            ? `${parentTypeName}_${elementObj.attributes.name}`
+            : elementObj.attributes.name);
         const outputTC = this.getOutputTypeForComplexType(complexTypeObj, namespace);
         return outputTC;
       }
@@ -1046,6 +1060,7 @@ export class SOAPLoader {
                     elementObj,
                     aliasMap,
                     complexTypeNamespace,
+                    complexTypeName,
                   );
                   if (isPlural) {
                     outputTC = outputTC.getTypePlural();
@@ -1136,6 +1151,7 @@ export class SOAPLoader {
                       elementObj,
                       aliasMap,
                       complexTypeNamespace,
+                      complexTypeName,
                     );
                     if (isPlural) {
                       outputTC = outputTC.getTypePlural();

--- a/packages/loaders/soap/test/__snapshots__/examples.test.ts.snap
+++ b/packages/loaders/soap/test/__snapshots__/examples.test.ts.snap
@@ -595,6 +595,75 @@ input SOAPHeaders {
 scalar ObjMap"
 `;
 
+exports[`Examples should generate schema for inline-type-collision: inline-type-collision 1`] = `
+"schema @transport(kind: "soap", subgraph: "inline-type-collision") {
+  query: Query
+}
+
+directive @soap(elementName: String, bindingNamespace: String, endpoint: String, subgraph: String, bodyAlias: String, soapHeaders: SOAPHeaders, soapAction: String, soapNamespace: String) on FIELD_DEFINITION
+
+type Query {
+  InlineTypeCollision_CollisionService_CollisionPort_getA(GetA: InlineTypeCollision_GetA_Input): InlineTypeCollision_GetAResponse @soap(elementName: "GetAResponse", bindingNamespace: "http://example.com/inline-collision", endpoint: "http://example.com/collision", subgraph: "inline-type-collision", soapNamespace: "http://schemas.xmlsoap.org/soap/envelope/", soapAction: "getA")
+  InlineTypeCollision_CollisionService_CollisionPort_getB(GetB: InlineTypeCollision_GetB_Input): InlineTypeCollision_GetBResponse @soap(elementName: "GetBResponse", bindingNamespace: "http://example.com/inline-collision", endpoint: "http://example.com/collision", subgraph: "inline-type-collision", soapNamespace: "http://schemas.xmlsoap.org/soap/envelope/", soapAction: "getB")
+}
+
+type InlineTypeCollision_GetAResponse {
+  result: InlineTypeCollision_TypeA
+}
+
+type InlineTypeCollision_TypeA {
+  details: InlineTypeCollision_TypeA_details
+}
+
+type InlineTypeCollision_TypeA_details {
+  valueA: String
+}
+
+input InlineTypeCollision_GetA_Input {
+  input: InlineTypeCollision_TypeA_Input
+}
+
+input InlineTypeCollision_TypeA_Input {
+  details: InlineTypeCollision_TypeA_details_Input
+}
+
+input InlineTypeCollision_TypeA_details_Input {
+  valueA: String
+}
+
+type InlineTypeCollision_GetBResponse {
+  result: InlineTypeCollision_TypeB
+}
+
+type InlineTypeCollision_TypeB {
+  details: InlineTypeCollision_TypeB_details
+}
+
+type InlineTypeCollision_TypeB_details {
+  valueB: Int
+}
+
+input InlineTypeCollision_GetB_Input {
+  input: InlineTypeCollision_TypeB_Input
+}
+
+input InlineTypeCollision_TypeB_Input {
+  details: InlineTypeCollision_TypeB_details_Input
+}
+
+input InlineTypeCollision_TypeB_details_Input {
+  valueB: Int
+}
+
+input SOAPHeaders {
+  namespace: String
+  alias: String
+  headers: ObjMap
+}
+
+scalar ObjMap"
+`;
+
 exports[`Examples should generate schema for tempconvert: tempconvert 1`] = `
 "schema @transport(kind: "soap", subgraph: "tempconvert") {
   query: Query

--- a/packages/loaders/soap/test/examples.test.ts
+++ b/packages/loaders/soap/test/examples.test.ts
@@ -8,7 +8,15 @@ import { SOAPLoader } from '../src/index.js';
 
 const { readFile } = promises;
 
-const examples = ['example1', 'example2', 'axis', 'greeting', 'tempconvert', 'any-simple-type', 'inline-type-collision'];
+const examples = [
+  'example1',
+  'example2',
+  'axis',
+  'greeting',
+  'tempconvert',
+  'any-simple-type',
+  'inline-type-collision',
+];
 
 describe('Examples', () => {
   examples.forEach(example => {

--- a/packages/loaders/soap/test/examples.test.ts
+++ b/packages/loaders/soap/test/examples.test.ts
@@ -8,7 +8,7 @@ import { SOAPLoader } from '../src/index.js';
 
 const { readFile } = promises;
 
-const examples = ['example1', 'example2', 'axis', 'greeting', 'tempconvert', 'any-simple-type'];
+const examples = ['example1', 'example2', 'axis', 'greeting', 'tempconvert', 'any-simple-type', 'inline-type-collision'];
 
 describe('Examples', () => {
   examples.forEach(example => {

--- a/packages/loaders/soap/test/fixtures/inline-type-collision.wsdl
+++ b/packages/loaders/soap/test/fixtures/inline-type-collision.wsdl
@@ -1,0 +1,111 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="http://schemas.xmlsoap.org/wsdl/"
+             xmlns:xs="http://www.w3.org/2001/XMLSchema"
+             xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/"
+             xmlns:tns="http://example.com/inline-collision"
+             name="InlineTypeCollision"
+             targetNamespace="http://example.com/inline-collision">
+  <types>
+    <xs:schema targetNamespace="http://example.com/inline-collision"
+               id="example_inline_collision"
+               xmlns:tns="http://example.com/inline-collision">
+      <!--
+        Two parent types each define an inline anonymous complex type on a field
+        named "details". Without the fix, both get the GraphQL name
+        "InlineTypeCollision_details", causing a schema build error.
+        With the fix they become "InlineTypeCollision_TypeA_details"
+        and "InlineTypeCollision_TypeB_details".
+      -->
+      <xs:complexType name="TypeA">
+        <xs:sequence>
+          <xs:element name="details">
+            <xs:complexType>
+              <xs:sequence>
+                <xs:element name="valueA" type="xs:string"/>
+              </xs:sequence>
+            </xs:complexType>
+          </xs:element>
+        </xs:sequence>
+      </xs:complexType>
+      <xs:complexType name="TypeB">
+        <xs:sequence>
+          <xs:element name="details">
+            <xs:complexType>
+              <xs:sequence>
+                <xs:element name="valueB" type="xs:int"/>
+              </xs:sequence>
+            </xs:complexType>
+          </xs:element>
+        </xs:sequence>
+      </xs:complexType>
+      <xs:element name="GetA">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="input" type="tns:TypeA"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="GetAResponse">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="result" type="tns:TypeA"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="GetB">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="input" type="tns:TypeB"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="GetBResponse">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="result" type="tns:TypeB"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:schema>
+  </types>
+  <message name="GetARequest">
+    <part name="parameters" element="tns:GetA"/>
+  </message>
+  <message name="GetAResponse">
+    <part name="parameters" element="tns:GetAResponse"/>
+  </message>
+  <message name="GetBRequest">
+    <part name="parameters" element="tns:GetB"/>
+  </message>
+  <message name="GetBResponse">
+    <part name="parameters" element="tns:GetBResponse"/>
+  </message>
+  <portType name="CollisionPortType">
+    <operation name="getA">
+      <input message="tns:GetARequest"/>
+      <output message="tns:GetAResponse"/>
+    </operation>
+    <operation name="getB">
+      <input message="tns:GetBRequest"/>
+      <output message="tns:GetBResponse"/>
+    </operation>
+  </portType>
+  <binding name="CollisionBinding" type="tns:CollisionPortType">
+    <soap:binding style="document" transport="http://schemas.xmlsoap.org/soap/http"/>
+    <operation name="getA">
+      <soap:operation soapAction="getA" style="document"/>
+      <input><soap:body use="literal"/></input>
+      <output><soap:body use="literal"/></output>
+    </operation>
+    <operation name="getB">
+      <soap:operation soapAction="getB" style="document"/>
+      <input><soap:body use="literal"/></input>
+      <output><soap:body use="literal"/></output>
+    </operation>
+  </binding>
+  <service name="CollisionService">
+    <port name="CollisionPort" binding="tns:CollisionBinding">
+      <soap:address location="http://example.com/collision"/>
+    </port>
+  </service>
+</definitions>


### PR DESCRIPTION
Fixes #4647

When multiple complex types each define an inline anonymous child type on a field with the same name, the loader named all of them after the field alone (e.g. `prefix_details`), causing `buildSchema()` to throw:

```
Error: Schema must contain uniquely named types but contains multiple types named "prefix_details".
```

The fix falls back to `${parentTypeName}_${fieldName}` instead of `${fieldName}` when an inline complex type has no explicit `name` attribute. Applied in both the input-type path (`getInputTypeForComplexType`) and the output-type path (`getOutputFieldTypeFromElement`, which now accepts an optional `parentTypeName` parameter propagated from `getOutputTypeForComplexType`).

**Type of change:** Bug fix

**Testing:** Added `inline-type-collision.wsdl` fixture to `examples.test.ts`. The fixture defines two parent types each with a same-named inline field — `buildSchema()` threw before the fix and produces distinct scoped type names after.

- [x] Followed contribution guidelines
- [x] Self-reviewed the changes
- [x] Added a test that fails without the fix
- [x] All existing tests pass
- [x] Added a changeset (`yarn changeset`)

---

*These are among my first contributions to this project, submitted alongside a few related fixes to the SOAP loader. If I've missed any step in the process or if this kind of change isn't what you're looking for, please let me know — happy to adjust. Utilized Claude Code for these changes.*