### PR TITLE
fix(soap): add xs:anySimpleType to built-in XSD type map

### DIFF
--- a/.changeset/soap-anysimpletype.md
+++ b/.changeset/soap-anysimpletype.md
@@ -1,0 +1,5 @@
+---
+"@omnigraph/soap": patch
+---
+
+Add missing xs:anySimpleType to built-in XSD type map, mapping it to GraphQLString

--- a/packages/loaders/soap/src/SOAPLoader.ts
+++ b/packages/loaders/soap/src/SOAPLoader.ts
@@ -220,6 +220,7 @@ export class SOAPLoader {
     const namespace = 'http://www.w3.org/2001/XMLSchema';
     const simpleTypeGraphQLScalarMap = new Map<string, GraphQLScalarType>([
       ['anyType', GraphQLJSON],
+      ['anySimpleType', GraphQLString],
       ['anyURI', GraphQLURL],
       ['base64Binary', GraphQLByte],
       ['byte', GraphQLByte],

--- a/packages/loaders/soap/test/__snapshots__/examples.test.ts.snap
+++ b/packages/loaders/soap/test/__snapshots__/examples.test.ts.snap
@@ -1,5 +1,38 @@
 // Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
+exports[`Examples should generate schema for any-simple-type: any-simple-type 1`] = `
+"schema @transport(kind: "soap", subgraph: "any-simple-type") {
+  query: Query
+}
+
+directive @soap(elementName: String, bindingNamespace: String, endpoint: String, subgraph: String, bodyAlias: String, soapHeaders: SOAPHeaders, soapAction: String, soapNamespace: String) on FIELD_DEFINITION
+
+type Query {
+  AnySimpleType_AttributeService_AttributePort_getAttributes(GetAttributes: AnySimpleType_GetAttributes_Input): AnySimpleType_GetAttributesResponse @soap(elementName: "GetAttributesResponse", bindingNamespace: "http://example.com/any-simple-type", endpoint: "http://example.com/attributes", subgraph: "any-simple-type", soapNamespace: "http://schemas.xmlsoap.org/soap/envelope/", soapAction: "getAttributes")
+}
+
+type AnySimpleType_GetAttributesResponse {
+  attribute: [AnySimpleType_Attribute]
+}
+
+type AnySimpleType_Attribute {
+  name: String
+  value: String
+}
+
+input AnySimpleType_GetAttributes_Input {
+  filter: String
+}
+
+input SOAPHeaders {
+  namespace: String
+  alias: String
+  headers: ObjMap
+}
+
+scalar ObjMap"
+`;
+
 exports[`Examples should generate schema for axis: axis 1`] = `
 "schema @transport(kind: "soap", subgraph: "axis") {
   query: Query

--- a/packages/loaders/soap/test/examples.test.ts
+++ b/packages/loaders/soap/test/examples.test.ts
@@ -8,7 +8,7 @@ import { SOAPLoader } from '../src/index.js';
 
 const { readFile } = promises;
 
-const examples = ['example1', 'example2', 'axis', 'greeting', 'tempconvert'];
+const examples = ['example1', 'example2', 'axis', 'greeting', 'tempconvert', 'any-simple-type'];
 
 describe('Examples', () => {
   examples.forEach(example => {

--- a/packages/loaders/soap/test/fixtures/any-simple-type.wsdl
+++ b/packages/loaders/soap/test/fixtures/any-simple-type.wsdl
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="http://schemas.xmlsoap.org/wsdl/"
+             xmlns:xs="http://www.w3.org/2001/XMLSchema"
+             xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/"
+             xmlns:tns="http://example.com/any-simple-type"
+             name="AnySimpleType"
+             targetNamespace="http://example.com/any-simple-type">
+  <types>
+    <xs:schema targetNamespace="http://example.com/any-simple-type"
+               id="example_any_simple_type"
+               xmlns:tns="http://example.com/any-simple-type">
+      <!--
+        xs:anySimpleType is a standard XSD abstract base type that acts as
+        the base for all simple types (string, int, date, etc.). It is valid
+        in WSDL schemas but was missing from the loader's built-in type map,
+        causing a crash when the loader tried to resolve it.
+      -->
+      <xs:complexType name="Attribute">
+        <xs:sequence>
+          <xs:element name="name" type="xs:string"/>
+          <xs:element name="value" type="xs:anySimpleType"/>
+        </xs:sequence>
+      </xs:complexType>
+      <xs:element name="GetAttributes">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="filter" type="xs:string"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="GetAttributesResponse">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="attribute" type="tns:Attribute"
+                        minOccurs="0" maxOccurs="unbounded"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:schema>
+  </types>
+  <message name="GetAttributesRequest">
+    <part name="parameters" element="tns:GetAttributes"/>
+  </message>
+  <message name="GetAttributesResponse">
+    <part name="parameters" element="tns:GetAttributesResponse"/>
+  </message>
+  <portType name="AttributePortType">
+    <operation name="getAttributes">
+      <input message="tns:GetAttributesRequest"/>
+      <output message="tns:GetAttributesResponse"/>
+    </operation>
+  </portType>
+  <binding name="AttributeBinding" type="tns:AttributePortType">
+    <soap:binding style="document" transport="http://schemas.xmlsoap.org/soap/http"/>
+    <operation name="getAttributes">
+      <soap:operation soapAction="getAttributes" style="document"/>
+      <input><soap:body use="literal"/></input>
+      <output><soap:body use="literal"/></output>
+    </operation>
+  </binding>
+  <service name="AttributeService">
+    <port name="AttributePort" binding="tns:AttributeBinding">
+      <soap:address location="http://example.com/attributes"/>
+    </port>
+  </service>
+</definitions>


### PR DESCRIPTION
Fixes #9412

`xs:anySimpleType` is a standard XSD abstract base type that serves as the base for all primitive types (`string`, `int`, `date`, etc.). It is valid in WSDL schemas but was absent from the loader's `simpleTypeGraphQLScalarMap` in `loadXMLSchemaNamespace()`, causing a crash whenever an element referenced it.

The fix registers `anySimpleType → GraphQLString` alongside the other built-in XSD types. `String` is the appropriate fallback because `anySimpleType`'s value space is the union of all simple type value spaces and GraphQL has no equivalent abstract scalar.

**Type of change:** Bug fix

**Testing:** Added `any-simple-type.wsdl` fixture to `examples.test.ts`. The fixture uses `xs:anySimpleType` as an element type — `buildSchema()` threw before the fix and maps the field to `String` after.

- [x] Followed contribution guidelines
- [x] Self-reviewed the changes
- [x] Added a test that fails without the fix
- [x] All existing tests pass
- [x] Added a changeset (`yarn changeset`)

---

*These are among my first contributions to this project, submitted alongside a few related fixes to the SOAP loader. If I've missed any step in the process or if this kind of change isn't what you're looking for, please let me know — happy to adjust. Utilized Claude Code for these changes.*