### PR TITLE
fix(composition): do not mark `Mutation` inaccessible even if all mutation fields are

### DIFF
--- a/.changeset/new-rocks-hide.md
+++ b/.changeset/new-rocks-hide.md
@@ -1,0 +1,6 @@
+---
+'@graphql-mesh/fusion-composition': patch
+---
+
+Do not filter root types if they don't have any fields accessible. Previously filtering all Mutation fields would make the Mutation type inaccessible, which is not the intended behavior. Root types should only be filtered if they are explicitly marked as inaccessible or if they have no fields and are not root types.
+In that case when Mutation is marked inaccessible, all the other subgraphs' Mutation fields are also marked inaccessible. Now Mutation is not marked inaccessible, but all the fields are marked inaccessible, which is the intended behavior.

--- a/.changeset/new-rocks-hide.md
+++ b/.changeset/new-rocks-hide.md
@@ -2,5 +2,5 @@
 '@graphql-mesh/fusion-composition': patch
 ---
 
-Do not filter root types if they don't have any fields accessible. Previously filtering all Mutation fields would make the Mutation type inaccessible, which is not the intended behavior. Root types should only be filtered if they are explicitly marked as inaccessible or if they have no fields and are not root types.
-In that case when Mutation is marked inaccessible, all the other subgraphs' Mutation fields are also marked inaccessible. Now Mutation is not marked inaccessible, but all the fields are marked inaccessible, which is the intended behavior.
+Do not mark root types inaccessible solely because all of their fields were filtered out. Previously, filtering all `Mutation` fields also made the `Mutation` type inaccessible, which was unintended.
+Now, root types are only marked inaccessible when explicitly marked as such. If all `Mutation` fields are filtered, the `Mutation` type remains accessible while those fields are marked inaccessible.

--- a/e2e/auto-type-merging/mesh.config.ts
+++ b/e2e/auto-type-merging/mesh.config.ts
@@ -22,6 +22,7 @@ export const composeConfig = defineConfig({
         createFilterTransform({
           rootFieldFilter: (typeName, fieldName) =>
             typeName === 'Query' && fieldName === 'getPetById',
+          typeFilter: type => type.name !== 'Mutation',
         }),
       ],
     },

--- a/e2e/inaccessible-all-mutations/__snapshots__/inaccessible-all-mutations.test.ts.snap
+++ b/e2e/inaccessible-all-mutations/__snapshots__/inaccessible-all-mutations.test.ts.snap
@@ -1,0 +1,121 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`Inaccessible All Mutations should compose the appropriate schema 1`] = `
+"schema
+    @link(url: "https://specs.apollo.dev/link/v1.0")
+    @link(url: "https://specs.apollo.dev/join/v0.3", for: EXECUTION)
+    
+    
+    @link(url: "https://specs.apollo.dev/inaccessible/v0.2", for: SECURITY)
+    
+    
+    
+    @link(url: "https://the-guild.dev/graphql/mesh/spec/v1.0", import: ["@source"]) 
+  {
+    query: Query
+    mutation: Mutation
+    
+  }
+
+  
+    directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
+
+    directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+    
+      directive @join__field(
+        graph: join__Graph
+        requires: join__FieldSet
+        provides: join__FieldSet
+        type: String
+        external: Boolean
+        override: String
+        usedOverridden: Boolean
+        
+        
+      ) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+    
+    
+
+    directive @join__implements(
+      graph: join__Graph!
+      interface: String!
+    ) repeatable on OBJECT | INTERFACE
+
+    directive @join__type(
+      graph: join__Graph!
+      key: join__FieldSet
+      extension: Boolean! = false
+      resolvable: Boolean! = true
+      isInterfaceObject: Boolean! = false
+    ) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+
+    directive @join__unionMember(
+      graph: join__Graph!
+      member: String!
+    ) repeatable on UNION
+
+    scalar join__FieldSet
+    
+  
+  
+  directive @link(
+    url: String
+    as: String
+    for: link__Purpose
+    import: [link__Import]
+  ) repeatable on SCHEMA
+
+  scalar link__Import
+
+  enum link__Purpose {
+    """
+    \`SECURITY\` features provide metadata necessary to securely resolve fields.
+    """
+    SECURITY
+
+    """
+    \`EXECUTION\` features provide metadata necessary for operation execution.
+    """
+    EXECUTION
+  }
+
+  
+  
+  
+  directive @inaccessible on FIELD_DEFINITION | OBJECT | INTERFACE | UNION | ENUM | ENUM_VALUE | SCALAR | INPUT_OBJECT | INPUT_FIELD_DEFINITION | ARGUMENT_DEFINITION
+
+  
+  
+  
+  
+enum join__Graph {
+  SERVICE_A @join__graph(name: "service-a", url: "http://localhost:<service-a_port>/graphql") 
+  SERVICE_B @join__graph(name: "service-b", url: "http://localhost:<service-b_port>/graphql") 
+}
+
+directive @source(name: String!, type: String, subgraph: String!)  repeatable on SCALAR | OBJECT | FIELD_DEFINITION | ARGUMENT_DEFINITION | INTERFACE | UNION | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
+
+scalar TransportOptions @join__type(graph: SERVICE_A)  @join__type(graph: SERVICE_B) 
+
+type Query @join__type(graph: SERVICE_A)  @join__type(graph: SERVICE_B)  {
+  todos: [Todo!]! @join__field(graph: SERVICE_A) 
+  users: [User!]! @join__field(graph: SERVICE_B) 
+}
+
+type Todo @join__type(graph: SERVICE_A)  {
+  id: ID!
+  title: String!
+}
+
+type Mutation @join__type(graph: SERVICE_A)  @join__type(graph: SERVICE_B)  {
+  createTodo(title: String!) : Todo! @join__field(graph: SERVICE_A) 
+  addUser(name: String!) : User! @join__field(graph: SERVICE_B)  @inaccessible
+}
+
+type User @join__type(graph: SERVICE_B)  {
+  id: ID!
+  name: String!
+}
+"
+`;

--- a/e2e/inaccessible-all-mutations/inaccessible-all-mutations.test.ts
+++ b/e2e/inaccessible-all-mutations/inaccessible-all-mutations.test.ts
@@ -1,0 +1,69 @@
+import { createTenv, type Service } from '@e2e/tenv';
+
+describe('Inaccessible All Mutations', () => {
+  // Check only service-b mutations  are filtered and service-a mutations are accessible
+
+  const { compose, serve, service, fs } = createTenv(__dirname);
+
+  let serviceA: Service;
+  let serviceB: Service;
+
+  beforeAll(async () => {
+    serviceA = await service('service-a');
+    serviceB = await service('service-b');
+  });
+
+  it('should compose the appropriate schema', async () => {
+    const { result } = await compose({
+      services: [serviceA, serviceB],
+      maskServicePorts: true,
+    });
+    expect(result).toMatchSnapshot();
+  });
+
+  it('should execute the accessible mutations', async () => {
+    const { output } = await compose({ output: 'graphql', services: [serviceA, serviceB] });
+
+    const { execute } = await serve({ supergraph: output });
+    await expect(
+      execute({
+        query: /* GraphQL */ `
+          mutation {
+            createTodo(title: "Test") {
+              id
+              title
+            }
+          }
+        `,
+      }),
+    ).resolves.toEqual({
+      data: {
+        createTodo: {
+          id: '3',
+          title: 'Test',
+        },
+      },
+    });
+  });
+
+  it('should not execute the inaccessible mutations', async () => {
+    const { output } = await compose({ output: 'graphql', services: [serviceA, serviceB] });
+
+    const { execute } = await serve({ supergraph: output });
+    await expect(
+      execute({
+        query: /* GraphQL */ `
+          mutation {
+            addUser(name: "Test") {
+              id
+              name
+            }
+          }
+        `,
+      }),
+    ).rejects.toThrowErrorMatchingInlineSnapshot(`
+"400 Bad Request
+{"errors":[{"message":"Cannot query field \\"addUser\\" on type \\"Mutation\\".","locations":[{"line":3,"column":13}],"extensions":{"code":"GRAPHQL_VALIDATION_FAILED"}}]}"
+`);
+  });
+});

--- a/e2e/inaccessible-all-mutations/mesh.config.ts
+++ b/e2e/inaccessible-all-mutations/mesh.config.ts
@@ -1,0 +1,33 @@
+import { Opts } from '@e2e/opts';
+import {
+  createFilterTransform,
+  defineConfig,
+  loadGraphQLHTTPSubgraph,
+} from '@graphql-mesh/compose-cli';
+
+const opts = Opts(process.argv);
+
+export const composeConfig = defineConfig({
+  subgraphs: [
+    {
+      sourceHandler: loadGraphQLHTTPSubgraph('service-a', {
+        endpoint: `http://localhost:${opts.getServicePort('service-a')}/graphql`,
+      }),
+    },
+    {
+      sourceHandler: loadGraphQLHTTPSubgraph('service-b', {
+        endpoint: `http://localhost:${opts.getServicePort('service-b')}/graphql`,
+      }),
+      transforms: [
+        createFilterTransform({
+          rootFieldFilter(typeName) {
+            if (typeName === 'Mutation') {
+              return false;
+            }
+            return true;
+          },
+        }),
+      ],
+    },
+  ],
+});

--- a/e2e/inaccessible-all-mutations/package.json
+++ b/e2e/inaccessible-all-mutations/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@e2e/hoist-and-prefix-transform",
+  "name": "@e2e/inaccessible-all-mutations",
   "type": "module",
   "private": true,
   "dependencies": {

--- a/e2e/inaccessible-all-mutations/services/service-a.ts
+++ b/e2e/inaccessible-all-mutations/services/service-a.ts
@@ -1,0 +1,44 @@
+import { createServer } from 'http';
+import { createSchema, createYoga } from 'graphql-yoga';
+import { Opts } from '@e2e/opts';
+
+const opts = Opts(process.argv);
+
+const todos = [
+  { id: '1', title: 'Buy milk' },
+  { id: '2', title: 'Walk the dog' },
+];
+
+createServer(
+  createYoga({
+    maskedErrors: false,
+    schema: createSchema<any>({
+      typeDefs: /* GraphQL */ `
+        type Query {
+          todos: [Todo!]!
+        }
+
+        type Todo {
+          id: ID!
+          title: String!
+        }
+
+        type Mutation {
+          createTodo(title: String!): Todo!
+        }
+      `,
+      resolvers: {
+        Query: {
+          todos: () => todos,
+        },
+        Mutation: {
+          createTodo(_: any, { title }: { title: string }) {
+            const newTodo = { id: String(todos.length + 1), title };
+            todos.push(newTodo);
+            return newTodo;
+          },
+        },
+      },
+    }),
+  }),
+).listen(opts.getServicePort('service-a'));

--- a/e2e/inaccessible-all-mutations/services/service-b.ts
+++ b/e2e/inaccessible-all-mutations/services/service-b.ts
@@ -1,0 +1,44 @@
+import { createServer } from 'http';
+import { createSchema, createYoga } from 'graphql-yoga';
+import { Opts } from '@e2e/opts';
+
+const opts = Opts(process.argv);
+
+const users = [
+  { id: '1', name: 'Alice' },
+  { id: '2', name: 'Bob' },
+];
+
+createServer(
+  createYoga({
+    maskedErrors: false,
+    schema: createSchema<any>({
+      typeDefs: /* GraphQL */ `
+        type Query {
+          users: [User!]!
+        }
+
+        type User {
+          id: ID!
+          name: String!
+        }
+
+        type Mutation {
+          addUser(name: String!): User!
+        }
+      `,
+      resolvers: {
+        Query: {
+          users: () => users,
+        },
+        Mutation: {
+          addUser(_: any, { name }: { name: string }) {
+            const newUser = { id: String(users.length + 1), name };
+            users.push(newUser);
+            return newUser;
+          },
+        },
+      },
+    }),
+  }),
+).listen(opts.getServicePort('service-b'));

--- a/packages/fusion/composition/src/transforms/filter-schema.ts
+++ b/packages/fusion/composition/src/transforms/filter-schema.ts
@@ -1,19 +1,16 @@
 import {
   isNonNullType,
-  type DirectiveLocation,
-  type GraphQLDirective,
   type GraphQLFieldConfig,
   type GraphQLInputFieldConfig,
   type GraphQLNamedType,
   type GraphQLSchema,
-  type isObjectType,
 } from 'graphql';
 import { Minimatch } from 'minimatch';
 import {
   getDirectiveExtensions,
+  getRootTypeNames,
   MapperKind,
   mapSchema,
-  type DirectableObject,
   type SchemaMapper,
 } from '@graphql-tools/utils';
 import type { SubgraphTransform } from '../compose.js';
@@ -34,6 +31,7 @@ function compareAndAddInaccessibleDirective(
   originalSchema: GraphQLSchema,
   filteredSchema: GraphQLSchema,
 ) {
+  const rootTypeNames = getRootTypeNames(originalSchema);
   return mapSchema(originalSchema, {
     [MapperKind.TYPE]: type => {
       const typeInFiltered = filteredSchema.getType(type.name);
@@ -44,7 +42,7 @@ function compareAndAddInaccessibleDirective(
           addInaccessibleDirective(type);
         } else {
           const numOfFieldsInFiltered = Object.keys(typeInFiltered.getFields()).length;
-          if (numOfFieldsInFiltered === 0) {
+          if (numOfFieldsInFiltered === 0 && !rootTypeNames.has(type.name)) {
             addInaccessibleDirective(type);
           }
         }

--- a/packages/fusion/composition/tests/transforms/filter-schema.test.ts
+++ b/packages/fusion/composition/tests/transforms/filter-schema.test.ts
@@ -343,39 +343,6 @@ type Query {
     );
   });
 
-  it('should remove type with pruning if all fields are filtered out', async () => {
-    let schema = buildSchema(/* GraphQL */ `
-      type Query {
-        foo: String
-        bar: String
-      }
-      type Mutation {
-        baz: String
-        qux: String
-      }
-    `);
-
-    const filterTransform = createFilterTransform({
-      filters: ['Mutation.!*'],
-    });
-    schema = await composeAndGetPublicSchema([
-      {
-        name: 'TEST',
-        schema,
-        transforms: [filterTransform, createPruneTransform()],
-      },
-    ]);
-    expectTheSchemaSDLToBe(
-      schema,
-      /* GraphQL */ `
-        type Query {
-          foo: String
-          bar: String
-        }
-      `,
-    );
-  });
-
   it('should filter out fields if array syntax is used only with one element', async () => {
     let schema = buildSchema(/* GraphQL */ `
       type User {

--- a/packages/fusion/composition/tests/transforms/filter-schema.test.ts
+++ b/packages/fusion/composition/tests/transforms/filter-schema.test.ts
@@ -1,5 +1,5 @@
-import { buildSchema, printSchema } from 'graphql';
-import { createFilterTransform, createPruneTransform } from '@graphql-mesh/fusion-composition';
+import { buildSchema } from 'graphql';
+import { createFilterTransform, createPruneTransform } from '../../src/index.js';
 import { composeAndGetPublicSchema, expectTheSchemaSDLToBe } from './utils.js';
 
 describe('filter-schema', () => {
@@ -856,35 +856,6 @@ type Test implements ITest {
 
 type Query {
   test: Test
-}
-`.trim(),
-    );
-  });
-
-  it("should filter Mutation type out if there are no fields left after filtering it's fields", async () => {
-    let schema = buildSchema(/* GraphQL */ `
-      type Query {
-        foo: String
-      }
-      type Mutation {
-        bar: String
-      }
-    `);
-    const filterTransform = createFilterTransform({
-      filters: ['Mutation.!bar'],
-    });
-    schema = await composeAndGetPublicSchema([
-      {
-        name: 'TEST',
-        schema,
-        transforms: [filterTransform, createPruneTransform()],
-      },
-    ]);
-    expectTheSchemaSDLToBe(
-      schema,
-      /* GraphQL */ `
-type Query {
-  foo: String
 }
 `.trim(),
     );

--- a/yarn.lock
+++ b/yarn.lock
@@ -3641,6 +3641,18 @@ __metadata:
     "@graphql-hive/gateway": "npm:^2.5.25"
     "@graphql-tools/schema": "npm:^10.0.32"
     graphql: "npm:16.13.2"
+    graphql-yoga: "npm:^5.21.0"
+  languageName: unknown
+  linkType: soft
+
+"@e2e/inaccessible-all-mutations@workspace:e2e/inaccessible-all-mutations":
+  version: 0.0.0-use.local
+  resolution: "@e2e/inaccessible-all-mutations@workspace:e2e/inaccessible-all-mutations"
+  dependencies:
+    "@graphql-hive/gateway": "npm:^2.5.25"
+    "@graphql-tools/schema": "npm:^10.0.32"
+    graphql: "npm:16.13.2"
+    graphql-yoga: "npm:^5.21.0"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION

Do not filter root types if they don't have any fields accessible. Previously filtering all Mutation fields would make the Mutation type inaccessible, which is not the intended behavior. Root types should only be filtered if they are explicitly marked as inaccessible or if they have no fields and are not root types.
In that case when Mutation is marked inaccessible, all the other subgraphs' Mutation fields are also marked inaccessible. Now Mutation is not marked inaccessible, but all the fields are marked inaccessible, which is the intended behavior.

So the following will no longer make `Mutation` type itself inaccessible;
```ts
{
      transforms: [
        createFilterTransform({
          rootFieldFilter(typeName) {
            if (typeName === 'Mutation') {
              return false;
            }
            return true;
          },
        }),
      ],
}
```