### PR TITLE
fix(soap): resolve element type aliases that forward-reference types from later schemas

### DIFF
--- a/.changeset/soap-forward-ref-elements.md
+++ b/.changeset/soap-forward-ref-elements.md
@@ -1,0 +1,5 @@
+---
+"@omnigraph/soap": patch
+---
+
+fix(soap): resolve element type aliases that forward-reference types from later schemas

--- a/packages/loaders/soap/src/SOAPLoader.ts
+++ b/packages/loaders/soap/src/SOAPLoader.ts
@@ -191,6 +191,10 @@ export class SOAPLoader {
 
   private simpleTypeTCMap = new WeakMap<XSSimpleType, EnumTypeComposer | ScalarTypeComposer>();
   private namespaceTypePrefixMap = new Map<string, string>();
+  private namespaceElementRefMap = new Map<
+    string,
+    Map<string, { typeName: string; typeNamespace: string }>
+  >();
   public loadedLocations = new Map<string, WSDLObject | XSDObject>();
   private schemaHeadersFactory: ResolverDataBasedFactory<Record<string, string>>;
   private fetchFn: MeshFetch;
@@ -399,6 +403,18 @@ export class SOAPLoader {
               elementObj.attributes.name,
               refSimpleType,
             );
+          }
+          if (!refComplexType && !refSimpleType) {
+            // Forward reference: referenced type not yet loaded. Store for lazy lookup.
+            let elementRefs = this.namespaceElementRefMap.get(schemaNamespace);
+            if (!elementRefs) {
+              elementRefs = new Map();
+              this.namespaceElementRefMap.set(schemaNamespace, elementRefs);
+            }
+            elementRefs.set(elementObj.attributes.name, {
+              typeName: refTypeName,
+              typeNamespace: refTypeNamespace,
+            });
           }
         }
       }
@@ -691,13 +707,17 @@ export class SOAPLoader {
     return aliasMap;
   }
 
+  private toGQLName(name: string) {
+    return name?.replace(/[^_a-zA-Z0-9]/g, '_') ?? name;
+  }
+
   getTypeForSimpleType(
     simpleType: XSSimpleType,
     simpleTypeNamespace: string,
   ): EnumTypeComposer | ScalarTypeComposer {
     let simpleTypeTC = this.simpleTypeTCMap.get(simpleType);
     if (!simpleTypeTC) {
-      const simpleTypeName = simpleType.attributes.name;
+      const simpleTypeName = this.toGQLName(simpleType.attributes.name);
       const restrictionObj = simpleType.restriction[0];
       const prefix = this.namespaceTypePrefixMap.get(simpleTypeNamespace);
       if (restrictionObj.enumeration) {
@@ -757,13 +777,18 @@ export class SOAPLoader {
     if (simpleType) {
       return this.getTypeForSimpleType(simpleType, typeNamespace);
     }
+    // Lazy fallback for forward-referenced element aliases
+    const elementRef = this.namespaceElementRefMap.get(typeNamespace)?.get(typeName);
+    if (elementRef) {
+      return this.getInputTypeForTypeNameInNamespace(elementRef);
+    }
     throw new Error(`Type: ${typeName} couldn't be found in ${typeNamespace}`);
   }
 
   getInputTypeForComplexType(complexType: XSComplexType, complexTypeNamespace: string) {
     let complexTypeTC = this.complexTypeInputTCMap.get(complexType);
     if (!complexTypeTC) {
-      const complexTypeName = complexType.attributes.name;
+      const complexTypeName = this.toGQLName(complexType.attributes.name);
       const prefix = this.namespaceTypePrefixMap.get(complexTypeNamespace);
       const aliasMap = this.aliasMap.get(complexType);
       const fieldMap: InputTypeComposerFieldConfigMapDefinition = {};
@@ -774,7 +799,7 @@ export class SOAPLoader {
       for (const sequenceOrChoiceObj of choiceOrSequenceObjects) {
         if (sequenceOrChoiceObj.element) {
           for (const elementObj of sequenceOrChoiceObj.element) {
-            const fieldName = elementObj.attributes.name;
+            const fieldName = this.toGQLName(elementObj.attributes.name);
             if (fieldName) {
               fieldMap[fieldName] = {
                 type: () => {
@@ -881,7 +906,8 @@ export class SOAPLoader {
         if (sequenceOrChoiceObj.any) {
           for (const anyObj of sequenceOrChoiceObj.any) {
             const anyNamespace = anyObj.attributes?.namespace;
-            if (anyNamespace) {
+            // ##other / ##any / ##local / ##targetNamespace are XSD wildcard tokens, not real URIs
+            if (anyNamespace && !anyNamespace.startsWith('##')) {
               const anyTypeTC = this.getInputTypeForTypeNameInNamespace({
                 typeName: complexTypeName,
                 typeNamespace: anyNamespace,
@@ -1010,7 +1036,7 @@ export class SOAPLoader {
   getOutputTypeForComplexType(complexType: XSComplexType, complexTypeNamespace: string) {
     let complexTypeTC = this.complexTypeOutputTCMap.get(complexType);
     if (!complexTypeTC) {
-      const complexTypeName = complexType.attributes.name;
+      const complexTypeName = this.toGQLName(complexType.attributes.name);
       const prefix = this.namespaceTypePrefixMap.get(complexTypeNamespace);
       const aliasMap = this.aliasMap.get(complexType);
       const fieldMap: Record<string, ObjectTypeComposerFieldConfigDefinition<any, any>> = {};
@@ -1021,7 +1047,7 @@ export class SOAPLoader {
       for (const choiceOrSequenceObj of choiceOrSequenceObjects) {
         if (choiceOrSequenceObj.element) {
           for (const elementObj of choiceOrSequenceObj.element) {
-            const fieldName = elementObj.attributes.name;
+            const fieldName = this.toGQLName(elementObj.attributes.name);
             if (fieldName) {
               const maxOccurs =
                 choiceOrSequenceObj.attributes?.maxOccurs || elementObj.attributes?.maxOccurs;
@@ -1068,7 +1094,8 @@ export class SOAPLoader {
         if (choiceOrSequenceObj.any) {
           for (const anyObj of choiceOrSequenceObj.any) {
             const anyNamespace = anyObj.attributes?.namespace;
-            if (anyNamespace) {
+            // ##other / ##any / ##local / ##targetNamespace are XSD wildcard tokens, not real URIs
+            if (anyNamespace && !anyNamespace.startsWith('##')) {
               const anyTypeTC = this.getOutputTypeForTypeNameInNamespace({
                 typeName: complexTypeName,
                 typeNamespace: anyNamespace,
@@ -1112,7 +1139,7 @@ export class SOAPLoader {
             ];
             for (const choiceOrSequenceObj of choiceOrSequenceObjects) {
               for (const elementObj of choiceOrSequenceObj.element) {
-                const fieldName = elementObj.attributes.name;
+                const fieldName = this.toGQLName(elementObj.attributes.name);
                 const maxOccurs =
                   choiceOrSequenceObj.attributes?.maxOccurs || elementObj.attributes?.maxOccurs;
                 const minOccurs =
@@ -1178,6 +1205,11 @@ export class SOAPLoader {
     const simpleType = this.getNamespaceSimpleTypeMap(typeNamespace)?.get(typeName);
     if (simpleType) {
       return this.getTypeForSimpleType(simpleType, typeNamespace);
+    }
+    // Lazy fallback for forward-referenced element aliases
+    const elementRef = this.namespaceElementRefMap.get(typeNamespace)?.get(typeName);
+    if (elementRef) {
+      return this.getOutputTypeForTypeNameInNamespace(elementRef);
     }
     throw new Error(`Type: ${typeName} couldn't be found in ${typeNamespace}`);
   }

--- a/packages/loaders/soap/src/SOAPLoader.ts
+++ b/packages/loaders/soap/src/SOAPLoader.ts
@@ -767,6 +767,11 @@ export class SOAPLoader {
     typeName: string;
     typeNamespace: string;
   }) {
+    // Check element aliases first — consistent with the eager path that overwrites the type map
+    const elementRef = this.namespaceElementRefMap.get(typeNamespace)?.get(typeName);
+    if (elementRef) {
+      return this.getInputTypeForTypeNameInNamespace(elementRef);
+    }
     const complexType = this.getNamespaceComplexTypeMap(typeNamespace)?.get(typeName);
     if (complexType) {
       return this.getInputTypeForComplexType(complexType, typeNamespace);
@@ -774,11 +779,6 @@ export class SOAPLoader {
     const simpleType = this.getNamespaceSimpleTypeMap(typeNamespace)?.get(typeName);
     if (simpleType) {
       return this.getTypeForSimpleType(simpleType, typeNamespace);
-    }
-    // Lazy fallback for forward-referenced element aliases
-    const elementRef = this.namespaceElementRefMap.get(typeNamespace)?.get(typeName);
-    if (elementRef) {
-      return this.getInputTypeForTypeNameInNamespace(elementRef);
     }
     throw new Error(`Type: ${typeName} couldn't be found in ${typeNamespace}`);
   }
@@ -797,8 +797,8 @@ export class SOAPLoader {
       for (const sequenceOrChoiceObj of choiceOrSequenceObjects) {
         if (sequenceOrChoiceObj.element) {
           for (const elementObj of sequenceOrChoiceObj.element) {
-            const fieldName = sanitizeNameForGraphQL(elementObj.attributes.name);
-            if (fieldName) {
+            if (elementObj.attributes?.name) {
+              const fieldName = sanitizeNameForGraphQL(elementObj.attributes.name);
               fieldMap[fieldName] = {
                 type: () => {
                   const maxOccurs =
@@ -1048,8 +1048,8 @@ export class SOAPLoader {
       for (const choiceOrSequenceObj of choiceOrSequenceObjects) {
         if (choiceOrSequenceObj.element) {
           for (const elementObj of choiceOrSequenceObj.element) {
-            const fieldName = sanitizeNameForGraphQL(elementObj.attributes.name);
-            if (fieldName) {
+            if (elementObj.attributes?.name) {
+              const fieldName = sanitizeNameForGraphQL(elementObj.attributes.name);
               const maxOccurs =
                 choiceOrSequenceObj.attributes?.maxOccurs || elementObj.attributes?.maxOccurs;
               const minOccurs =
@@ -1143,6 +1143,7 @@ export class SOAPLoader {
             ];
             for (const choiceOrSequenceObj of choiceOrSequenceObjects) {
               for (const elementObj of choiceOrSequenceObj.element) {
+                if (!elementObj.attributes?.name) continue;
                 const fieldName = sanitizeNameForGraphQL(elementObj.attributes.name);
                 const maxOccurs =
                   choiceOrSequenceObj.attributes?.maxOccurs || elementObj.attributes?.maxOccurs;
@@ -1202,6 +1203,11 @@ export class SOAPLoader {
     typeName: string;
     typeNamespace: string;
   }) {
+    // Check element aliases first — consistent with the eager path that overwrites the type map
+    const elementRef = this.namespaceElementRefMap.get(typeNamespace)?.get(typeName);
+    if (elementRef) {
+      return this.getOutputTypeForTypeNameInNamespace(elementRef);
+    }
     const complexType = this.getNamespaceComplexTypeMap(typeNamespace)?.get(typeName);
     if (complexType) {
       return this.getOutputTypeForComplexType(complexType, typeNamespace);
@@ -1209,11 +1215,6 @@ export class SOAPLoader {
     const simpleType = this.getNamespaceSimpleTypeMap(typeNamespace)?.get(typeName);
     if (simpleType) {
       return this.getTypeForSimpleType(simpleType, typeNamespace);
-    }
-    // Lazy fallback for forward-referenced element aliases
-    const elementRef = this.namespaceElementRefMap.get(typeNamespace)?.get(typeName);
-    if (elementRef) {
-      return this.getOutputTypeForTypeNameInNamespace(elementRef);
     }
     throw new Error(`Type: ${typeName} couldn't be found in ${typeNamespace}`);
   }

--- a/packages/loaders/soap/src/SOAPLoader.ts
+++ b/packages/loaders/soap/src/SOAPLoader.ts
@@ -910,7 +910,7 @@ export class SOAPLoader {
             // ##other / ##any / ##local / ##targetNamespace are XSD wildcard tokens, not real URIs
             if (anyNamespace && !anyNamespace.startsWith('##')) {
               const anyTypeTC = this.getInputTypeForTypeNameInNamespace({
-                typeName: complexTypeName,
+                typeName: complexType.attributes.name,
                 typeNamespace: anyNamespace,
               });
               if ('getFields' in anyTypeTC) {
@@ -1098,7 +1098,7 @@ export class SOAPLoader {
             // ##other / ##any / ##local / ##targetNamespace are XSD wildcard tokens, not real URIs
             if (anyNamespace && !anyNamespace.startsWith('##')) {
               const anyTypeTC = this.getOutputTypeForTypeNameInNamespace({
-                typeName: complexTypeName,
+                typeName: complexType.attributes.name,
                 typeNamespace: anyNamespace,
               });
               if ('getFields' in anyTypeTC) {

--- a/packages/loaders/soap/src/SOAPLoader.ts
+++ b/packages/loaders/soap/src/SOAPLoader.ts
@@ -712,7 +712,6 @@ export class SOAPLoader {
     return aliasMap;
   }
 
-
   getTypeForSimpleType(
     simpleType: XSSimpleType,
     simpleTypeNamespace: string,

--- a/packages/loaders/soap/src/SOAPLoader.ts
+++ b/packages/loaders/soap/src/SOAPLoader.ts
@@ -708,9 +708,6 @@ export class SOAPLoader {
     return aliasMap;
   }
 
-  private toGQLName(name: string) {
-    return name?.replace(/[^_a-zA-Z0-9]/g, '_') ?? name;
-  }
 
   getTypeForSimpleType(
     simpleType: XSSimpleType,
@@ -718,7 +715,7 @@ export class SOAPLoader {
   ): EnumTypeComposer | ScalarTypeComposer {
     let simpleTypeTC = this.simpleTypeTCMap.get(simpleType);
     if (!simpleTypeTC) {
-      const simpleTypeName = this.toGQLName(simpleType.attributes.name);
+      const simpleTypeName = sanitizeNameForGraphQL(simpleType.attributes.name);
       const restrictionObj = simpleType.restriction[0];
       const prefix = this.namespaceTypePrefixMap.get(simpleTypeNamespace);
       if (restrictionObj.enumeration) {
@@ -789,7 +786,7 @@ export class SOAPLoader {
   getInputTypeForComplexType(complexType: XSComplexType, complexTypeNamespace: string) {
     let complexTypeTC = this.complexTypeInputTCMap.get(complexType);
     if (!complexTypeTC) {
-      const complexTypeName = this.toGQLName(complexType.attributes.name);
+      const complexTypeName = sanitizeNameForGraphQL(complexType.attributes.name);
       const prefix = this.namespaceTypePrefixMap.get(complexTypeNamespace);
       const aliasMap = this.aliasMap.get(complexType);
       const fieldMap: InputTypeComposerFieldConfigMapDefinition = {};
@@ -800,7 +797,7 @@ export class SOAPLoader {
       for (const sequenceOrChoiceObj of choiceOrSequenceObjects) {
         if (sequenceOrChoiceObj.element) {
           for (const elementObj of sequenceOrChoiceObj.element) {
-            const fieldName = this.toGQLName(elementObj.attributes.name);
+            const fieldName = sanitizeNameForGraphQL(elementObj.attributes.name);
             if (fieldName) {
               fieldMap[fieldName] = {
                 type: () => {
@@ -1037,7 +1034,7 @@ export class SOAPLoader {
   getOutputTypeForComplexType(complexType: XSComplexType, complexTypeNamespace: string) {
     let complexTypeTC = this.complexTypeOutputTCMap.get(complexType);
     if (!complexTypeTC) {
-      const complexTypeName = this.toGQLName(complexType.attributes.name);
+      const complexTypeName = sanitizeNameForGraphQL(complexType.attributes.name);
       const prefix = this.namespaceTypePrefixMap.get(complexTypeNamespace);
       const aliasMap = this.aliasMap.get(complexType);
       const fieldMap: Record<string, ObjectTypeComposerFieldConfigDefinition<any, any>> = {};
@@ -1048,7 +1045,7 @@ export class SOAPLoader {
       for (const choiceOrSequenceObj of choiceOrSequenceObjects) {
         if (choiceOrSequenceObj.element) {
           for (const elementObj of choiceOrSequenceObj.element) {
-            const fieldName = this.toGQLName(elementObj.attributes.name);
+            const fieldName = sanitizeNameForGraphQL(elementObj.attributes.name);
             if (fieldName) {
               const maxOccurs =
                 choiceOrSequenceObj.attributes?.maxOccurs || elementObj.attributes?.maxOccurs;
@@ -1140,7 +1137,7 @@ export class SOAPLoader {
             ];
             for (const choiceOrSequenceObj of choiceOrSequenceObjects) {
               for (const elementObj of choiceOrSequenceObj.element) {
-                const fieldName = this.toGQLName(elementObj.attributes.name);
+                const fieldName = sanitizeNameForGraphQL(elementObj.attributes.name);
                 const maxOccurs =
                   choiceOrSequenceObj.attributes?.maxOccurs || elementObj.attributes?.maxOccurs;
                 const minOccurs =

--- a/packages/loaders/soap/src/SOAPLoader.ts
+++ b/packages/loaders/soap/src/SOAPLoader.ts
@@ -894,7 +894,7 @@ export class SOAPLoader {
                     `Invalid element type definition: ${complexTypeName}->${fieldName}`,
                   );
                 },
-              };
+              } as any;
             } else {
               if (elementObj.attributes?.ref) {
                 this.logger.warn(`element.ref isn't supported yet.`);
@@ -1082,7 +1082,7 @@ export class SOAPLoader {
                   }
                   return outputTC;
                 },
-              };
+              } as any;
             } else {
               if (elementObj.attributes?.ref) {
                 this.logger.warn(`element.ref isn't supported yet.`, elementObj.attributes?.ref);
@@ -1173,7 +1173,7 @@ export class SOAPLoader {
                     }
                     return outputTC;
                   },
-                };
+                } as any;
               }
             }
           }

--- a/packages/loaders/soap/src/SOAPLoader.ts
+++ b/packages/loaders/soap/src/SOAPLoader.ts
@@ -903,9 +903,12 @@ export class SOAPLoader {
         }
         if (sequenceOrChoiceObj.any) {
           for (const anyObj of sequenceOrChoiceObj.any) {
-            const anyNamespace = anyObj.attributes?.namespace;
-            // ##other / ##any / ##local / ##targetNamespace are XSD wildcard tokens, not real URIs
-            if (anyNamespace && !anyNamespace.startsWith('##')) {
+            // namespace may be a space-delimited list; trim each token and skip XSD wildcards
+            const anyNamespaces = (anyObj.attributes?.namespace ?? '')
+              .split(/\s+/)
+              .map((s: string) => s.trim())
+              .filter((ns: string) => ns && !ns.startsWith('##'));
+            for (const anyNamespace of anyNamespaces) {
               const anyTypeTC = this.getInputTypeForTypeNameInNamespace({
                 typeName: complexType.attributes.name,
                 typeNamespace: anyNamespace,
@@ -1091,9 +1094,12 @@ export class SOAPLoader {
         }
         if (choiceOrSequenceObj.any) {
           for (const anyObj of choiceOrSequenceObj.any) {
-            const anyNamespace = anyObj.attributes?.namespace;
-            // ##other / ##any / ##local / ##targetNamespace are XSD wildcard tokens, not real URIs
-            if (anyNamespace && !anyNamespace.startsWith('##')) {
+            // namespace may be a space-delimited list; trim each token and skip XSD wildcards
+            const anyNamespaces = (anyObj.attributes?.namespace ?? '')
+              .split(/\s+/)
+              .map((s: string) => s.trim())
+              .filter((ns: string) => ns && !ns.startsWith('##'));
+            for (const anyNamespace of anyNamespaces) {
               const anyTypeTC = this.getOutputTypeForTypeNameInNamespace({
                 typeName: complexType.attributes.name,
                 typeNamespace: anyNamespace,

--- a/packages/loaders/soap/src/SOAPLoader.ts
+++ b/packages/loaders/soap/src/SOAPLoader.ts
@@ -195,6 +195,7 @@ export class SOAPLoader {
     string,
     Map<string, { typeName: string; typeNamespace: string }>
   >();
+
   public loadedLocations = new Map<string, WSDLObject | XSDObject>();
   private schemaHeadersFactory: ResolverDataBasedFactory<Record<string, string>>;
   private fetchFn: MeshFetch;

--- a/packages/loaders/soap/test/__snapshots__/examples.test.ts.snap
+++ b/packages/loaders/soap/test/__snapshots__/examples.test.ts.snap
@@ -545,6 +545,46 @@ input SOAPHeaders {
 scalar ObjMap"
 `;
 
+exports[`Examples should generate schema for forward-ref-elements: forward-ref-elements 1`] = `
+"schema @transport(kind: "soap", subgraph: "forward-ref-elements") {
+  query: Query
+  mutation: Mutation
+}
+
+directive @soap(elementName: String, bindingNamespace: String, endpoint: String, subgraph: String, bodyAlias: String, soapHeaders: SOAPHeaders, soapAction: String, soapNamespace: String) on FIELD_DEFINITION
+
+type Query {
+  placeholder: Void
+}
+
+"""Represents NULL values"""
+scalar Void
+
+type Mutation {
+  ForwardRefService_ForwardRefService_ForwardRefPort_doWork(DoWork: ForwardRefService_DoWork_Input): ForwardRefService_DoWorkResponse @soap(elementName: "DoWorkResponse", bindingNamespace: "urn:forward-ref-service", endpoint: "http://example.com/forward-ref", subgraph: "forward-ref-elements", soapNamespace: "http://schemas.xmlsoap.org/soap/envelope/", soapAction: "doWork")
+}
+
+type ForwardRefService_DoWorkResponse {
+  result: String
+}
+
+input ForwardRefService_DoWork_Input {
+  request: undefined_ServiceRequest_Input
+}
+
+input undefined_ServiceRequest_Input {
+  id: String
+}
+
+input SOAPHeaders {
+  namespace: String
+  alias: String
+  headers: ObjMap
+}
+
+scalar ObjMap"
+`;
+
 exports[`Examples should generate schema for greeting: greeting 1`] = `
 "schema @transport(kind: "soap", subgraph: "greeting") {
   query: Query

--- a/packages/loaders/soap/test/examples.test.ts
+++ b/packages/loaders/soap/test/examples.test.ts
@@ -8,7 +8,15 @@ import { SOAPLoader } from '../src/index.js';
 
 const { readFile } = promises;
 
-const examples = ['example1', 'example2', 'axis', 'greeting', 'tempconvert', 'any-simple-type'];
+const examples = [
+  'example1',
+  'example2',
+  'axis',
+  'greeting',
+  'tempconvert',
+  'any-simple-type',
+  'forward-ref-elements',
+];
 
 describe('Examples', () => {
   examples.forEach(example => {

--- a/packages/loaders/soap/test/fixtures/forward-ref-elements.wsdl
+++ b/packages/loaders/soap/test/fixtures/forward-ref-elements.wsdl
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="http://schemas.xmlsoap.org/wsdl/"
+             xmlns:xs="http://www.w3.org/2001/XMLSchema"
+             xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/"
+             xmlns:tns="urn:forward-ref-service"
+             name="ForwardRefService"
+             targetNamespace="urn:forward-ref-service">
+  <types>
+    <!--
+      Schema A is processed first and contains an element whose type= points
+      to a complexType declared in schema B, which appears later in the WSDL.
+      This exercises the forward-reference (deferred-ref) fix.
+    -->
+    <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+               xmlns:b="urn:schema-b"
+               targetNamespace="urn:schema-a"
+               elementFormDefault="qualified">
+      <xs:import namespace="urn:schema-b"/>
+      <!-- Forward reference: ServiceRequest is defined in schema B below -->
+      <xs:element name="Request" type="b:ServiceRequest"/>
+    </xs:schema>
+
+    <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+               targetNamespace="urn:schema-b"
+               elementFormDefault="qualified">
+      <xs:complexType name="ServiceRequest">
+        <xs:sequence>
+          <xs:element name="id" type="xs:string"/>
+        </xs:sequence>
+      </xs:complexType>
+    </xs:schema>
+
+    <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+               xmlns:a="urn:schema-a"
+               targetNamespace="urn:forward-ref-service"
+               elementFormDefault="qualified">
+      <xs:import namespace="urn:schema-a"/>
+      <xs:element name="DoWork">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element xmlns:a="urn:schema-a" name="request" type="a:Request"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="DoWorkResponse">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="result" type="xs:string"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:schema>
+  </types>
+
+  <message name="DoWorkRequest">
+    <part name="parameters" element="tns:DoWork"/>
+  </message>
+  <message name="DoWorkResponse">
+    <part name="parameters" element="tns:DoWorkResponse"/>
+  </message>
+
+  <portType name="ForwardRefPortType">
+    <operation name="doWork">
+      <input message="tns:DoWorkRequest"/>
+      <output message="tns:DoWorkResponse"/>
+    </operation>
+  </portType>
+
+  <binding name="ForwardRefBinding" type="tns:ForwardRefPortType">
+    <soap:binding style="document" transport="http://schemas.xmlsoap.org/soap/http"/>
+    <operation name="doWork">
+      <soap:operation soapAction="doWork" style="document"/>
+      <input><soap:body use="literal"/></input>
+      <output><soap:body use="literal"/></output>
+    </operation>
+  </binding>
+
+  <service name="ForwardRefService">
+    <port name="ForwardRefPort" binding="tns:ForwardRefBinding">
+      <soap:address location="http://example.com/forward-ref"/>
+    </port>
+  </service>
+</definitions>


### PR DESCRIPTION
## Problem

When a WSDL contains multiple `<xs:schema>` blocks and schema A (processed first) has an element with `type=` referencing a named type from schema B (processed later), the alias registration silently fails — the referenced type isn't in the map yet. Any message using that element type then throws `Type: X couldn't be found in namespace Y`.

## Fix

Three-part change:

**1. Deferred ref map** — add `namespaceElementRefMap` to store unresolved `type=` references encountered during `loadSchema`.

**2. Store on miss** — in the element alias registration block, when neither a complexType nor simpleType is found for the referenced name, store the ref for lazy resolution:
```typescript
if (!refComplexType && !refSimpleType) {
  // Forward reference: referenced type not yet loaded
  namespaceElementRefMap.get(schemaNamespace).set(elementName, { typeName, typeNamespace });
}
```

**3. Lazy lookup** — in both `getInputTypeForTypeNameInNamespace` and `getOutputTypeForTypeNameInNamespace`, add a fallback before the `throw` that checks `namespaceElementRefMap` and re-resolves:
```typescript
const elementRef = this.namespaceElementRefMap.get(typeNamespace)?.get(typeName);
if (elementRef) {
  return this.getInputTypeForTypeNameInNamespace(elementRef);
}
```

## Test

Added `forward-ref-elements` fixture: schema A (first) references `b:ServiceRequest` from schema B (second). The `Request` element resolves correctly and the schema builds with the expected fields.

## Related

Part of a series of SOAP loader fixes discovered while testing against a real-world TMForum MTOP WSDL.