### PR TITLE
fix(soap): wrap empty complex types in TypeComposer instead of raw GraphQLJSON

### DIFF
--- a/.changeset/soap-empty-complextype-json.md
+++ b/.changeset/soap-empty-complextype-json.md
@@ -1,0 +1,5 @@
+---
+"@omnigraph/soap": patch
+---
+
+Fix crash when empty complex type used in repeated element (getTypePlural called on raw GraphQLJSON scalar)

--- a/packages/loaders/soap/src/SOAPLoader.ts
+++ b/packages/loaders/soap/src/SOAPLoader.ts
@@ -183,7 +183,7 @@ export class SOAPLoader {
     }
   >();
 
-  private complexTypeInputTCMap = new WeakMap<XSComplexType, InputTypeComposer>();
+  private complexTypeInputTCMap = new WeakMap<XSComplexType, InputTypeComposer | ScalarTypeComposer>();
   private complexTypeOutputTCMap = new WeakMap<
     XSComplexType,
     ObjectTypeComposer | ScalarTypeComposer
@@ -917,8 +917,10 @@ export class SOAPLoader {
               );
             }
             const baseTypeTC = this.getInputTypeForComplexType(baseType, baseTypeNamespace);
-            for (const fieldName in baseTypeTC.getFields()) {
-              fieldMap[fieldName] = baseTypeTC.getField(fieldName);
+            if ('getFields' in baseTypeTC) {
+              for (const fieldName in baseTypeTC.getFields()) {
+                fieldMap[fieldName] = baseTypeTC.getField(fieldName);
+              }
             }
             for (const sequenceObj of extensionObj.sequence) {
               for (const elementObj of sequenceObj.element) {
@@ -945,7 +947,7 @@ export class SOAPLoader {
         }
       }
       if (Object.keys(fieldMap).length === 0) {
-        complexTypeTC = GraphQLJSON as any;
+        complexTypeTC = this.schemaComposer.createScalarTC(GraphQLJSON);
       } else {
         complexTypeTC = this.schemaComposer.createInputTC({
           name: `${prefix}_${complexTypeName}_Input`,

--- a/packages/loaders/soap/src/SOAPLoader.ts
+++ b/packages/loaders/soap/src/SOAPLoader.ts
@@ -183,7 +183,10 @@ export class SOAPLoader {
     }
   >();
 
-  private complexTypeInputTCMap = new WeakMap<XSComplexType, InputTypeComposer | ScalarTypeComposer>();
+  private complexTypeInputTCMap = new WeakMap<
+    XSComplexType,
+    InputTypeComposer | ScalarTypeComposer
+  >();
   private complexTypeOutputTCMap = new WeakMap<
     XSComplexType,
     ObjectTypeComposer | ScalarTypeComposer

--- a/packages/loaders/soap/src/SOAPLoader.ts
+++ b/packages/loaders/soap/src/SOAPLoader.ts
@@ -187,6 +187,7 @@ export class SOAPLoader {
     XSComplexType,
     InputTypeComposer | ScalarTypeComposer
   >();
+
   private complexTypeOutputTCMap = new WeakMap<
     XSComplexType,
     ObjectTypeComposer | ScalarTypeComposer

--- a/packages/loaders/soap/test/__snapshots__/examples.test.ts.snap
+++ b/packages/loaders/soap/test/__snapshots__/examples.test.ts.snap
@@ -165,6 +165,55 @@ input SOAPHeaders {
 scalar ObjMap"
 `;
 
+exports[`Examples should generate schema for empty-complextype: empty-complextype 1`] = `
+"schema @transport(kind: "soap", subgraph: "empty-complextype") {
+  query: Query
+  mutation: Mutation
+}
+
+directive @soap(elementName: String, bindingNamespace: String, endpoint: String, subgraph: String, bodyAlias: String, soapHeaders: SOAPHeaders, soapAction: String, soapNamespace: String) on FIELD_DEFINITION
+
+type Query {
+  placeholder: Void
+}
+
+"""Represents NULL values"""
+scalar Void
+
+type Mutation {
+  EmptyComplexType_ProcessService_ProcessPort_process(Process: EmptyComplexType_Process_Input): EmptyComplexType_ProcessResponse @soap(elementName: "ProcessResponse", bindingNamespace: "http://example.com/empty-complextype", endpoint: "http://example.com/process", subgraph: "empty-complextype", soapNamespace: "http://schemas.xmlsoap.org/soap/envelope/", soapAction: "process")
+}
+
+type EmptyComplexType_ProcessResponse {
+  result: EmptyComplexType_Container
+}
+
+type EmptyComplexType_Container {
+  extensions: [JSON]
+}
+
+"""
+The \`JSON\` scalar type represents JSON values as specified by [ECMA-404](http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf).
+"""
+scalar JSON
+
+input EmptyComplexType_Process_Input {
+  payload: EmptyComplexType_Container_Input
+}
+
+input EmptyComplexType_Container_Input {
+  extensions: [JSON]
+}
+
+input SOAPHeaders {
+  namespace: String
+  alias: String
+  headers: ObjMap
+}
+
+scalar ObjMap"
+`;
+
 exports[`Examples should generate schema for example1: example1 1`] = `
 "schema @transport(kind: "soap", subgraph: "example1") {
   query: Query

--- a/packages/loaders/soap/test/examples.test.ts
+++ b/packages/loaders/soap/test/examples.test.ts
@@ -8,7 +8,7 @@ import { SOAPLoader } from '../src/index.js';
 
 const { readFile } = promises;
 
-const examples = ['example1', 'example2', 'axis', 'greeting', 'tempconvert', 'any-simple-type'];
+const examples = ['example1', 'example2', 'axis', 'greeting', 'tempconvert', 'any-simple-type', 'empty-complextype'];
 
 describe('Examples', () => {
   examples.forEach(example => {

--- a/packages/loaders/soap/test/examples.test.ts
+++ b/packages/loaders/soap/test/examples.test.ts
@@ -8,7 +8,15 @@ import { SOAPLoader } from '../src/index.js';
 
 const { readFile } = promises;
 
-const examples = ['example1', 'example2', 'axis', 'greeting', 'tempconvert', 'any-simple-type', 'empty-complextype'];
+const examples = [
+  'example1',
+  'example2',
+  'axis',
+  'greeting',
+  'tempconvert',
+  'any-simple-type',
+  'empty-complextype',
+];
 
 describe('Examples', () => {
   examples.forEach(example => {

--- a/packages/loaders/soap/test/fixtures/empty-complextype.wsdl
+++ b/packages/loaders/soap/test/fixtures/empty-complextype.wsdl
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="http://schemas.xmlsoap.org/wsdl/"
+             xmlns:xs="http://www.w3.org/2001/XMLSchema"
+             xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/"
+             xmlns:tns="http://example.com/empty-complextype"
+             name="EmptyComplexType"
+             targetNamespace="http://example.com/empty-complextype">
+  <types>
+    <xs:schema targetNamespace="http://example.com/empty-complextype"
+               id="example_empty_complextype"
+               xmlns:tns="http://example.com/empty-complextype">
+      <!--
+        EmptyExtension has no fields. When used as a repeated element
+        (maxOccurs="unbounded"), the loader calls getTypePlural() on the
+        result of getInputTypeForComplexType(). Prior to the fix, that
+        method returned raw GraphQLJSON (not a TypeComposer), causing:
+          "finalTC.getTypePlural is not a function"
+      -->
+      <xs:complexType name="EmptyExtension"/>
+      <xs:complexType name="Container">
+        <xs:sequence>
+          <xs:element name="extensions" type="tns:EmptyExtension"
+                      minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+      </xs:complexType>
+      <xs:element name="Process">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="payload" type="tns:Container"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="ProcessResponse">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="result" type="tns:Container"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:schema>
+  </types>
+  <message name="ProcessRequest">
+    <part name="parameters" element="tns:Process"/>
+  </message>
+  <message name="ProcessResponse">
+    <part name="parameters" element="tns:ProcessResponse"/>
+  </message>
+  <portType name="ProcessPortType">
+    <operation name="process">
+      <input message="tns:ProcessRequest"/>
+      <output message="tns:ProcessResponse"/>
+    </operation>
+  </portType>
+  <binding name="ProcessBinding" type="tns:ProcessPortType">
+    <soap:binding style="document" transport="http://schemas.xmlsoap.org/soap/http"/>
+    <operation name="process">
+      <soap:operation soapAction="process" style="document"/>
+      <input><soap:body use="literal"/></input>
+      <output><soap:body use="literal"/></output>
+    </operation>
+  </binding>
+  <service name="ProcessService">
+    <port name="ProcessPort" binding="tns:ProcessBinding">
+      <soap:address location="http://example.com/process"/>
+    </port>
+  </service>
+</definitions>


### PR DESCRIPTION
Fixes #4647

`getInputTypeForComplexType()` returned the bare `GraphQLJSON` scalar object when a complex type had no fields. `GraphQLJSON` is a `GraphQLScalarType`, not a TypeComposer, so any subsequent `.getTypePlural()` or `.getTypeNonNull()` call crashed with `"x is not a function"`. This is most commonly triggered when an empty type appears in a repeated element (`maxOccurs="unbounded"`).

The fix replaces `GraphQLJSON as any` with `this.schemaComposer.createScalarTC(GraphQLJSON)`, which is already the pattern used in the equivalent output-type path.

**Type of change:** Bug fix

**Testing:** Added `empty-complextype.wsdl` fixture to `examples.test.ts`. The fixture defines an empty complex type used in a repeated element — `buildSchema()` threw before the fix and succeeds after.

- [x] Followed contribution guidelines
- [x] Self-reviewed the changes
- [x] Added a test that fails without the fix
- [x] All existing tests pass
- [x] Added a changeset (`yarn changeset`)

---

*These are among my first contributions to this project, submitted alongside a few related fixes to the SOAP loader. If I've missed any step in the process or if this kind of change isn't what you're looking for, please let me know — happy to adjust. Utilized Claude Code for these changes.*