### PR TITLE
fix(soap): sanitize XSD names containing illegal GraphQL characters

### DIFF
--- a/.changeset/soap-illegal-gql-names.md
+++ b/.changeset/soap-illegal-gql-names.md
@@ -1,0 +1,5 @@
+---
+"@omnigraph/soap": patch
+---
+
+fix(soap): sanitize XSD type and field names containing illegal GraphQL characters (dots, hyphens, etc.)

--- a/packages/loaders/soap/src/SOAPLoader.ts
+++ b/packages/loaders/soap/src/SOAPLoader.ts
@@ -289,7 +289,6 @@ export class SOAPLoader {
     return namespaceComplexTypes;
   }
 
-
   private getNamespaceSimpleTypeMap(namespace: string) {
     let namespaceSimpleTypes = this.namespaceSimpleTypesMap.get(namespace);
     if (!namespaceSimpleTypes) {

--- a/packages/loaders/soap/src/SOAPLoader.ts
+++ b/packages/loaders/soap/src/SOAPLoader.ts
@@ -285,6 +285,10 @@ export class SOAPLoader {
     return namespaceComplexTypes;
   }
 
+  private toGQLName(name: string) {
+    return name?.replace(/[^_a-zA-Z0-9]/g, '_') ?? name;
+  }
+
   private getNamespaceSimpleTypeMap(namespace: string) {
     let namespaceSimpleTypes = this.namespaceSimpleTypesMap.get(namespace);
     if (!namespaceSimpleTypes) {
@@ -697,7 +701,7 @@ export class SOAPLoader {
   ): EnumTypeComposer | ScalarTypeComposer {
     let simpleTypeTC = this.simpleTypeTCMap.get(simpleType);
     if (!simpleTypeTC) {
-      const simpleTypeName = simpleType.attributes.name;
+      const simpleTypeName = this.toGQLName(simpleType.attributes.name);
       const restrictionObj = simpleType.restriction[0];
       const prefix = this.namespaceTypePrefixMap.get(simpleTypeNamespace);
       if (restrictionObj.enumeration) {
@@ -763,7 +767,7 @@ export class SOAPLoader {
   getInputTypeForComplexType(complexType: XSComplexType, complexTypeNamespace: string) {
     let complexTypeTC = this.complexTypeInputTCMap.get(complexType);
     if (!complexTypeTC) {
-      const complexTypeName = complexType.attributes.name;
+      const complexTypeName = this.toGQLName(complexType.attributes.name);
       const prefix = this.namespaceTypePrefixMap.get(complexTypeNamespace);
       const aliasMap = this.aliasMap.get(complexType);
       const fieldMap: InputTypeComposerFieldConfigMapDefinition = {};
@@ -774,7 +778,7 @@ export class SOAPLoader {
       for (const sequenceOrChoiceObj of choiceOrSequenceObjects) {
         if (sequenceOrChoiceObj.element) {
           for (const elementObj of sequenceOrChoiceObj.element) {
-            const fieldName = elementObj.attributes.name;
+            const fieldName = this.toGQLName(elementObj.attributes.name);
             if (fieldName) {
               fieldMap[fieldName] = {
                 type: () => {
@@ -881,7 +885,8 @@ export class SOAPLoader {
         if (sequenceOrChoiceObj.any) {
           for (const anyObj of sequenceOrChoiceObj.any) {
             const anyNamespace = anyObj.attributes?.namespace;
-            if (anyNamespace) {
+            // ##other / ##any / ##local / ##targetNamespace are XSD wildcards, not real namespace URIs
+            if (anyNamespace && !anyNamespace.startsWith('##')) {
               const anyTypeTC = this.getInputTypeForTypeNameInNamespace({
                 typeName: complexTypeName,
                 typeNamespace: anyNamespace,
@@ -1010,7 +1015,7 @@ export class SOAPLoader {
   getOutputTypeForComplexType(complexType: XSComplexType, complexTypeNamespace: string) {
     let complexTypeTC = this.complexTypeOutputTCMap.get(complexType);
     if (!complexTypeTC) {
-      const complexTypeName = complexType.attributes.name;
+      const complexTypeName = this.toGQLName(complexType.attributes.name);
       const prefix = this.namespaceTypePrefixMap.get(complexTypeNamespace);
       const aliasMap = this.aliasMap.get(complexType);
       const fieldMap: Record<string, ObjectTypeComposerFieldConfigDefinition<any, any>> = {};
@@ -1021,7 +1026,7 @@ export class SOAPLoader {
       for (const choiceOrSequenceObj of choiceOrSequenceObjects) {
         if (choiceOrSequenceObj.element) {
           for (const elementObj of choiceOrSequenceObj.element) {
-            const fieldName = elementObj.attributes.name;
+            const fieldName = this.toGQLName(elementObj.attributes.name);
             if (fieldName) {
               const maxOccurs =
                 choiceOrSequenceObj.attributes?.maxOccurs || elementObj.attributes?.maxOccurs;
@@ -1068,7 +1073,8 @@ export class SOAPLoader {
         if (choiceOrSequenceObj.any) {
           for (const anyObj of choiceOrSequenceObj.any) {
             const anyNamespace = anyObj.attributes?.namespace;
-            if (anyNamespace) {
+            // ##other / ##any / ##local / ##targetNamespace are XSD wildcards, not real namespace URIs
+            if (anyNamespace && !anyNamespace.startsWith('##')) {
               const anyTypeTC = this.getOutputTypeForTypeNameInNamespace({
                 typeName: complexTypeName,
                 typeNamespace: anyNamespace,
@@ -1112,7 +1118,7 @@ export class SOAPLoader {
             ];
             for (const choiceOrSequenceObj of choiceOrSequenceObjects) {
               for (const elementObj of choiceOrSequenceObj.element) {
-                const fieldName = elementObj.attributes.name;
+                const fieldName = this.toGQLName(elementObj.attributes.name);
                 const maxOccurs =
                   choiceOrSequenceObj.attributes?.maxOccurs || elementObj.attributes?.maxOccurs;
                 const minOccurs =

--- a/packages/loaders/soap/src/SOAPLoader.ts
+++ b/packages/loaders/soap/src/SOAPLoader.ts
@@ -285,9 +285,6 @@ export class SOAPLoader {
     return namespaceComplexTypes;
   }
 
-  private toGQLName(name: string) {
-    return name?.replace(/[^_a-zA-Z0-9]/g, '_') ?? name;
-  }
 
   private getNamespaceSimpleTypeMap(namespace: string) {
     let namespaceSimpleTypes = this.namespaceSimpleTypesMap.get(namespace);
@@ -587,7 +584,7 @@ export class SOAPLoader {
               if (part.attributes.element) {
                 const [elementNamespaceAlias, elementName] = part.attributes.element.split(':');
                 rootTC.addFieldArgs(operationFieldName, {
-                  [this.toGQLName(elementName)]: {
+                  [sanitizeNameForGraphQL(elementName)]: {
                     type: () => {
                       const elementNamespace =
                         aliasMap.get(elementNamespaceAlias) ||
@@ -608,7 +605,7 @@ export class SOAPLoader {
               } else if (part.attributes.name) {
                 const partName = part.attributes.name;
                 rootTC.addFieldArgs(operationFieldName, {
-                  [this.toGQLName(partName)]: {
+                  [sanitizeNameForGraphQL(partName)]: {
                     type: () => {
                       const typeRef = part.attributes.type;
                       const [typeNamespaceAlias, typeName] = typeRef.split(':');
@@ -701,7 +698,7 @@ export class SOAPLoader {
   ): EnumTypeComposer | ScalarTypeComposer {
     let simpleTypeTC = this.simpleTypeTCMap.get(simpleType);
     if (!simpleTypeTC) {
-      const simpleTypeName = this.toGQLName(simpleType.attributes.name);
+      const simpleTypeName = sanitizeNameForGraphQL(simpleType.attributes.name);
       const restrictionObj = simpleType.restriction[0];
       const prefix = this.namespaceTypePrefixMap.get(simpleTypeNamespace);
       if (restrictionObj.enumeration) {
@@ -767,7 +764,7 @@ export class SOAPLoader {
   getInputTypeForComplexType(complexType: XSComplexType, complexTypeNamespace: string) {
     let complexTypeTC = this.complexTypeInputTCMap.get(complexType);
     if (!complexTypeTC) {
-      const complexTypeName = this.toGQLName(complexType.attributes.name);
+      const complexTypeName = sanitizeNameForGraphQL(complexType.attributes.name);
       const prefix = this.namespaceTypePrefixMap.get(complexTypeNamespace);
       const aliasMap = this.aliasMap.get(complexType);
       const fieldMap: InputTypeComposerFieldConfigMapDefinition = {};
@@ -778,7 +775,7 @@ export class SOAPLoader {
       for (const sequenceOrChoiceObj of choiceOrSequenceObjects) {
         if (sequenceOrChoiceObj.element) {
           for (const elementObj of sequenceOrChoiceObj.element) {
-            const fieldName = this.toGQLName(elementObj.attributes.name);
+            const fieldName = sanitizeNameForGraphQL(elementObj.attributes.name);
             if (fieldName) {
               fieldMap[fieldName] = {
                 type: () => {
@@ -1015,7 +1012,7 @@ export class SOAPLoader {
   getOutputTypeForComplexType(complexType: XSComplexType, complexTypeNamespace: string) {
     let complexTypeTC = this.complexTypeOutputTCMap.get(complexType);
     if (!complexTypeTC) {
-      const complexTypeName = this.toGQLName(complexType.attributes.name);
+      const complexTypeName = sanitizeNameForGraphQL(complexType.attributes.name);
       const prefix = this.namespaceTypePrefixMap.get(complexTypeNamespace);
       const aliasMap = this.aliasMap.get(complexType);
       const fieldMap: Record<string, ObjectTypeComposerFieldConfigDefinition<any, any>> = {};
@@ -1026,7 +1023,7 @@ export class SOAPLoader {
       for (const choiceOrSequenceObj of choiceOrSequenceObjects) {
         if (choiceOrSequenceObj.element) {
           for (const elementObj of choiceOrSequenceObj.element) {
-            const fieldName = this.toGQLName(elementObj.attributes.name);
+            const fieldName = sanitizeNameForGraphQL(elementObj.attributes.name);
             if (fieldName) {
               const maxOccurs =
                 choiceOrSequenceObj.attributes?.maxOccurs || elementObj.attributes?.maxOccurs;
@@ -1118,7 +1115,7 @@ export class SOAPLoader {
             ];
             for (const choiceOrSequenceObj of choiceOrSequenceObjects) {
               for (const elementObj of choiceOrSequenceObj.element) {
-                const fieldName = this.toGQLName(elementObj.attributes.name);
+                const fieldName = sanitizeNameForGraphQL(elementObj.attributes.name);
                 const maxOccurs =
                   choiceOrSequenceObj.attributes?.maxOccurs || elementObj.attributes?.maxOccurs;
                 const minOccurs =

--- a/packages/loaders/soap/src/SOAPLoader.ts
+++ b/packages/loaders/soap/src/SOAPLoader.ts
@@ -778,8 +778,8 @@ export class SOAPLoader {
       for (const sequenceOrChoiceObj of choiceOrSequenceObjects) {
         if (sequenceOrChoiceObj.element) {
           for (const elementObj of sequenceOrChoiceObj.element) {
-            const fieldName = sanitizeNameForGraphQL(elementObj.attributes.name);
-            if (fieldName) {
+            if (elementObj.attributes?.name) {
+              const fieldName = sanitizeNameForGraphQL(elementObj.attributes.name);
               fieldMap[fieldName] = {
                 type: () => {
                   const maxOccurs =
@@ -1083,8 +1083,8 @@ export class SOAPLoader {
       for (const choiceOrSequenceObj of choiceOrSequenceObjects) {
         if (choiceOrSequenceObj.element) {
           for (const elementObj of choiceOrSequenceObj.element) {
-            const fieldName = sanitizeNameForGraphQL(elementObj.attributes.name);
-            if (fieldName) {
+            if (elementObj.attributes?.name) {
+              const fieldName = sanitizeNameForGraphQL(elementObj.attributes.name);
               const maxOccurs =
                 choiceOrSequenceObj.attributes?.maxOccurs || elementObj.attributes?.maxOccurs;
               const minOccurs =
@@ -1179,6 +1179,7 @@ export class SOAPLoader {
             ];
             for (const choiceOrSequenceObj of choiceOrSequenceObjects) {
               for (const elementObj of choiceOrSequenceObj.element) {
+                if (!elementObj.attributes?.name) continue;
                 const fieldName = sanitizeNameForGraphQL(elementObj.attributes.name);
                 const maxOccurs =
                   choiceOrSequenceObj.attributes?.maxOccurs || elementObj.attributes?.maxOccurs;

--- a/packages/loaders/soap/src/SOAPLoader.ts
+++ b/packages/loaders/soap/src/SOAPLoader.ts
@@ -881,9 +881,12 @@ export class SOAPLoader {
         }
         if (sequenceOrChoiceObj.any) {
           for (const anyObj of sequenceOrChoiceObj.any) {
-            const anyNamespace = anyObj.attributes?.namespace;
-            // ##other / ##any / ##local / ##targetNamespace are XSD wildcards, not real namespace URIs
-            if (anyNamespace && !anyNamespace.startsWith('##')) {
+            // namespace may be a space-delimited list; trim each token and skip XSD wildcards
+            const anyNamespaces = (anyObj.attributes?.namespace ?? '')
+              .split(/\s+/)
+              .map((s: string) => s.trim())
+              .filter((ns: string) => ns && !ns.startsWith('##'));
+            for (const anyNamespace of anyNamespaces) {
               const anyTypeTC = this.getInputTypeForTypeNameInNamespace({
                 typeName: complexType.attributes.name,
                 typeNamespace: anyNamespace,
@@ -1069,9 +1072,12 @@ export class SOAPLoader {
         }
         if (choiceOrSequenceObj.any) {
           for (const anyObj of choiceOrSequenceObj.any) {
-            const anyNamespace = anyObj.attributes?.namespace;
-            // ##other / ##any / ##local / ##targetNamespace are XSD wildcards, not real namespace URIs
-            if (anyNamespace && !anyNamespace.startsWith('##')) {
+            // namespace may be a space-delimited list; trim each token and skip XSD wildcards
+            const anyNamespaces = (anyObj.attributes?.namespace ?? '')
+              .split(/\s+/)
+              .map((s: string) => s.trim())
+              .filter((ns: string) => ns && !ns.startsWith('##'));
+            for (const anyNamespace of anyNamespaces) {
               const anyTypeTC = this.getOutputTypeForTypeNameInNamespace({
                 typeName: complexType.attributes.name,
                 typeNamespace: anyNamespace,

--- a/packages/loaders/soap/src/SOAPLoader.ts
+++ b/packages/loaders/soap/src/SOAPLoader.ts
@@ -587,7 +587,7 @@ export class SOAPLoader {
               if (part.attributes.element) {
                 const [elementNamespaceAlias, elementName] = part.attributes.element.split(':');
                 rootTC.addFieldArgs(operationFieldName, {
-                  [elementName]: {
+                  [this.toGQLName(elementName)]: {
                     type: () => {
                       const elementNamespace =
                         aliasMap.get(elementNamespaceAlias) ||
@@ -608,7 +608,7 @@ export class SOAPLoader {
               } else if (part.attributes.name) {
                 const partName = part.attributes.name;
                 rootTC.addFieldArgs(operationFieldName, {
-                  [partName]: {
+                  [this.toGQLName(partName)]: {
                     type: () => {
                       const typeRef = part.attributes.type;
                       const [typeNamespaceAlias, typeName] = typeRef.split(':');
@@ -888,7 +888,7 @@ export class SOAPLoader {
             // ##other / ##any / ##local / ##targetNamespace are XSD wildcards, not real namespace URIs
             if (anyNamespace && !anyNamespace.startsWith('##')) {
               const anyTypeTC = this.getInputTypeForTypeNameInNamespace({
-                typeName: complexTypeName,
+                typeName: complexType.attributes.name,
                 typeNamespace: anyNamespace,
               });
               if ('getFields' in anyTypeTC) {
@@ -1076,7 +1076,7 @@ export class SOAPLoader {
             // ##other / ##any / ##local / ##targetNamespace are XSD wildcards, not real namespace URIs
             if (anyNamespace && !anyNamespace.startsWith('##')) {
               const anyTypeTC = this.getOutputTypeForTypeNameInNamespace({
-                typeName: complexTypeName,
+                typeName: complexType.attributes.name,
                 typeNamespace: anyNamespace,
               });
               if ('getFields' in anyTypeTC) {

--- a/packages/loaders/soap/src/SOAPLoader.ts
+++ b/packages/loaders/soap/src/SOAPLoader.ts
@@ -927,7 +927,7 @@ export class SOAPLoader {
             }
             for (const sequenceObj of extensionObj.sequence) {
               for (const elementObj of sequenceObj.element) {
-                fieldMap[elementObj.attributes.name] = {
+                fieldMap[sanitizeNameForGraphQL(elementObj.attributes.name)] = {
                   type: () => {
                     const [typeNamespaceAlias, typeName] = elementObj.attributes.type.split(
                       ':',

--- a/packages/loaders/soap/test/__snapshots__/examples.test.ts.snap
+++ b/packages/loaders/soap/test/__snapshots__/examples.test.ts.snap
@@ -33,6 +33,50 @@ input SOAPHeaders {
 scalar ObjMap"
 `;
 
+exports[`Examples should generate schema for any-wildcard-namespace: any-wildcard-namespace 1`] = `
+"schema @transport(kind: "soap", subgraph: "any-wildcard-namespace") {
+  query: Query
+  mutation: Mutation
+}
+
+directive @soap(elementName: String, bindingNamespace: String, endpoint: String, subgraph: String, bodyAlias: String, soapHeaders: SOAPHeaders, soapAction: String, soapNamespace: String) on FIELD_DEFINITION
+
+type Query {
+  placeholder: Void
+}
+
+"""Represents NULL values"""
+scalar Void
+
+type Mutation {
+  AnyWildcardNamespace_WildcardService_WildcardPort_processItem(ProcessItem: AnyWildcardNamespace_ProcessItem_Input): AnyWildcardNamespace_ProcessItemResponse @soap(elementName: "ProcessItemResponse", bindingNamespace: "http://example.com/any-wildcard-namespace", endpoint: "http://example.com/wildcard", subgraph: "any-wildcard-namespace", soapNamespace: "http://schemas.xmlsoap.org/soap/envelope/", soapAction: "processItem")
+}
+
+type AnyWildcardNamespace_ProcessItemResponse {
+  result: AnyWildcardNamespace_WildcardContainer
+}
+
+type AnyWildcardNamespace_WildcardContainer {
+  name: String
+}
+
+input AnyWildcardNamespace_ProcessItem_Input {
+  item: AnyWildcardNamespace_WildcardContainer_Input
+}
+
+input AnyWildcardNamespace_WildcardContainer_Input {
+  name: String
+}
+
+input SOAPHeaders {
+  namespace: String
+  alias: String
+  headers: ObjMap
+}
+
+scalar ObjMap"
+`;
+
 exports[`Examples should generate schema for axis: axis 1`] = `
 "schema @transport(kind: "soap", subgraph: "axis") {
   query: Query
@@ -584,6 +628,47 @@ type NumberConversion_NumberToDollarsResponse {
 
 input NumberConversion_NumberToDollars_Input {
   dNum: Float
+}
+
+input SOAPHeaders {
+  namespace: String
+  alias: String
+  headers: ObjMap
+}
+
+scalar ObjMap"
+`;
+
+exports[`Examples should generate schema for illegal-gql-names: illegal-gql-names 1`] = `
+"schema @transport(kind: "soap", subgraph: "illegal-gql-names") {
+  query: Query
+}
+
+directive @soap(elementName: String, bindingNamespace: String, endpoint: String, subgraph: String, bodyAlias: String, soapHeaders: SOAPHeaders, soapAction: String, soapNamespace: String) on FIELD_DEFINITION
+
+type Query {
+  IllegalGqlNames_IllegalGqlNames_IllegalGqlNamesSoap_GetState(GetState: IllegalGqlNames_GetState_Input): IllegalGqlNames_GetStateResponse @soap(elementName: "GetStateResponse", bindingNamespace: "http://example.com/illegal-gql-names/", endpoint: "http://example.com/illegal-gql-names/soap", subgraph: "illegal-gql-names", soapNamespace: "http://schemas.xmlsoap.org/soap/envelope/")
+}
+
+type IllegalGqlNames_GetStateResponse {
+  result: IllegalGqlNames_X721_Type
+}
+
+type IllegalGqlNames_X721_Type {
+  code: String
+}
+
+input IllegalGqlNames_GetState_Input {
+  input: IllegalGqlNames_My_ComplexType_Input
+}
+
+input IllegalGqlNames_My_ComplexType_Input {
+  state: IllegalGqlNames_X721_Type_Input
+  response_data: String
+}
+
+input IllegalGqlNames_X721_Type_Input {
+  code: String
 }
 
 input SOAPHeaders {

--- a/packages/loaders/soap/test/__snapshots__/examples.test.ts.snap
+++ b/packages/loaders/soap/test/__snapshots__/examples.test.ts.snap
@@ -652,10 +652,16 @@ type Query {
 
 type IllegalGqlNames_GetStateResponse {
   result: IllegalGqlNames_X721_Type
+  extended: IllegalGqlNames_Extended_Type
 }
 
 type IllegalGqlNames_X721_Type {
   code: String
+}
+
+type IllegalGqlNames_Extended_Type {
+  code: String
+  extra_field: String
 }
 
 input IllegalGqlNames_GetState_Input {

--- a/packages/loaders/soap/test/examples.test.ts
+++ b/packages/loaders/soap/test/examples.test.ts
@@ -8,7 +8,16 @@ import { SOAPLoader } from '../src/index.js';
 
 const { readFile } = promises;
 
-const examples = ['example1', 'example2', 'axis', 'greeting', 'tempconvert', 'any-simple-type'];
+const examples = [
+  'example1',
+  'example2',
+  'axis',
+  'greeting',
+  'tempconvert',
+  'any-simple-type',
+  'any-wildcard-namespace',
+  'illegal-gql-names',
+];
 
 describe('Examples', () => {
   examples.forEach(example => {

--- a/packages/loaders/soap/test/fixtures/any-wildcard-namespace.wsdl
+++ b/packages/loaders/soap/test/fixtures/any-wildcard-namespace.wsdl
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="http://schemas.xmlsoap.org/wsdl/"
+             xmlns:xs="http://www.w3.org/2001/XMLSchema"
+             xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/"
+             xmlns:tns="http://example.com/any-wildcard-namespace"
+             name="AnyWildcardNamespace"
+             targetNamespace="http://example.com/any-wildcard-namespace">
+  <types>
+    <xs:schema targetNamespace="http://example.com/any-wildcard-namespace"
+               id="example_any_wildcard_namespace"
+               xmlns:tns="http://example.com/any-wildcard-namespace">
+      <!--
+        xs:any with namespace="##other" (or ##any / ##local / ##targetNamespace) is an
+        XSD wildcard token, not a real namespace URI. The loader must skip the type
+        lookup for these tokens instead of trying to resolve them as namespaces.
+      -->
+      <xs:complexType name="WildcardContainer">
+        <xs:sequence>
+          <xs:element name="name" type="xs:string"/>
+          <xs:any namespace="##other" minOccurs="0" processContents="lax"/>
+        </xs:sequence>
+      </xs:complexType>
+      <xs:element name="ProcessItem">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="item" type="tns:WildcardContainer"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="ProcessItemResponse">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="result" type="tns:WildcardContainer"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:schema>
+  </types>
+  <message name="ProcessItemRequest">
+    <part name="parameters" element="tns:ProcessItem"/>
+  </message>
+  <message name="ProcessItemResponse">
+    <part name="parameters" element="tns:ProcessItemResponse"/>
+  </message>
+  <portType name="WildcardPortType">
+    <operation name="processItem">
+      <input message="tns:ProcessItemRequest"/>
+      <output message="tns:ProcessItemResponse"/>
+    </operation>
+  </portType>
+  <binding name="WildcardBinding" type="tns:WildcardPortType">
+    <soap:binding style="document" transport="http://schemas.xmlsoap.org/soap/http"/>
+    <operation name="processItem">
+      <soap:operation soapAction="processItem" style="document"/>
+      <input><soap:body use="literal"/></input>
+      <output><soap:body use="literal"/></output>
+    </operation>
+  </binding>
+  <service name="WildcardService">
+    <port name="WildcardPort" binding="tns:WildcardBinding">
+      <soap:address location="http://example.com/wildcard"/>
+    </port>
+  </service>
+</definitions>

--- a/packages/loaders/soap/test/fixtures/any-wildcard-namespace.wsdl
+++ b/packages/loaders/soap/test/fixtures/any-wildcard-namespace.wsdl
@@ -17,7 +17,12 @@
       <xs:complexType name="WildcardContainer">
         <xs:sequence>
           <xs:element name="name" type="xs:string"/>
+          <!-- single wildcard token -->
           <xs:any namespace="##other" minOccurs="0" processContents="lax"/>
+          <!-- whitespace-padded wildcard -->
+          <xs:any namespace="  ##any  " minOccurs="0" processContents="lax"/>
+          <!-- space-delimited list of wildcards -->
+          <xs:any namespace="##other ##local" minOccurs="0" processContents="lax"/>
         </xs:sequence>
       </xs:complexType>
       <xs:element name="ProcessItem">

--- a/packages/loaders/soap/test/fixtures/illegal-gql-names.wsdl
+++ b/packages/loaders/soap/test/fixtures/illegal-gql-names.wsdl
@@ -1,0 +1,62 @@
+<definitions xmlns="http://schemas.xmlsoap.org/wsdl/" xmlns:xs="http://www.w3.org/2001/XMLSchema"
+             xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/" xmlns:tns="http://example.com/illegal-gql-names/"
+             name="IllegalGqlNames" targetNamespace="http://example.com/illegal-gql-names/">
+  <types>
+    <xs:schema elementFormDefault="qualified" targetNamespace="http://example.com/illegal-gql-names/">
+      <xs:complexType name="X721.Type">
+        <xs:sequence>
+          <xs:element name="code" type="xs:string"/>
+        </xs:sequence>
+      </xs:complexType>
+      <xs:complexType name="My.ComplexType">
+        <xs:sequence>
+          <xs:element name="state" type="tns:X721.Type"/>
+          <xs:element name="response-data" type="xs:string"/>
+        </xs:sequence>
+      </xs:complexType>
+      <xs:element name="GetState">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="input" type="tns:My.ComplexType"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="GetStateResponse">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="result" type="tns:X721.Type"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:schema>
+  </types>
+  <message name="GetStateSoapRequest">
+    <part name="parameters" element="tns:GetState"/>
+  </message>
+  <message name="GetStateSoapResponse">
+    <part name="parameters" element="tns:GetStateResponse"/>
+  </message>
+  <portType name="IllegalGqlNamesSoapType">
+    <operation name="GetState">
+      <input message="tns:GetStateSoapRequest"/>
+      <output message="tns:GetStateSoapResponse"/>
+    </operation>
+  </portType>
+  <binding name="IllegalGqlNamesSoapBinding" type="tns:IllegalGqlNamesSoapType">
+    <soap:binding style="document" transport="http://schemas.xmlsoap.org/soap/http"/>
+    <operation name="GetState">
+      <soap:operation soapAction="" style="document"/>
+      <input>
+        <soap:body use="literal"/>
+      </input>
+      <output>
+        <soap:body use="literal"/>
+      </output>
+    </operation>
+  </binding>
+  <service name="IllegalGqlNames">
+    <port name="IllegalGqlNamesSoap" binding="tns:IllegalGqlNamesSoapBinding">
+      <soap:address location="http://example.com/illegal-gql-names/soap"/>
+    </port>
+  </service>
+</definitions>

--- a/packages/loaders/soap/test/fixtures/illegal-gql-names.wsdl
+++ b/packages/loaders/soap/test/fixtures/illegal-gql-names.wsdl
@@ -14,6 +14,15 @@
           <xs:element name="response-data" type="xs:string"/>
         </xs:sequence>
       </xs:complexType>
+      <xs:complexType name="Extended.Type">
+        <xs:complexContent>
+          <xs:extension base="tns:X721.Type">
+            <xs:sequence>
+              <xs:element name="extra-field" type="xs:string"/>
+            </xs:sequence>
+          </xs:extension>
+        </xs:complexContent>
+      </xs:complexType>
       <xs:element name="GetState">
         <xs:complexType>
           <xs:sequence>
@@ -25,6 +34,7 @@
         <xs:complexType>
           <xs:sequence>
             <xs:element name="result" type="tns:X721.Type"/>
+            <xs:element name="extended" type="tns:Extended.Type"/>
           </xs:sequence>
         </xs:complexType>
       </xs:element>


### PR DESCRIPTION
## Problem

XSD type names and element names can contain characters that are illegal in GraphQL (e.g. dots in `X721.AdministrativeStateType`, hyphens in `response-data`). GraphQL names must match `/^[_a-zA-Z][_a-zA-Z0-9]*$/`. When these names are used as-is for GraphQL type/field names, schema construction throws `Invalid type name`.

## Fix

Add a private helper to the loader:

```typescript
private toGQLName(name: string) {
  return name?.replace(/[^_a-zA-Z0-9]/g, '_') ?? name;
}
```

Apply it to all name derivation sites: `simpleTypeName`, `complexTypeName` (both input and output paths), and `fieldName` (all locations including the extension inheritance loop).

## Test

Added `illegal-gql-names` fixture with type names `X721.Type`, `My.ComplexType` (dots) and field name `response-data` (hyphen). Snapshot confirms they become `X721_Type`, `My_ComplexType`, and `response_data`.

## Related

Part of a series of SOAP loader fixes discovered while testing against a real-world TMForum MTOP WSDL.