### PR TITLE
fix(soap): resolve type name collisions from shared namespace aliases

### DIFF
--- a/.changeset/soap-prefix-collision.md
+++ b/.changeset/soap-prefix-collision.md
@@ -1,0 +1,5 @@
+---
+"@omnigraph/soap": patch
+---
+
+Fix GraphQL type name collisions when multiple embedded schemas share the same namespace alias (e.g. tns)

--- a/packages/loaders/soap/src/SOAPLoader.ts
+++ b/packages/loaders/soap/src/SOAPLoader.ts
@@ -947,8 +947,27 @@ export class SOAPLoader {
       if (Object.keys(fieldMap).length === 0) {
         complexTypeTC = GraphQLJSON as any;
       } else {
+        // When two schemas share the same alias-derived prefix (e.g. both declare
+        // xmlns:tns="<own namespace>"), types with the same name from different
+        // namespaces collide. Detect the collision and fall back to a slug derived
+        // from the namespace URI. Loop until unique in case two URIs produce the
+        // same slug after normalization.
+        const candidateName = `${prefix}_${complexTypeName}_Input`;
+        let inputTypeName = candidateName;
+        if (this.schemaComposer.has(candidateName)) {
+          const nsSlug = complexTypeNamespace
+            .replace(/^https?:\/\//, '')
+            .replace(/[^a-zA-Z0-9]+/g, '_')
+            .replace(/^_+|_+$/g, '')
+            .replace(/^\d/, '_$&');
+          inputTypeName = `${nsSlug}_${complexTypeName}_Input`;
+          let i = 2;
+          while (this.schemaComposer.has(inputTypeName)) {
+            inputTypeName = `${nsSlug}_${complexTypeName}_Input_${i++}`;
+          }
+        }
         complexTypeTC = this.schemaComposer.createInputTC({
-          name: `${prefix}_${complexTypeName}_Input`,
+          name: inputTypeName,
           fields: fieldMap,
         });
       }
@@ -1154,8 +1173,27 @@ export class SOAPLoader {
       if (Object.keys(fieldMap).length === 0) {
         complexTypeTC = this.schemaComposer.createScalarTC(GraphQLJSON);
       } else {
+        // When two schemas share the same alias-derived prefix (e.g. both declare
+        // xmlns:tns="<own namespace>"), types with the same name from different
+        // namespaces collide. Detect the collision and fall back to a slug derived
+        // from the namespace URI. Loop until unique in case two URIs produce the
+        // same slug after normalization.
+        const candidateName = `${prefix}_${complexTypeName}`;
+        let outputTypeName = candidateName;
+        if (this.schemaComposer.has(candidateName)) {
+          const nsSlug = complexTypeNamespace
+            .replace(/^https?:\/\//, '')
+            .replace(/[^a-zA-Z0-9]+/g, '_')
+            .replace(/^_+|_+$/g, '')
+            .replace(/^\d/, '_$&');
+          outputTypeName = `${nsSlug}_${complexTypeName}`;
+          let i = 2;
+          while (this.schemaComposer.has(outputTypeName)) {
+            outputTypeName = `${nsSlug}_${complexTypeName}_${i++}`;
+          }
+        }
         complexTypeTC = this.schemaComposer.createObjectTC({
-          name: `${prefix}_${complexTypeName}`,
+          name: outputTypeName,
           fields: fieldMap,
         });
       }

--- a/packages/loaders/soap/test/__snapshots__/examples.test.ts.snap
+++ b/packages/loaders/soap/test/__snapshots__/examples.test.ts.snap
@@ -595,6 +595,53 @@ input SOAPHeaders {
 scalar ObjMap"
 `;
 
+exports[`Examples should generate schema for prefix-collision: prefix-collision 1`] = `
+"schema @transport(kind: "soap", subgraph: "prefix-collision") {
+  query: Query
+}
+
+directive @soap(elementName: String, bindingNamespace: String, endpoint: String, subgraph: String, bodyAlias: String, soapHeaders: SOAPHeaders, soapAction: String, soapNamespace: String) on FIELD_DEFINITION
+
+type Query {
+  PrefixCollision_ItemsService_ItemsPort_getNs1Items(GetNs1Items: PrefixCollision_GetNs1Items_Input): PrefixCollision_GetNs1ItemsResponse @soap(elementName: "GetNs1ItemsResponse", bindingNamespace: "http://example.com/service", endpoint: "http://example.com/items", subgraph: "prefix-collision", soapNamespace: "http://schemas.xmlsoap.org/soap/envelope/", soapAction: "getNs1Items")
+  PrefixCollision_ItemsService_ItemsPort_getNs2Items(GetNs2Items: PrefixCollision_GetNs2Items_Input): PrefixCollision_GetNs2ItemsResponse @soap(elementName: "GetNs2ItemsResponse", bindingNamespace: "http://example.com/service", endpoint: "http://example.com/items", subgraph: "prefix-collision", soapNamespace: "http://schemas.xmlsoap.org/soap/envelope/", soapAction: "getNs2Items")
+}
+
+type PrefixCollision_GetNs1ItemsResponse {
+  item: [tns_Item]
+}
+
+type tns_Item {
+  id: String
+  label: String
+}
+
+input PrefixCollision_GetNs1Items_Input {
+  filter: String
+}
+
+type PrefixCollision_GetNs2ItemsResponse {
+  item: [example_com_ns2_Item]
+}
+
+type example_com_ns2_Item {
+  code: Int
+  description: String
+}
+
+input PrefixCollision_GetNs2Items_Input {
+  filter: String
+}
+
+input SOAPHeaders {
+  namespace: String
+  alias: String
+  headers: ObjMap
+}
+
+scalar ObjMap"
+`;
+
 exports[`Examples should generate schema for tempconvert: tempconvert 1`] = `
 "schema @transport(kind: "soap", subgraph: "tempconvert") {
   query: Query

--- a/packages/loaders/soap/test/examples.test.ts
+++ b/packages/loaders/soap/test/examples.test.ts
@@ -8,7 +8,7 @@ import { SOAPLoader } from '../src/index.js';
 
 const { readFile } = promises;
 
-const examples = ['example1', 'example2', 'axis', 'greeting', 'tempconvert', 'any-simple-type'];
+const examples = ['example1', 'example2', 'axis', 'greeting', 'tempconvert', 'any-simple-type', 'prefix-collision'];
 
 describe('Examples', () => {
   examples.forEach(example => {

--- a/packages/loaders/soap/test/examples.test.ts
+++ b/packages/loaders/soap/test/examples.test.ts
@@ -8,7 +8,15 @@ import { SOAPLoader } from '../src/index.js';
 
 const { readFile } = promises;
 
-const examples = ['example1', 'example2', 'axis', 'greeting', 'tempconvert', 'any-simple-type', 'prefix-collision'];
+const examples = [
+  'example1',
+  'example2',
+  'axis',
+  'greeting',
+  'tempconvert',
+  'any-simple-type',
+  'prefix-collision',
+];
 
 describe('Examples', () => {
   examples.forEach(example => {

--- a/packages/loaders/soap/test/fixtures/prefix-collision.wsdl
+++ b/packages/loaders/soap/test/fixtures/prefix-collision.wsdl
@@ -1,0 +1,112 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="http://schemas.xmlsoap.org/wsdl/"
+             xmlns:xs="http://www.w3.org/2001/XMLSchema"
+             xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/"
+             xmlns:tns="http://example.com/service"
+             xmlns:ns1="http://example.com/ns1"
+             xmlns:ns2="http://example.com/ns2"
+             name="PrefixCollision"
+             targetNamespace="http://example.com/service">
+  <types>
+    <!--
+      Both embedded schemas use "tns" as their self-referential alias (the standard
+      pattern in auto-generated WSDLs). Both also define a complex type named "Item".
+      Without the fix, both schemas get the prefix "tns", so both generate a type
+      named "tns_Item", causing buildSchema() to throw:
+        "Schema must contain uniquely named types but contains multiple types named 'tns_Item'"
+      With the fix, the second registration detects the collision via schemaComposer.has()
+      and falls back to a prefix derived from the namespace URI, which is globally unique.
+    -->
+    <xs:schema targetNamespace="http://example.com/ns1"
+               xmlns:tns="http://example.com/ns1">
+      <xs:complexType name="Item">
+        <xs:sequence>
+          <xs:element name="id" type="xs:string"/>
+          <xs:element name="label" type="xs:string"/>
+        </xs:sequence>
+      </xs:complexType>
+    </xs:schema>
+    <xs:schema targetNamespace="http://example.com/ns2"
+               xmlns:tns="http://example.com/ns2">
+      <xs:complexType name="Item">
+        <xs:sequence>
+          <xs:element name="code" type="xs:int"/>
+          <xs:element name="description" type="xs:string"/>
+        </xs:sequence>
+      </xs:complexType>
+    </xs:schema>
+    <xs:schema targetNamespace="http://example.com/service"
+               xmlns:tns="http://example.com/service"
+               xmlns:ns1="http://example.com/ns1"
+               xmlns:ns2="http://example.com/ns2">
+      <xs:element name="GetNs1Items">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="filter" type="xs:string"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="GetNs1ItemsResponse">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="item" type="ns1:Item" minOccurs="0" maxOccurs="unbounded"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="GetNs2Items">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="filter" type="xs:string"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="GetNs2ItemsResponse">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="item" type="ns2:Item" minOccurs="0" maxOccurs="unbounded"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:schema>
+  </types>
+  <message name="GetNs1ItemsRequest">
+    <part name="parameters" element="tns:GetNs1Items"/>
+  </message>
+  <message name="GetNs1ItemsResponse">
+    <part name="parameters" element="tns:GetNs1ItemsResponse"/>
+  </message>
+  <message name="GetNs2ItemsRequest">
+    <part name="parameters" element="tns:GetNs2Items"/>
+  </message>
+  <message name="GetNs2ItemsResponse">
+    <part name="parameters" element="tns:GetNs2ItemsResponse"/>
+  </message>
+  <portType name="ItemsPortType">
+    <operation name="getNs1Items">
+      <input message="tns:GetNs1ItemsRequest"/>
+      <output message="tns:GetNs1ItemsResponse"/>
+    </operation>
+    <operation name="getNs2Items">
+      <input message="tns:GetNs2ItemsRequest"/>
+      <output message="tns:GetNs2ItemsResponse"/>
+    </operation>
+  </portType>
+  <binding name="ItemsBinding" type="tns:ItemsPortType">
+    <soap:binding style="document" transport="http://schemas.xmlsoap.org/soap/http"/>
+    <operation name="getNs1Items">
+      <soap:operation soapAction="getNs1Items" style="document"/>
+      <input><soap:body use="literal"/></input>
+      <output><soap:body use="literal"/></output>
+    </operation>
+    <operation name="getNs2Items">
+      <soap:operation soapAction="getNs2Items" style="document"/>
+      <input><soap:body use="literal"/></input>
+      <output><soap:body use="literal"/></output>
+    </operation>
+  </binding>
+  <service name="ItemsService">
+    <port name="ItemsPort" binding="tns:ItemsBinding">
+      <soap:address location="http://example.com/items"/>
+    </port>
+  </service>
+</definitions>


### PR DESCRIPTION
Fixes #9413

WSDLs with multiple embedded schemas commonly declare the same self-referential alias in each schema (e.g. every schema has `xmlns:tns="<own namespace>"`). All those schemas derive the same prefix (`tns`), so two schemas that define a type with the same name both produce e.g. `tns_Item`, causing:

```
Error: Schema must contain uniquely named types but contains multiple types named "tns_Item".
```

The fix checks `this.schemaComposer.has(candidateName)` at type-registration time. When a collision is detected, it falls back to a name derived from the full namespace URI (which is globally unique) instead of the shared alias. The check is deferred to creation time so schemas with distinct type names continue to share their alias-derived prefix without any change to existing generated names.

**Type of change:** Bug fix

**Testing:** Added `prefix-collision.wsdl` fixture to `examples.test.ts`. The fixture has two schemas both declaring `xmlns:tns` and both defining a type named `Item` — `buildSchema()` threw before the fix and produces distinct names after.

- [x] Followed contribution guidelines
- [x] Self-reviewed the changes
- [x] Added a test that fails without the fix
- [x] All existing tests pass
- [x] Added a changeset (`yarn changeset`)

---

*These are among my first contributions to this project, submitted alongside a few related fixes to the SOAP loader. If I've missed any step in the process or if this kind of change isn't what you're looking for, please let me know — happy to adjust. Utilized Claude Code for these changes.*