### PR TITLE
fix(transport/rest): handle string interpolation correctly for `DateTime` input values

### DIFF
--- a/.changeset/wicked-eyes-raise.md
+++ b/.changeset/wicked-eyes-raise.md
@@ -1,0 +1,5 @@
+---
+'@graphql-mesh/transport-rest': patch
+---
+
+Handle DateTime values correctly in string interpolation on HTTP headers and URI paths

--- a/packages/loaders/openapi/tests/date-in-header.test.ts
+++ b/packages/loaders/openapi/tests/date-in-header.test.ts
@@ -1,0 +1,76 @@
+import { execute, parse, validate } from 'graphql';
+import { Headers, Response, URL } from '@whatwg-node/fetch';
+import loadGraphQLSchemaFromOpenAPI from '../src';
+
+describe('Date parameter in header and path', () => {
+  it('succeeds', async () => {
+    const schema = await loadGraphQLSchemaFromOpenAPI('test', {
+      source: './fixtures/date-params.yaml',
+      endpoint: 'http://localhost:3000',
+      fetch(url, options) {
+        const urlObj = new URL(url);
+        const path = urlObj.pathname;
+        const body = options?.body ? JSON.parse(options.body.toString()) : null;
+        const dateInPathVariable = path.split('/')[3];
+        const headers = new Headers(options?.headers);
+        return Response.json({
+          success: true,
+          pathDate: dateInPathVariable,
+          headerDate: headers.get('request-date'),
+          bodyDate: body?.eventDate,
+          eventName: body?.eventName,
+        });
+      },
+      cwd: __dirname,
+    });
+    const document = parse(/* GraphQL */ `
+      mutation TestDateTime(
+        $eventName: String!
+        $eventDate: DateTime!
+        $dateInPathVariable: DateTime!
+        $requestDate: DateTime!
+      ) {
+        testDateTime(
+          input: { eventName: $eventName, eventDate: $eventDate }
+          dateInPathVariable: $dateInPathVariable
+          request_date: $requestDate
+        ) {
+          ... on testDateTime_200_response {
+            success
+            pathDate
+            headerDate
+            bodyDate
+            eventName
+          }
+        }
+      }
+    `);
+    const eventName = 'Test Event';
+    const eventDate = new Date('2024-01-01T00:00:00Z');
+    const dateInPathVariable = new Date('2024-01-02T00:00:00Z');
+    const requestDate = new Date('2024-01-03T00:00:00Z');
+    const validation = validate(schema, document);
+    expect(validation).toEqual([]);
+    const result = await execute({
+      document,
+      schema,
+      variableValues: {
+        eventName,
+        eventDate,
+        dateInPathVariable,
+        requestDate,
+      },
+    });
+    expect(result).toEqual({
+      data: {
+        testDateTime: {
+          success: true,
+          pathDate: dateInPathVariable,
+          headerDate: requestDate,
+          bodyDate: eventDate,
+          eventName,
+        },
+      },
+    });
+  });
+});

--- a/packages/loaders/openapi/tests/fixtures/date-params.yaml
+++ b/packages/loaders/openapi/tests/fixtures/date-params.yaml
@@ -19,7 +19,7 @@ paths:
           schema:
             type: string
             format: date-time
-            example: "2023-12-31T23:59:59.000Z"
+            example: '2023-12-31T23:59:59.000Z'
           description: Date passed as path variable (ISO 8601 format)
         - name: request-date
           in: header
@@ -27,7 +27,7 @@ paths:
           schema:
             type: string
             format: date-time
-            example: "2023-12-31T23:59:59.000Z"
+            example: '2023-12-31T23:59:59.000Z'
           description: Date passed in request header (ISO 8601 format)
       requestBody:
         required: true
@@ -39,15 +39,15 @@ paths:
                 eventDate:
                   type: string
                   format: date-time
-                  example: "2023-12-31T23:59:59.000Z"
+                  example: '2023-12-31T23:59:59.000Z'
                   description: Date of the event
                 eventName:
                   type: string
-                  example: "Sample Event"
+                  example: 'Sample Event'
                   description: Name of the event
                 eventDescription:
                   type: string
-                  example: "This is a sample event"
+                  example: 'This is a sample event'
                   description: Description of the event
               required:
                 - eventDate
@@ -65,22 +65,22 @@ paths:
                     example: true
                   message:
                     type: string
-                    example: "Date processed successfully"
+                    example: 'Date processed successfully'
                   pathDate:
                     type: string
                     format: date-time
-                    example: "2023-12-31T23:59:59.000Z"
+                    example: '2023-12-31T23:59:59.000Z'
                   headerDate:
                     type: string
                     format: date-time
-                    example: "2023-12-31T23:59:59.000Z"
+                    example: '2023-12-31T23:59:59.000Z'
                   bodyDate:
                     type: string
                     format: date-time
-                    example: "2023-12-31T23:59:59.000Z"
+                    example: '2023-12-31T23:59:59.000Z'
                   eventName:
                     type: string
-                    example: "Sample Event"
+                    example: 'Sample Event'
         '400':
           description: Bad request - invalid date format or missing required fields
           content:
@@ -93,7 +93,7 @@ paths:
                     example: false
                   error:
                     type: string
-                    example: "Invalid date format"
+                    example: 'Invalid date format'
         '500':
           description: Internal server error
           content:
@@ -106,4 +106,4 @@ paths:
                     example: false
                   error:
                     type: string
-                    example: "Internal server error"
+                    example: 'Internal server error'

--- a/packages/loaders/openapi/tests/fixtures/date-params.yaml
+++ b/packages/loaders/openapi/tests/fixtures/date-params.yaml
@@ -1,0 +1,109 @@
+openapi: 3.0.0
+info:
+  title: Test Date API
+  version: 1.0.0
+  description: API with date handling in header, path variable, and body
+servers:
+  - url: http://localhost:3000
+    description: Development server
+paths:
+  /api/test-date-time/{dateInPathVariable}:
+    post:
+      operationId: testDateTime
+      summary: Process test date
+      description: Endpoint that accepts date in path variable, header, and request body
+      parameters:
+        - name: dateInPathVariable
+          in: path
+          required: true
+          schema:
+            type: string
+            format: date-time
+            example: "2023-12-31T23:59:59.000Z"
+          description: Date passed as path variable (ISO 8601 format)
+        - name: request-date
+          in: header
+          required: true
+          schema:
+            type: string
+            format: date-time
+            example: "2023-12-31T23:59:59.000Z"
+          description: Date passed in request header (ISO 8601 format)
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                eventDate:
+                  type: string
+                  format: date-time
+                  example: "2023-12-31T23:59:59.000Z"
+                  description: Date of the event
+                eventName:
+                  type: string
+                  example: "Sample Event"
+                  description: Name of the event
+                eventDescription:
+                  type: string
+                  example: "This is a sample event"
+                  description: Description of the event
+              required:
+                - eventDate
+                - eventName
+      responses:
+        '200':
+          description: Successfully processed the date
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    example: true
+                  message:
+                    type: string
+                    example: "Date processed successfully"
+                  pathDate:
+                    type: string
+                    format: date-time
+                    example: "2023-12-31T23:59:59.000Z"
+                  headerDate:
+                    type: string
+                    format: date-time
+                    example: "2023-12-31T23:59:59.000Z"
+                  bodyDate:
+                    type: string
+                    format: date-time
+                    example: "2023-12-31T23:59:59.000Z"
+                  eventName:
+                    type: string
+                    example: "Sample Event"
+        '400':
+          description: Bad request - invalid date format or missing required fields
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    example: false
+                  error:
+                    type: string
+                    example: "Invalid date format"
+        '500':
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    example: false
+                  error:
+                    type: string
+                    example: "Internal server error"

--- a/packages/transports/rest/src/directives/httpOperation.ts
+++ b/packages/transports/rest/src/directives/httpOperation.ts
@@ -19,6 +19,7 @@ import { Blob, fetch as defaultFetch, File, FormData, URLSearchParams } from '@w
 import { isFileUpload } from './isFileUpload.js';
 import { getJsonApiFieldsQuery } from './jsonApiFields.js';
 import { resolveDataByUnionInputType } from './resolveDataByUnionInputType.js';
+import { serializeArgumentsForInterpolation } from './utils.js';
 
 type HTTPMethod =
   | 'GET'
@@ -125,7 +126,18 @@ export function addHTTPRootFieldResolver(
       operation: `${info.parentType.name}.${info.fieldName}`,
     });
     operationLogger.debug(`Resolving`);
-    const interpolationData = { root, args, context, env: process.env };
+    // Args should be serialized with their scalars
+    const argsSerializeProxy = new Proxy(args, {
+      get(args, argName) {
+        const value = args[argName];
+        const argDef = field.args?.find(arg => arg.name === argName.toString());
+        if (argDef) {
+          return serializeArgumentsForInterpolation(value, argDef.type);
+        }
+        return value;
+      },
+    });
+    const interpolationData = { root, args: argsSerializeProxy, context, env: process.env };
     const interpolatedBaseUrl = stringInterpolator.parse(endpoint, interpolationData) || '';
     const interpolatedPath = stringInterpolator.parse(path, interpolationData) || '';
     let fullPath = urlJoin(interpolatedBaseUrl, interpolatedPath);

--- a/packages/transports/rest/src/directives/utils.ts
+++ b/packages/transports/rest/src/directives/utils.ts
@@ -1,9 +1,8 @@
-import type { ASTNode, ConstDirectiveNode, GraphQLArgument, GraphQLInputType } from 'graphql';
+import type { ASTNode, ConstDirectiveNode, GraphQLInputType } from 'graphql';
 import {
   isInputObjectType,
   isListType,
   isNonNullType,
-  isObjectType,
   isScalarType,
   valueFromASTUntyped,
 } from 'graphql';

--- a/packages/transports/rest/src/directives/utils.ts
+++ b/packages/transports/rest/src/directives/utils.ts
@@ -1,6 +1,13 @@
-import type { ASTNode, ConstDirectiveNode } from 'graphql';
-import { valueFromASTUntyped } from 'graphql';
-import type { DirectiveAnnotation } from '@graphql-tools/utils';
+import type { ASTNode, ConstDirectiveNode, GraphQLArgument, GraphQLInputType } from 'graphql';
+import {
+  isInputObjectType,
+  isListType,
+  isNonNullType,
+  isObjectType,
+  isScalarType,
+  valueFromASTUntyped,
+} from 'graphql';
+import { asArray, type DirectiveAnnotation } from '@graphql-tools/utils';
 
 export function getDirectiveAnnotations(directableObj: {
   astNode?: ASTNode & { directives?: readonly ConstDirectiveNode[] };
@@ -33,4 +40,38 @@ export function getDirectiveAnnotations(directableObj: {
   }
 
   return directiveAnnotations;
+}
+
+function normalizeArgValueForInterpolation(argValue: any): any {
+  if (argValue instanceof Date) {
+    return argValue.toJSON();
+  }
+  return argValue;
+}
+
+export function serializeArgumentsForInterpolation(argValue: any, argType: GraphQLInputType) {
+  if (isScalarType(argType)) {
+    try {
+      return normalizeArgValueForInterpolation(argType.serialize(argValue));
+    } catch (e) {
+      return normalizeArgValueForInterpolation(argValue);
+    }
+  } else if (isListType(argType)) {
+    return asArray(argValue).map(item => serializeArgumentsForInterpolation(item, argType.ofType));
+  } else if (isInputObjectType(argType)) {
+    const serializedObj: Record<string, any> = {};
+    const argTypeFields = argType.getFields();
+    for (const fieldName in argValue) {
+      const fieldValue = argValue[fieldName];
+      const fieldType = argTypeFields[fieldName]?.type;
+      if (fieldType) {
+        serializedObj[fieldName] = serializeArgumentsForInterpolation(fieldValue, fieldType);
+      }
+    }
+    return serializedObj;
+  } else if (isNonNullType(argType)) {
+    return serializeArgumentsForInterpolation(argValue, argType.ofType);
+  }
+
+  return normalizeArgValueForInterpolation(argValue);
 }

--- a/packages/transports/rest/src/directives/utils.ts
+++ b/packages/transports/rest/src/directives/utils.ts
@@ -49,6 +49,9 @@ function normalizeArgValueForInterpolation(argValue: any): any {
 }
 
 export function serializeArgumentsForInterpolation(argValue: any, argType: GraphQLInputType) {
+  if (argValue == null) {
+    return argValue;
+  }
   if (isScalarType(argType)) {
     try {
       return normalizeArgValueForInterpolation(argType.serialize(argValue));


### PR DESCRIPTION
If you have an input value that is used as part of a URL like `/api/sth/{myParam}` or part of an HTTP header, it should be correctly serialized.
Today DateTime was serialized with `Date.toString()` which is not in ISO format, and this was unintended. This PR fixes that issue.

Closes https://github.com/graphql-hive/gateway/discussions/2268#discussion-9907692