### PR TITLE
fix(soap): skip xs:any wildcard namespace tokens instead of treating as URIs

### DIFF
--- a/.changeset/soap-any-wildcard-namespace.md
+++ b/.changeset/soap-any-wildcard-namespace.md
@@ -1,0 +1,5 @@
+---
+"@omnigraph/soap": patch
+---
+
+fix(soap): skip xs:any wildcard namespace tokens (##other, ##any, etc.) instead of treating them as namespace URIs

--- a/packages/loaders/soap/src/SOAPLoader.ts
+++ b/packages/loaders/soap/src/SOAPLoader.ts
@@ -880,9 +880,12 @@ export class SOAPLoader {
         }
         if (sequenceOrChoiceObj.any) {
           for (const anyObj of sequenceOrChoiceObj.any) {
-            const anyNamespace = anyObj.attributes?.namespace;
-            // ##other / ##any / ##local / ##targetNamespace are XSD wildcards, not real namespace URIs
-            if (anyNamespace && !anyNamespace.startsWith('##')) {
+            // namespace may be a space-delimited list; trim each token and skip XSD wildcards
+            const anyNamespaces = (anyObj.attributes?.namespace ?? '')
+              .split(/\s+/)
+              .map((s: string) => s.trim())
+              .filter((ns: string) => ns && !ns.startsWith('##'));
+            for (const anyNamespace of anyNamespaces) {
               const anyTypeTC = this.getInputTypeForTypeNameInNamespace({
                 typeName: complexTypeName,
                 typeNamespace: anyNamespace,
@@ -1068,9 +1071,12 @@ export class SOAPLoader {
         }
         if (choiceOrSequenceObj.any) {
           for (const anyObj of choiceOrSequenceObj.any) {
-            const anyNamespace = anyObj.attributes?.namespace;
-            // ##other / ##any / ##local / ##targetNamespace are XSD wildcards, not real namespace URIs
-            if (anyNamespace && !anyNamespace.startsWith('##')) {
+            // namespace may be a space-delimited list; trim each token and skip XSD wildcards
+            const anyNamespaces = (anyObj.attributes?.namespace ?? '')
+              .split(/\s+/)
+              .map((s: string) => s.trim())
+              .filter((ns: string) => ns && !ns.startsWith('##'));
+            for (const anyNamespace of anyNamespaces) {
               const anyTypeTC = this.getOutputTypeForTypeNameInNamespace({
                 typeName: complexTypeName,
                 typeNamespace: anyNamespace,

--- a/packages/loaders/soap/src/SOAPLoader.ts
+++ b/packages/loaders/soap/src/SOAPLoader.ts
@@ -881,7 +881,8 @@ export class SOAPLoader {
         if (sequenceOrChoiceObj.any) {
           for (const anyObj of sequenceOrChoiceObj.any) {
             const anyNamespace = anyObj.attributes?.namespace;
-            if (anyNamespace) {
+            // ##other / ##any / ##local / ##targetNamespace are XSD wildcards, not real namespace URIs
+            if (anyNamespace && !anyNamespace.startsWith('##')) {
               const anyTypeTC = this.getInputTypeForTypeNameInNamespace({
                 typeName: complexTypeName,
                 typeNamespace: anyNamespace,
@@ -1068,7 +1069,8 @@ export class SOAPLoader {
         if (choiceOrSequenceObj.any) {
           for (const anyObj of choiceOrSequenceObj.any) {
             const anyNamespace = anyObj.attributes?.namespace;
-            if (anyNamespace) {
+            // ##other / ##any / ##local / ##targetNamespace are XSD wildcards, not real namespace URIs
+            if (anyNamespace && !anyNamespace.startsWith('##')) {
               const anyTypeTC = this.getOutputTypeForTypeNameInNamespace({
                 typeName: complexTypeName,
                 typeNamespace: anyNamespace,

--- a/packages/loaders/soap/test/__snapshots__/examples.test.ts.snap
+++ b/packages/loaders/soap/test/__snapshots__/examples.test.ts.snap
@@ -33,6 +33,50 @@ input SOAPHeaders {
 scalar ObjMap"
 `;
 
+exports[`Examples should generate schema for any-wildcard-namespace: any-wildcard-namespace 1`] = `
+"schema @transport(kind: "soap", subgraph: "any-wildcard-namespace") {
+  query: Query
+  mutation: Mutation
+}
+
+directive @soap(elementName: String, bindingNamespace: String, endpoint: String, subgraph: String, bodyAlias: String, soapHeaders: SOAPHeaders, soapAction: String, soapNamespace: String) on FIELD_DEFINITION
+
+type Query {
+  placeholder: Void
+}
+
+"""Represents NULL values"""
+scalar Void
+
+type Mutation {
+  AnyWildcardNamespace_WildcardService_WildcardPort_processItem(ProcessItem: AnyWildcardNamespace_ProcessItem_Input): AnyWildcardNamespace_ProcessItemResponse @soap(elementName: "ProcessItemResponse", bindingNamespace: "http://example.com/any-wildcard-namespace", endpoint: "http://example.com/wildcard", subgraph: "any-wildcard-namespace", soapNamespace: "http://schemas.xmlsoap.org/soap/envelope/", soapAction: "processItem")
+}
+
+type AnyWildcardNamespace_ProcessItemResponse {
+  result: AnyWildcardNamespace_WildcardContainer
+}
+
+type AnyWildcardNamespace_WildcardContainer {
+  name: String
+}
+
+input AnyWildcardNamespace_ProcessItem_Input {
+  item: AnyWildcardNamespace_WildcardContainer_Input
+}
+
+input AnyWildcardNamespace_WildcardContainer_Input {
+  name: String
+}
+
+input SOAPHeaders {
+  namespace: String
+  alias: String
+  headers: ObjMap
+}
+
+scalar ObjMap"
+`;
+
 exports[`Examples should generate schema for axis: axis 1`] = `
 "schema @transport(kind: "soap", subgraph: "axis") {
   query: Query

--- a/packages/loaders/soap/test/examples.test.ts
+++ b/packages/loaders/soap/test/examples.test.ts
@@ -8,7 +8,15 @@ import { SOAPLoader } from '../src/index.js';
 
 const { readFile } = promises;
 
-const examples = ['example1', 'example2', 'axis', 'greeting', 'tempconvert', 'any-simple-type'];
+const examples = [
+  'example1',
+  'example2',
+  'axis',
+  'greeting',
+  'tempconvert',
+  'any-simple-type',
+  'any-wildcard-namespace',
+];
 
 describe('Examples', () => {
   examples.forEach(example => {

--- a/packages/loaders/soap/test/fixtures/any-wildcard-namespace.wsdl
+++ b/packages/loaders/soap/test/fixtures/any-wildcard-namespace.wsdl
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="http://schemas.xmlsoap.org/wsdl/"
+             xmlns:xs="http://www.w3.org/2001/XMLSchema"
+             xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/"
+             xmlns:tns="http://example.com/any-wildcard-namespace"
+             name="AnyWildcardNamespace"
+             targetNamespace="http://example.com/any-wildcard-namespace">
+  <types>
+    <xs:schema targetNamespace="http://example.com/any-wildcard-namespace"
+               id="example_any_wildcard_namespace"
+               xmlns:tns="http://example.com/any-wildcard-namespace">
+      <!--
+        xs:any with namespace="##other" (or ##any / ##local / ##targetNamespace) is an
+        XSD wildcard token, not a real namespace URI. The loader must skip the type
+        lookup for these tokens instead of trying to resolve them as namespaces.
+      -->
+      <xs:complexType name="WildcardContainer">
+        <xs:sequence>
+          <xs:element name="name" type="xs:string"/>
+          <xs:any namespace="##other" minOccurs="0" processContents="lax"/>
+        </xs:sequence>
+      </xs:complexType>
+      <xs:element name="ProcessItem">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="item" type="tns:WildcardContainer"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="ProcessItemResponse">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="result" type="tns:WildcardContainer"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:schema>
+  </types>
+  <message name="ProcessItemRequest">
+    <part name="parameters" element="tns:ProcessItem"/>
+  </message>
+  <message name="ProcessItemResponse">
+    <part name="parameters" element="tns:ProcessItemResponse"/>
+  </message>
+  <portType name="WildcardPortType">
+    <operation name="processItem">
+      <input message="tns:ProcessItemRequest"/>
+      <output message="tns:ProcessItemResponse"/>
+    </operation>
+  </portType>
+  <binding name="WildcardBinding" type="tns:WildcardPortType">
+    <soap:binding style="document" transport="http://schemas.xmlsoap.org/soap/http"/>
+    <operation name="processItem">
+      <soap:operation soapAction="processItem" style="document"/>
+      <input><soap:body use="literal"/></input>
+      <output><soap:body use="literal"/></output>
+    </operation>
+  </binding>
+  <service name="WildcardService">
+    <port name="WildcardPort" binding="tns:WildcardBinding">
+      <soap:address location="http://example.com/wildcard"/>
+    </port>
+  </service>
+</definitions>

--- a/packages/loaders/soap/test/fixtures/any-wildcard-namespace.wsdl
+++ b/packages/loaders/soap/test/fixtures/any-wildcard-namespace.wsdl
@@ -17,7 +17,12 @@
       <xs:complexType name="WildcardContainer">
         <xs:sequence>
           <xs:element name="name" type="xs:string"/>
+          <!-- single wildcard token -->
           <xs:any namespace="##other" minOccurs="0" processContents="lax"/>
+          <!-- whitespace-padded wildcard -->
+          <xs:any namespace="  ##any  " minOccurs="0" processContents="lax"/>
+          <!-- space-delimited list of wildcards -->
+          <xs:any namespace="##other ##local" minOccurs="0" processContents="lax"/>
         </xs:sequence>
       </xs:complexType>
       <xs:element name="ProcessItem">


### PR DESCRIPTION
## Problem

When a WSDL complexType contains `<xs:any namespace="##other"/>` (or `##any`, `##local`, `##targetNamespace`), the loader reads the `namespace` attribute and passes it directly to the type lookup functions as if it were a real namespace URI. These `##`-prefixed values are XSD wildcard tokens — they do not represent a resolvable namespace, so the lookup throws `Type: X couldn't be found in ##other`.

## Fix

Guard both `anyNamespace` checks (input and output paths) to skip wildcards:

```typescript
// ##other / ##any / ##local / ##targetNamespace are XSD wildcards, not real namespace URIs
if (anyNamespace && !anyNamespace.startsWith('##')) {
```

## Test

Added `any-wildcard-namespace` fixture with `<xs:any namespace="##other" processContents="lax"/>` in a sequence. Schema builds successfully and the wildcard element is silently skipped (consistent with XSD open content semantics).

## Related

Part of a series of SOAP loader fixes discovered while testing against a real-world TMForum MTOP WSDL.