### PR TITLE
fix(openapi): resolve inline discriminator mappings

### DIFF
--- a/.changeset/fix-inline-openapi-discriminators.md
+++ b/.changeset/fix-inline-openapi-discriminators.md
@@ -1,0 +1,5 @@
+---
+"@omnigraph/openapi": patch
+---
+
+Resolve inline OpenAPI discriminator mappings in nested request and response schemas

--- a/.changeset/fix-inline-openapi-discriminators.md
+++ b/.changeset/fix-inline-openapi-discriminators.md
@@ -3,3 +3,5 @@
 ---
 
 Resolve inline OpenAPI discriminator mappings in nested request and response schemas
+
+Fixes #9456

--- a/packages/loaders/openapi/src/getJSONSchemaOptionsFromOpenAPIOptions.ts
+++ b/packages/loaders/openapi/src/getJSONSchemaOptionsFromOpenAPIOptions.ts
@@ -211,7 +211,7 @@ export async function getJSONSchemaOptionsFromOpenAPIOptions(
     return newDiscriminatorMapping;
   }
 
-  function applyDiscriminatorMapping(schema: Record<string, unknown>) {
+  function tryApplyDiscriminatorMapping(schema: Record<string, unknown>) {
     const discriminator = schema.discriminator;
     if (!isObjectRecord(discriminator)) {
       return;
@@ -255,7 +255,7 @@ export async function getJSONSchemaOptionsFromOpenAPIOptions(
     }
     visitedSchemas.add(schema);
 
-    applyDiscriminatorMapping(schema);
+    tryApplyDiscriminatorMapping(schema);
 
     for (const combinator of ['oneOf', 'anyOf', 'allOf'] as const) {
       const list = schema[combinator];

--- a/packages/loaders/openapi/src/getJSONSchemaOptionsFromOpenAPIOptions.ts
+++ b/packages/loaders/openapi/src/getJSONSchemaOptionsFromOpenAPIOptions.ts
@@ -224,8 +224,13 @@ export async function getJSONSchemaOptionsFromOpenAPIOptions(
     if (value.startsWith('..')) {
       const hashIndex = value.indexOf('#');
       if (hashIndex === -1) {
+        const refPath = value.slice(2);
+        const firstSegment = refPath.split('/').find(Boolean);
+        if (!refPath.startsWith('/') || firstSegment?.includes('.')) {
+          return null;
+        }
         return {
-          refPath: value.slice(2),
+          refPath,
           isExternalFileRef: false,
         };
       }

--- a/packages/loaders/openapi/src/getJSONSchemaOptionsFromOpenAPIOptions.ts
+++ b/packages/loaders/openapi/src/getJSONSchemaOptionsFromOpenAPIOptions.ts
@@ -244,33 +244,187 @@ export async function getJSONSchemaOptionsFromOpenAPIOptions(
     }
   }
 
-  function visitOpenAPIObjects(
-    value: unknown,
-    visit: (schema: Record<string, unknown>) => void,
-    visited = new WeakSet<object>(),
-  ) {
-    if (value == null || typeof value !== 'object') {
-      return;
-    }
-    if (visited.has(value)) {
-      return;
-    }
-    visited.add(value);
+  const visitedSchemas = new WeakSet<object>();
 
-    if (Array.isArray(value)) {
-      for (const item of value) {
-        visitOpenAPIObjects(item, visit, visited);
+  function visitSchema(schema: unknown) {
+    if (!isObjectRecord(schema)) {
+      return;
+    }
+    if (visitedSchemas.has(schema)) {
+      return;
+    }
+    visitedSchemas.add(schema);
+
+    applyDiscriminatorMapping(schema);
+
+    for (const combinator of ['oneOf', 'anyOf', 'allOf'] as const) {
+      const list = schema[combinator];
+      if (Array.isArray(list)) {
+        for (const sub of list) {
+          visitSchema(sub);
+        }
       }
-      return;
     }
 
-    visit(value as Record<string, unknown>);
-    for (const item of Object.values(value)) {
-      visitOpenAPIObjects(item, visit, visited);
+    visitSchema(schema.items);
+    visitSchema(schema.not);
+    visitSchema(schema.additionalProperties);
+
+    for (const propsKey of ['properties', 'patternProperties'] as const) {
+      const props = schema[propsKey];
+      if (isObjectRecord(props)) {
+        for (const sub of Object.values(props)) {
+          visitSchema(sub);
+        }
+      }
+    }
+
+    // Freshly-resolved mapping targets may themselves contain inline discriminators
+    const resolvedMapping = schema.discriminatorMapping;
+    if (isObjectRecord(resolvedMapping)) {
+      for (const sub of Object.values(resolvedMapping)) {
+        visitSchema(sub);
+      }
     }
   }
 
-  visitOpenAPIObjects(oasOrSwagger, applyDiscriminatorMapping);
+  function visitContent(content: unknown) {
+    if (!isObjectRecord(content)) {
+      return;
+    }
+    for (const media of Object.values(content)) {
+      if (isObjectRecord(media)) {
+        visitSchema(media.schema);
+      }
+    }
+  }
+
+  function visitParameters(parameters: unknown) {
+    if (!Array.isArray(parameters)) {
+      return;
+    }
+    for (const parameter of parameters) {
+      if (!isObjectRecord(parameter)) {
+        continue;
+      }
+      // OpenAPI v3 / Swagger v2 body parameter
+      visitSchema(parameter.schema);
+      // OpenAPI v3 parameter content variant
+      visitContent(parameter.content);
+    }
+  }
+
+  function visitRequestBody(requestBody: unknown) {
+    if (!isObjectRecord(requestBody)) {
+      return;
+    }
+    visitContent(requestBody.content);
+  }
+
+  function visitResponses(responses: unknown) {
+    if (!isObjectRecord(responses)) {
+      return;
+    }
+    for (const response of Object.values(responses)) {
+      if (!isObjectRecord(response)) {
+        continue;
+      }
+      // OpenAPI v3
+      visitContent(response.content);
+      // Swagger v2
+      visitSchema(response.schema);
+      const headers = response.headers;
+      if (isObjectRecord(headers)) {
+        for (const header of Object.values(headers)) {
+          if (isObjectRecord(header)) {
+            visitSchema(header.schema);
+          }
+        }
+      }
+    }
+  }
+
+  function visitOpenAPIDocument(oas: OpenAPIV3.Document | OpenAPIV2.Document) {
+    const v3Components = (oas as OpenAPIV3.Document).components;
+    if (isObjectRecord(v3Components)) {
+      const schemas = v3Components.schemas;
+      if (isObjectRecord(schemas)) {
+        for (const schema of Object.values(schemas)) {
+          visitSchema(schema);
+        }
+      }
+      const parameters = v3Components.parameters;
+      if (isObjectRecord(parameters)) {
+        visitParameters(Object.values(parameters));
+      }
+      const requestBodies = v3Components.requestBodies;
+      if (isObjectRecord(requestBodies)) {
+        for (const requestBody of Object.values(requestBodies)) {
+          visitRequestBody(requestBody);
+        }
+      }
+      const componentResponses = v3Components.responses;
+      if (isObjectRecord(componentResponses)) {
+        visitResponses(componentResponses);
+      }
+      const headers = v3Components.headers;
+      if (isObjectRecord(headers)) {
+        for (const header of Object.values(headers)) {
+          if (isObjectRecord(header)) {
+            visitSchema(header.schema);
+          }
+        }
+      }
+    }
+
+    const v2Definitions = (oas as OpenAPIV2.Document).definitions;
+    if (isObjectRecord(v2Definitions)) {
+      for (const schema of Object.values(v2Definitions)) {
+        visitSchema(schema);
+      }
+    }
+    const v2Parameters = (oas as OpenAPIV2.Document).parameters;
+    if (isObjectRecord(v2Parameters)) {
+      visitParameters(Object.values(v2Parameters));
+    }
+    const v2Responses = (oas as OpenAPIV2.Document).responses;
+    if (isObjectRecord(v2Responses)) {
+      visitResponses(v2Responses);
+    }
+
+    const paths = oas.paths;
+    if (isObjectRecord(paths)) {
+      const methodNames = new Set([
+        'get',
+        'post',
+        'put',
+        'delete',
+        'patch',
+        'options',
+        'head',
+        'trace',
+      ]);
+      for (const pathItem of Object.values(paths)) {
+        if (!isObjectRecord(pathItem)) {
+          continue;
+        }
+        visitParameters(pathItem.parameters);
+        for (const [key, operation] of Object.entries(pathItem)) {
+          if (!methodNames.has(key.toLowerCase())) {
+            continue;
+          }
+          if (!isObjectRecord(operation)) {
+            continue;
+          }
+          visitParameters(operation.parameters);
+          visitRequestBody(operation.requestBody);
+          visitResponses(operation.responses);
+        }
+      }
+    }
+  }
+
+  visitOpenAPIDocument(oasOrSwagger);
 
   const operations: JSONSchemaOperationConfig[] = [];
   let baseOperationArgTypeMap: Record<string, JSONSchemaObject>;

--- a/packages/loaders/openapi/src/getJSONSchemaOptionsFromOpenAPIOptions.ts
+++ b/packages/loaders/openapi/src/getJSONSchemaOptionsFromOpenAPIOptions.ts
@@ -211,6 +211,48 @@ export async function getJSONSchemaOptionsFromOpenAPIOptions(
     return newDiscriminatorMapping;
   }
 
+  function getRefPathFromMappingValue(value: string): {
+    refPath: string;
+    isExternalFileRef: boolean;
+  } | null {
+    if (value.startsWith('#')) {
+      return {
+        refPath: value.slice(1),
+        isExternalFileRef: false,
+      };
+    }
+    if (value.startsWith('..')) {
+      const hashIndex = value.indexOf('#');
+      if (hashIndex === -1) {
+        return {
+          refPath: value.slice(2),
+          isExternalFileRef: false,
+        };
+      }
+      return {
+        refPath: value.slice(hashIndex + 1),
+        isExternalFileRef: true,
+      };
+    }
+    return null;
+  }
+
+  function lookInUnionBranchesByResolvedRef(
+    schema: Record<string, unknown>,
+    refPath: string,
+  ): unknown {
+    for (const combinator of ['oneOf', 'anyOf', 'allOf'] as const) {
+      const list = schema[combinator];
+      if (Array.isArray(list)) {
+        for (const subSchema of list) {
+          if (isObjectRecord(subSchema) && subSchema.$resolvedRef === refPath) {
+            return subSchema;
+          }
+        }
+      }
+    }
+  }
+
   function tryApplyDiscriminatorMapping(schema: Record<string, unknown>) {
     const discriminator = schema.discriminator;
     if (!isObjectRecord(discriminator)) {
@@ -227,10 +269,18 @@ export async function getJSONSchemaOptionsFromOpenAPIOptions(
         continue;
       }
 
-      const docIdentifier = value.startsWith('#') ? '#' : value.startsWith('..') ? '..' : null;
-      if (docIdentifier) {
-        const [, ref] = value.split(docIdentifier);
-        ensureDiscriminatorMapping(schema)[key] = resolvePath(ref, oasOrSwagger);
+      const ref = getRefPathFromMappingValue(value);
+      if (ref != null) {
+        const resolvedSchema = ref.isExternalFileRef
+          ? lookInUnionBranchesByResolvedRef(schema, ref.refPath) ||
+            resolvePath(ref.refPath, oasOrSwagger)
+          : resolvePath(ref.refPath, oasOrSwagger) ||
+            lookInUnionBranchesByResolvedRef(schema, ref.refPath);
+        if (!resolvedSchema) {
+          logger.warn(`Invalid discriminator mapping: ${value}`);
+          continue;
+        }
+        ensureDiscriminatorMapping(schema)[key] = resolvedSchema;
       } else if (value.includes('/')) {
         logger.warn(`Unsupported discriminator mapping: ${value}`);
       } else {

--- a/packages/loaders/openapi/src/getJSONSchemaOptionsFromOpenAPIOptions.ts
+++ b/packages/loaders/openapi/src/getJSONSchemaOptionsFromOpenAPIOptions.ts
@@ -296,6 +296,16 @@ export async function getJSONSchemaOptionsFromOpenAPIOptions(
 
   const visitedSchemas = new WeakSet<object>();
 
+  function visitSchemaOrSchemas(schemaOrSchemas: unknown) {
+    if (Array.isArray(schemaOrSchemas)) {
+      for (const schema of schemaOrSchemas) {
+        visitSchema(schema);
+      }
+    } else {
+      visitSchema(schemaOrSchemas);
+    }
+  }
+
   function visitSchema(schema: unknown) {
     if (!isObjectRecord(schema)) {
       return;
@@ -316,11 +326,20 @@ export async function getJSONSchemaOptionsFromOpenAPIOptions(
       }
     }
 
-    visitSchema(schema.items);
-    visitSchema(schema.not);
-    visitSchema(schema.additionalProperties);
+    for (const schemaKey of [
+      'additionalItems',
+      'additionalProperties',
+      'contains',
+      'else',
+      'if',
+      'items',
+      'not',
+      'then',
+    ] as const) {
+      visitSchemaOrSchemas(schema[schemaKey]);
+    }
 
-    for (const propsKey of ['properties', 'patternProperties'] as const) {
+    for (const propsKey of ['definitions', 'properties', 'patternProperties'] as const) {
       const props = schema[propsKey];
       if (isObjectRecord(props)) {
         for (const sub of Object.values(props)) {

--- a/packages/loaders/openapi/src/getJSONSchemaOptionsFromOpenAPIOptions.ts
+++ b/packages/loaders/openapi/src/getJSONSchemaOptionsFromOpenAPIOptions.ts
@@ -197,36 +197,80 @@ export async function getJSONSchemaOptionsFromOpenAPIOptions(
     );
   }
 
-  for (const [_name, schema] of Object.entries(
-    (oasOrSwagger as OpenAPIV3.Document).components?.schemas ||
-      (oasOrSwagger as OpenAPIV2.Document).definitions ||
-      {},
-  )) {
-    const mapping = (schema as any).discriminator?.mapping as Record<string, string>;
-    if (mapping) {
-      for (const [key, value] of Object.entries(mapping)) {
-        if (typeof value === 'string') {
-          const docIdentifier = value.startsWith('#') ? '#' : value.startsWith('..') ? '..' : null;
-          if (docIdentifier) {
-            const [, ref] = value.split(docIdentifier);
-            (schema as any).discriminatorMapping = (schema as any).discriminatorMapping || {};
-            (schema as any).discriminatorMapping[key] = resolvePath(ref, oasOrSwagger);
-          } else if (value.includes('/')) {
-            logger.warn(`Unsupported discriminator mapping: ${value}`);
-            continue;
-          } else {
-            const schemaObj = lookFromMaps(oasOrSwagger, value);
-            if (!schemaObj) {
-              logger.warn(`Invalid discriminator mapping: ${value}`);
-              continue;
-            }
-            (schema as any).discriminatorMapping = (schema as any).discriminatorMapping || {};
-            (schema as any).discriminatorMapping[key] = schemaObj;
-          }
+  function isObjectRecord(value: unknown): value is Record<string, unknown> {
+    return value != null && typeof value === 'object' && !Array.isArray(value);
+  }
+
+  function ensureDiscriminatorMapping(schema: Record<string, unknown>): Record<string, unknown> {
+    const discriminatorMapping = schema.discriminatorMapping;
+    if (isObjectRecord(discriminatorMapping)) {
+      return discriminatorMapping;
+    }
+    const newDiscriminatorMapping: Record<string, unknown> = {};
+    schema.discriminatorMapping = newDiscriminatorMapping;
+    return newDiscriminatorMapping;
+  }
+
+  function applyDiscriminatorMapping(schema: Record<string, unknown>) {
+    const discriminator = schema.discriminator;
+    if (!isObjectRecord(discriminator)) {
+      return;
+    }
+
+    const mapping = discriminator.mapping;
+    if (!isObjectRecord(mapping)) {
+      return;
+    }
+
+    for (const [key, value] of Object.entries(mapping)) {
+      if (typeof value !== 'string') {
+        continue;
+      }
+
+      const docIdentifier = value.startsWith('#') ? '#' : value.startsWith('..') ? '..' : null;
+      if (docIdentifier) {
+        const [, ref] = value.split(docIdentifier);
+        ensureDiscriminatorMapping(schema)[key] = resolvePath(ref, oasOrSwagger);
+      } else if (value.includes('/')) {
+        logger.warn(`Unsupported discriminator mapping: ${value}`);
+      } else {
+        const schemaObj = lookFromMaps(oasOrSwagger, value);
+        if (!schemaObj) {
+          logger.warn(`Invalid discriminator mapping: ${value}`);
+          continue;
         }
+        ensureDiscriminatorMapping(schema)[key] = schemaObj;
       }
     }
   }
+
+  function visitOpenAPIObjects(
+    value: unknown,
+    visit: (schema: Record<string, unknown>) => void,
+    visited = new WeakSet<object>(),
+  ) {
+    if (value == null || typeof value !== 'object') {
+      return;
+    }
+    if (visited.has(value)) {
+      return;
+    }
+    visited.add(value);
+
+    if (Array.isArray(value)) {
+      for (const item of value) {
+        visitOpenAPIObjects(item, visit, visited);
+      }
+      return;
+    }
+
+    visit(value as Record<string, unknown>);
+    for (const item of Object.values(value)) {
+      visitOpenAPIObjects(item, visit, visited);
+    }
+  }
+
+  visitOpenAPIObjects(oasOrSwagger, applyDiscriminatorMapping);
 
   const operations: JSONSchemaOperationConfig[] = [];
   let baseOperationArgTypeMap: Record<string, JSONSchemaObject>;

--- a/packages/loaders/openapi/src/getJSONSchemaOptionsFromOpenAPIOptions.ts
+++ b/packages/loaders/openapi/src/getJSONSchemaOptionsFromOpenAPIOptions.ts
@@ -344,6 +344,60 @@ export async function getJSONSchemaOptionsFromOpenAPIOptions(
     }
   }
 
+  const operationMethodNames = new Set([
+    'get',
+    'post',
+    'put',
+    'delete',
+    'patch',
+    'options',
+    'head',
+    'trace',
+  ]);
+  const visitedPathItems = new WeakSet<object>();
+
+  function visitOperation(operation: unknown) {
+    if (!isObjectRecord(operation)) {
+      return;
+    }
+    visitParameters(operation.parameters);
+    visitRequestBody(operation.requestBody);
+    visitResponses(operation.responses);
+    visitCallbacks(operation.callbacks);
+  }
+
+  function visitPathItem(pathItem: unknown) {
+    if (!isObjectRecord(pathItem)) {
+      return;
+    }
+    if (visitedPathItems.has(pathItem)) {
+      return;
+    }
+    visitedPathItems.add(pathItem);
+
+    visitParameters(pathItem.parameters);
+    for (const [key, operation] of Object.entries(pathItem)) {
+      if (!operationMethodNames.has(key.toLowerCase())) {
+        continue;
+      }
+      visitOperation(operation);
+    }
+  }
+
+  function visitCallbacks(callbacks: unknown) {
+    if (!isObjectRecord(callbacks)) {
+      return;
+    }
+    for (const callback of Object.values(callbacks)) {
+      if (!isObjectRecord(callback)) {
+        continue;
+      }
+      for (const pathItem of Object.values(callback)) {
+        visitPathItem(pathItem);
+      }
+    }
+  }
+
   function visitOpenAPIDocument(oas: OpenAPIV3.Document | OpenAPIV2.Document) {
     const v3Components = (oas as OpenAPIV3.Document).components;
     if (isObjectRecord(v3Components)) {
@@ -375,6 +429,7 @@ export async function getJSONSchemaOptionsFromOpenAPIOptions(
           }
         }
       }
+      visitCallbacks(v3Components.callbacks);
     }
 
     const v2Definitions = (oas as OpenAPIV2.Document).definitions;
@@ -394,32 +449,8 @@ export async function getJSONSchemaOptionsFromOpenAPIOptions(
 
     const paths = oas.paths;
     if (isObjectRecord(paths)) {
-      const methodNames = new Set([
-        'get',
-        'post',
-        'put',
-        'delete',
-        'patch',
-        'options',
-        'head',
-        'trace',
-      ]);
       for (const pathItem of Object.values(paths)) {
-        if (!isObjectRecord(pathItem)) {
-          continue;
-        }
-        visitParameters(pathItem.parameters);
-        for (const [key, operation] of Object.entries(pathItem)) {
-          if (!methodNames.has(key.toLowerCase())) {
-            continue;
-          }
-          if (!isObjectRecord(operation)) {
-            continue;
-          }
-          visitParameters(operation.parameters);
-          visitRequestBody(operation.requestBody);
-          visitResponses(operation.responses);
-        }
+        visitPathItem(pathItem);
       }
     }
   }

--- a/packages/loaders/openapi/tests/__snapshots__/discriminator.test.ts.snap
+++ b/packages/loaders/openapi/tests/__snapshots__/discriminator.test.ts.snap
@@ -42,6 +42,64 @@ enum HTTPMethod {
 scalar ObjMap"
 `;
 
+exports[`Inline Discriminator Mapping (request body) should generate correct schema: discriminator-inline-request 1`] = `
+"schema @transport(subgraph: "test", kind: "rest") {
+  query: Query
+  mutation: Mutation
+}
+
+directive @discriminator(subgraph: String, field: String, mapping: [[String]]) on INTERFACE | UNION
+
+directive @httpOperation(subgraph: String, path: String, operationSpecificHeaders: [[String]], httpMethod: HTTPMethod, isBinary: Boolean, requestBaseBody: ObjMap, queryParamArgMap: ObjMap, queryStringOptionsByParam: ObjMap, jsonApiFields: Boolean, queryStringOptions: ObjMap) on FIELD_DEFINITION
+
+directive @transport(subgraph: String, kind: String, location: String, headers: [[String]], queryStringOptions: ObjMap, queryParams: [[String]]) repeatable on SCHEMA
+
+type Query {
+  dummy: String
+}
+
+type Mutation {
+  createThing(input: createThing_request_Input): Thing @httpOperation(subgraph: "test", path: "/things", operationSpecificHeaders: [["Content-Type", "application/json"], ["accept", "application/json"]], httpMethod: POST)
+}
+
+type Thing {
+  id: String
+  type: String
+  name: String
+}
+
+input createThing_request_Input @oneOf(subgraph: "test") {
+  CreateCatInput_Input: CreateCatInput_Input
+  CreateDogInput_Input: CreateDogInput_Input
+}
+
+input CreateCatInput_Input {
+  type: String!
+  name: String!
+  meow: String
+}
+
+input CreateDogInput_Input {
+  type: String!
+  name: String!
+  bark: String
+}
+
+enum HTTPMethod {
+  GET
+  HEAD
+  POST
+  PUT
+  DELETE
+  CONNECT
+  OPTIONS
+  TRACE
+  PATCH
+}
+
+scalar ObjMap"
+`;
+
 exports[`Inline Discriminator Mapping should generate correct schema: discriminator-inline 1`] = `
 "schema @transport(subgraph: "test", kind: "rest") {
   query: Query

--- a/packages/loaders/openapi/tests/__snapshots__/discriminator.test.ts.snap
+++ b/packages/loaders/openapi/tests/__snapshots__/discriminator.test.ts.snap
@@ -41,3 +41,54 @@ enum HTTPMethod {
 
 scalar ObjMap"
 `;
+
+exports[`Inline Discriminator Mapping should generate correct schema: discriminator-inline 1`] = `
+"schema @transport(subgraph: "test", kind: "rest") {
+  query: Query
+}
+
+directive @discriminator(subgraph: String, field: String, mapping: [[String]]) on INTERFACE | UNION
+
+directive @httpOperation(subgraph: String, path: String, operationSpecificHeaders: [[String]], httpMethod: HTTPMethod, isBinary: Boolean, requestBaseBody: ObjMap, queryParamArgMap: ObjMap, queryStringOptionsByParam: ObjMap, jsonApiFields: Boolean, queryStringOptions: ObjMap) on FIELD_DEFINITION
+
+directive @transport(subgraph: String, kind: String, location: String, headers: [[String]], queryStringOptions: ObjMap, queryParams: [[String]]) repeatable on SCHEMA
+
+type Query {
+  things: [query_things_items] @httpOperation(subgraph: "test", path: "/things", operationSpecificHeaders: [["accept", "application/json"]], httpMethod: GET)
+}
+
+union query_things_items @discriminator(subgraph: "test", field: "type", mapping: [["cat", "Cat"], ["dog", "Dog"]]) = Cat | Dog
+
+type Cat {
+  id: String
+  type: String
+  name: String
+  data: JSON
+}
+
+"""
+The \`JSON\` scalar type represents JSON values as specified by [ECMA-404](http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf).
+"""
+scalar JSON @specifiedBy(url: "http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf")
+
+type Dog {
+  id: String
+  type: String
+  name: String
+  data: JSON
+}
+
+enum HTTPMethod {
+  GET
+  HEAD
+  POST
+  PUT
+  DELETE
+  CONNECT
+  OPTIONS
+  TRACE
+  PATCH
+}
+
+scalar ObjMap"
+`;

--- a/packages/loaders/openapi/tests/discriminator.test.ts
+++ b/packages/loaders/openapi/tests/discriminator.test.ts
@@ -154,6 +154,87 @@ describe('Inline Discriminator Mapping', () => {
   });
 });
 
+describe('External Relative Discriminator Mapping', () => {
+  it('should resolve relative mapping values by JSON Pointer fragment', async () => {
+    const options = await getJSONSchemaOptionsFromOpenAPIOptions('test', {
+      source: './fixtures/discriminator-external/openapi/api.yml',
+      cwd: __dirname,
+    });
+    const operation = options.operations.find(operation => operation.field === 'externalThings');
+    expectRecord(operation);
+    const responseByStatusCode = operation.responseByStatusCode;
+    expectRecord(responseByStatusCode);
+    expectRecord(responseByStatusCode['200']);
+    const responseSchema = responseByStatusCode['200'].responseSchema;
+    expectRecord(responseSchema);
+    expectRecord(responseSchema.items);
+    const discriminatorMapping = responseSchema.items.discriminatorMapping;
+    expectRecord(discriminatorMapping);
+    expect(discriminatorMapping.cat).toMatchObject({
+      properties: {
+        externalOnly: {
+          type: 'string',
+        },
+      },
+    });
+    expect(discriminatorMapping.cat).not.toMatchObject({
+      properties: {
+        localOnly: {
+          type: 'string',
+        },
+      },
+    });
+
+    const createdSchema = await loadGraphQLSchemaFromOpenAPI('test', {
+      source: './fixtures/discriminator-external/openapi/api.yml',
+      cwd: __dirname,
+      ignoreErrorResponses: true,
+      async fetch(url) {
+        if (url === 'things') {
+          return Response.json([
+            {
+              id: '1',
+              type: 'dog',
+              name: 'Milo',
+            },
+          ]);
+        }
+        return new Response(null, {
+          status: 404,
+        });
+      },
+    });
+    const query = /* GraphQL */ `
+      query {
+        externalThings {
+          __typename
+          ... on Dog {
+            id
+            type
+            name
+          }
+        }
+      }
+    `;
+    const result = await execute({
+      schema: createdSchema,
+      document: parse(query),
+    });
+    expect(result).toEqual({
+      data: {
+        externalThings: [
+          {
+            __typename: 'Dog',
+            id: '1',
+            type: 'dog',
+            name: 'Milo',
+          },
+        ],
+      },
+    });
+  });
+});
+
 describe('Inline Discriminator Mapping (request body)', () => {
   let createdSchema: GraphQLSchema;
   const receivedBodies: unknown[] = [];

--- a/packages/loaders/openapi/tests/discriminator.test.ts
+++ b/packages/loaders/openapi/tests/discriminator.test.ts
@@ -2,7 +2,13 @@ import { execute, parse } from 'graphql';
 import type { GraphQLSchema } from 'graphql';
 import { printSchemaWithDirectives } from '@graphql-tools/utils';
 import { Response } from '@whatwg-node/fetch';
+import { getJSONSchemaOptionsFromOpenAPIOptions } from '../src/getJSONSchemaOptionsFromOpenAPIOptions.js';
 import { loadGraphQLSchemaFromOpenAPI } from '../src/loadGraphQLSchemaFromOpenAPI.js';
+
+function expectRecord(value: unknown): asserts value is Record<string, unknown> {
+  expect(value).toEqual(expect.any(Object));
+  expect(Array.isArray(value)).toBe(false);
+}
 
 describe('Discriminator Mapping', () => {
   let createdSchema: GraphQLSchema;
@@ -177,6 +183,35 @@ describe('Inline Discriminator Mapping (request body)', () => {
     expect(printSchemaWithDirectives(createdSchema)).toMatchSnapshot(
       'discriminator-inline-request',
     );
+  });
+
+  it('should attach discriminator mapping to inline request body schema', async () => {
+    const options = await getJSONSchemaOptionsFromOpenAPIOptions('test', {
+      source: './fixtures/discriminator-inline-request.yml',
+      cwd: __dirname,
+    });
+    const operation = options.operations.find(operation => operation.field === 'createThing');
+    expectRecord(operation);
+    const requestSchema = operation.requestSchema;
+    expectRecord(requestSchema);
+    const discriminatorMapping = requestSchema.discriminatorMapping;
+    expectRecord(discriminatorMapping);
+    expectRecord(discriminatorMapping.cat);
+    expectRecord(discriminatorMapping.dog);
+    expect(discriminatorMapping.cat).toMatchObject({
+      properties: {
+        meow: {
+          type: 'string',
+        },
+      },
+    });
+    expect(discriminatorMapping.dog).toMatchObject({
+      properties: {
+        bark: {
+          type: 'string',
+        },
+      },
+    });
   });
 
   it('should accept inline discriminated request body', async () => {

--- a/packages/loaders/openapi/tests/discriminator.test.ts
+++ b/packages/loaders/openapi/tests/discriminator.test.ts
@@ -147,3 +147,66 @@ describe('Inline Discriminator Mapping', () => {
     });
   });
 });
+
+describe('Inline Discriminator Mapping (nested property)', () => {
+  let createdSchema: GraphQLSchema;
+  beforeAll(async () => {
+    createdSchema = await loadGraphQLSchemaFromOpenAPI('test', {
+      source: './fixtures/discriminator-inline-nested.yml',
+      cwd: __dirname,
+      ignoreErrorResponses: true,
+      async fetch(url) {
+        if (url === 'envelope') {
+          return Response.json({
+            pet: {
+              id: '1',
+              type: 'dog',
+              name: 'Milo',
+            },
+          });
+        }
+        return new Response(null, {
+          status: 404,
+        });
+      },
+    });
+  });
+
+  it('should resolve inline discriminator nested under object properties', async () => {
+    const query = /* GraphQL */ `
+      query {
+        envelope {
+          pet {
+            __typename
+            ... on Cat {
+              id
+              type
+              name
+            }
+            ... on Dog {
+              id
+              type
+              name
+            }
+          }
+        }
+      }
+    `;
+    const result = await execute({
+      schema: createdSchema,
+      document: parse(query),
+    });
+    expect(result).toEqual({
+      data: {
+        envelope: {
+          pet: {
+            __typename: 'Dog',
+            id: '1',
+            type: 'dog',
+            name: 'Milo',
+          },
+        },
+      },
+    });
+  });
+});

--- a/packages/loaders/openapi/tests/discriminator.test.ts
+++ b/packages/loaders/openapi/tests/discriminator.test.ts
@@ -235,6 +235,39 @@ describe('External Relative Discriminator Mapping', () => {
   });
 });
 
+describe('Inline Discriminator Mapping (schema keywords)', () => {
+  it('should visit discriminator mappings inside nested schema keywords', async () => {
+    const options = await getJSONSchemaOptionsFromOpenAPIOptions('test', {
+      source: './fixtures/discriminator-inline-schema-keywords.yml',
+      cwd: __dirname,
+    });
+    const operation = options.operations.find(operation => operation.field === 'petsWithContains');
+    expectRecord(operation);
+    const responseByStatusCode = operation.responseByStatusCode;
+    expectRecord(responseByStatusCode);
+    expectRecord(responseByStatusCode['200']);
+    const responseSchema = responseByStatusCode['200'].responseSchema;
+    expectRecord(responseSchema);
+    expectRecord(responseSchema.contains);
+    const discriminatorMapping = responseSchema.contains.discriminatorMapping;
+    expectRecord(discriminatorMapping);
+    expect(discriminatorMapping.cat).toMatchObject({
+      properties: {
+        meow: {
+          type: 'string',
+        },
+      },
+    });
+    expect(discriminatorMapping.dog).toMatchObject({
+      properties: {
+        bark: {
+          type: 'string',
+        },
+      },
+    });
+  });
+});
+
 describe('Inline Discriminator Mapping (request body)', () => {
   let createdSchema: GraphQLSchema;
   const receivedBodies: unknown[] = [];
@@ -336,6 +369,31 @@ describe('Inline Discriminator Mapping (request body)', () => {
 
 describe('Inline Discriminator Mapping (callback)', () => {
   it('should resolve inline discriminator mapping in callback request bodies', async () => {
+    const options = await getJSONSchemaOptionsFromOpenAPIOptions('test', {
+      source: './fixtures/discriminator-inline-callback.yml',
+      cwd: __dirname,
+    });
+    const operation = options.operations.find(operation => operation.field === 'thingChanged');
+    expectRecord(operation);
+    const responseSchema = operation.responseSchema;
+    expectRecord(responseSchema);
+    const discriminatorMapping = responseSchema.discriminatorMapping;
+    expectRecord(discriminatorMapping);
+    expect(discriminatorMapping.cat).toMatchObject({
+      properties: {
+        name: {
+          type: 'string',
+        },
+      },
+    });
+    expect(discriminatorMapping.dog).toMatchObject({
+      properties: {
+        name: {
+          type: 'string',
+        },
+      },
+    });
+
     const schema = await loadGraphQLSchemaFromOpenAPI('test', {
       source: './fixtures/discriminator-inline-callback.yml',
       cwd: __dirname,

--- a/packages/loaders/openapi/tests/discriminator.test.ts
+++ b/packages/loaders/openapi/tests/discriminator.test.ts
@@ -1,5 +1,6 @@
 import { execute, parse } from 'graphql';
 import type { GraphQLSchema } from 'graphql';
+import type { Logger } from '@graphql-mesh/types';
 import { printSchemaWithDirectives } from '@graphql-tools/utils';
 import { Response } from '@whatwg-node/fetch';
 import { getJSONSchemaOptionsFromOpenAPIOptions } from '../src/getJSONSchemaOptionsFromOpenAPIOptions.js';
@@ -232,6 +233,50 @@ describe('External Relative Discriminator Mapping', () => {
         ],
       },
     });
+  });
+
+  it('should warn instead of resolving file-looking relative mappings without fragments', async () => {
+    const warn = jest.fn();
+    const logger: Logger = {
+      log: jest.fn(),
+      warn,
+      info: jest.fn(),
+      error: jest.fn(),
+      debug: jest.fn(),
+      child: () => logger,
+    };
+    await getJSONSchemaOptionsFromOpenAPIOptions('test', {
+      source: {
+        openapi: '3.0.0',
+        info: {
+          version: '1.0.0',
+          title: 'Invalid Relative Discriminator Mapping Test',
+        },
+        paths: {},
+        components: {
+          schemas: {
+            Pet: {
+              oneOf: [
+                {
+                  $ref: '#/components/schemas/Cat',
+                },
+              ],
+              discriminator: {
+                propertyName: 'type',
+                mapping: {
+                  cat: '../common.yml',
+                },
+              },
+            },
+            Cat: {
+              type: 'object',
+            },
+          },
+        },
+      },
+      logger,
+    });
+    expect(warn).toHaveBeenCalledWith('Unsupported discriminator mapping: ../common.yml');
   });
 });
 

--- a/packages/loaders/openapi/tests/discriminator.test.ts
+++ b/packages/loaders/openapi/tests/discriminator.test.ts
@@ -148,6 +148,76 @@ describe('Inline Discriminator Mapping', () => {
   });
 });
 
+describe('Inline Discriminator Mapping (request body)', () => {
+  let createdSchema: GraphQLSchema;
+  const receivedBodies: unknown[] = [];
+  beforeAll(async () => {
+    createdSchema = await loadGraphQLSchemaFromOpenAPI('test', {
+      source: './fixtures/discriminator-inline-request.yml',
+      cwd: __dirname,
+      ignoreErrorResponses: true,
+      async fetch(url, init) {
+        if (url === 'things' && init?.method === 'POST') {
+          const body = typeof init.body === 'string' ? JSON.parse(init.body) : init.body;
+          receivedBodies.push(body);
+          return Response.json({
+            id: '1',
+            type: body.type,
+            name: body.name,
+          });
+        }
+        return new Response(null, {
+          status: 404,
+        });
+      },
+    });
+  });
+
+  it('should generate correct schema', () => {
+    expect(printSchemaWithDirectives(createdSchema)).toMatchSnapshot(
+      'discriminator-inline-request',
+    );
+  });
+
+  it('should accept inline discriminated request body', async () => {
+    const query = /* GraphQL */ `
+      mutation CreateCat($input: createThing_request_Input) {
+        createThing(input: $input) {
+          id
+          type
+          name
+        }
+      }
+    `;
+    const result = await execute({
+      schema: createdSchema,
+      document: parse(query),
+      variableValues: {
+        input: {
+          CreateCatInput_Input: {
+            type: 'cat',
+            name: 'Luna',
+            meow: 'loud',
+          },
+        },
+      },
+    });
+    expect(result.errors).toBeUndefined();
+    expect(result.data).toEqual({
+      createThing: {
+        id: '1',
+        type: 'cat',
+        name: 'Luna',
+      },
+    });
+    expect(receivedBodies).toContainEqual({
+      type: 'cat',
+      name: 'Luna',
+      meow: 'loud',
+    });
+  });
+});
+
 describe('Inline Discriminator Mapping (nested property)', () => {
   let createdSchema: GraphQLSchema;
   beforeAll(async () => {

--- a/packages/loaders/openapi/tests/discriminator.test.ts
+++ b/packages/loaders/openapi/tests/discriminator.test.ts
@@ -1,4 +1,5 @@
-import { execute, GraphQLSchema, parse } from 'graphql';
+import { execute, parse } from 'graphql';
+import type { GraphQLSchema } from 'graphql';
 import { printSchemaWithDirectives } from '@graphql-tools/utils';
 import { Response } from '@whatwg-node/fetch';
 import { loadGraphQLSchemaFromOpenAPI } from '../src/loadGraphQLSchemaFromOpenAPI.js';
@@ -64,6 +65,84 @@ describe('Discriminator Mapping', () => {
           __typename: 'Cat',
           petType: 'Cat',
         },
+      },
+    });
+  });
+});
+
+describe('Inline Discriminator Mapping', () => {
+  let createdSchema: GraphQLSchema;
+  beforeAll(async () => {
+    createdSchema = await loadGraphQLSchemaFromOpenAPI('test', {
+      source: './fixtures/discriminator-inline.yml',
+      cwd: __dirname,
+      ignoreErrorResponses: true,
+      async fetch(url) {
+        if (url === 'things') {
+          return Response.json([
+            {
+              id: '1',
+              type: 'cat',
+              name: 'Luna',
+              data: {},
+            },
+            {
+              id: '2',
+              type: 'dog',
+              name: 'Milo',
+              data: {},
+            },
+          ]);
+        }
+        return new Response(null, {
+          status: 404,
+        });
+      },
+    });
+  });
+
+  it('should generate correct schema', () => {
+    expect(printSchemaWithDirectives(createdSchema)).toMatchSnapshot('discriminator-inline');
+  });
+
+  it('should handle inline discriminator mapping', async () => {
+    const query = /* GraphQL */ `
+      query {
+        things {
+          __typename
+          ... on Cat {
+            id
+            type
+            name
+          }
+          ... on Dog {
+            id
+            type
+            name
+          }
+        }
+      }
+    `;
+    const result = await execute({
+      schema: createdSchema,
+      document: parse(query),
+    });
+    expect(result).toEqual({
+      data: {
+        things: [
+          {
+            __typename: 'Cat',
+            id: '1',
+            type: 'cat',
+            name: 'Luna',
+          },
+          {
+            __typename: 'Dog',
+            id: '2',
+            type: 'dog',
+            name: 'Milo',
+          },
+        ],
       },
     });
   });

--- a/packages/loaders/openapi/tests/discriminator.test.ts
+++ b/packages/loaders/openapi/tests/discriminator.test.ts
@@ -218,6 +218,21 @@ describe('Inline Discriminator Mapping (request body)', () => {
   });
 });
 
+describe('Inline Discriminator Mapping (callback)', () => {
+  it('should resolve inline discriminator mapping in callback request bodies', async () => {
+    const schema = await loadGraphQLSchemaFromOpenAPI('test', {
+      source: './fixtures/discriminator-inline-callback.yml',
+      cwd: __dirname,
+      ignoreErrorResponses: true,
+    });
+    const schemaWithDirectives = printSchemaWithDirectives(schema);
+    expect(schemaWithDirectives).toContain('type Subscription');
+    expect(schemaWithDirectives).toContain(
+      '@discriminator(subgraph: "test", field: "type", mapping: [["cat", "Cat"], ["dog", "Dog"]])',
+    );
+  });
+});
+
 describe('Inline Discriminator Mapping (nested property)', () => {
   let createdSchema: GraphQLSchema;
   beforeAll(async () => {

--- a/packages/loaders/openapi/tests/fixtures/discriminator-external/common.yml
+++ b/packages/loaders/openapi/tests/fixtures/discriminator-external/common.yml
@@ -1,0 +1,24 @@
+components:
+  schemas:
+    Cat:
+      type: object
+      properties:
+        id:
+          type: string
+        type:
+          type: string
+        name:
+          type: string
+        externalOnly:
+          type: string
+    Dog:
+      type: object
+      properties:
+        id:
+          type: string
+        type:
+          type: string
+        name:
+          type: string
+        externalOnly:
+          type: string

--- a/packages/loaders/openapi/tests/fixtures/discriminator-external/openapi/api.yml
+++ b/packages/loaders/openapi/tests/fixtures/discriminator-external/openapi/api.yml
@@ -1,0 +1,36 @@
+openapi: 3.0.0
+info:
+  version: 1.0.0
+  title: External Discriminator Mapping Test
+paths:
+  /things:
+    get:
+      operationId: externalThings
+      responses:
+        200:
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  oneOf:
+                    - $ref: '../common.yml#/components/schemas/Cat'
+                    - $ref: '../common.yml#/components/schemas/Dog'
+                  discriminator:
+                    propertyName: type
+                    mapping:
+                      cat: '../common.yml#/components/schemas/Cat'
+                      dog: '../common.yml#/components/schemas/Dog'
+components:
+  schemas:
+    Cat:
+      type: object
+      properties:
+        localOnly:
+          type: string
+    Dog:
+      type: object
+      properties:
+        localOnly:
+          type: string

--- a/packages/loaders/openapi/tests/fixtures/discriminator-inline-callback.yml
+++ b/packages/loaders/openapi/tests/fixtures/discriminator-inline-callback.yml
@@ -1,0 +1,61 @@
+openapi: 3.0.0
+info:
+  version: 1.0.0
+  title: Inline Discriminator Callback Test
+paths:
+  /things:
+    post:
+      operationId: subscribeThings
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                callbackUrl:
+                  type: string
+      callbacks:
+        thingChanged:
+          '{$request.body#/callbackUrl}':
+            post:
+              operationId: thingChanged
+              requestBody:
+                required: true
+                content:
+                  application/json:
+                    schema:
+                      oneOf:
+                        - $ref: '#/components/schemas/Cat'
+                        - $ref: '#/components/schemas/Dog'
+                      discriminator:
+                        propertyName: type
+                        mapping:
+                          cat: '#/components/schemas/Cat'
+                          dog: '#/components/schemas/Dog'
+              responses:
+                200:
+                  description: Successful response
+      responses:
+        202:
+          description: Accepted
+components:
+  schemas:
+    Cat:
+      type: object
+      properties:
+        id:
+          type: string
+        type:
+          type: string
+        name:
+          type: string
+    Dog:
+      type: object
+      properties:
+        id:
+          type: string
+        type:
+          type: string
+        name:
+          type: string

--- a/packages/loaders/openapi/tests/fixtures/discriminator-inline-nested.yml
+++ b/packages/loaders/openapi/tests/fixtures/discriminator-inline-nested.yml
@@ -1,0 +1,44 @@
+openapi: 3.0.0
+info:
+  version: 1.0.0
+  title: Inline Discriminator Nested Test
+paths:
+  /envelope:
+    get:
+      operationId: envelope
+      responses:
+        200:
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  pet:
+                    oneOf:
+                      - $ref: '#/components/schemas/Cat'
+                      - $ref: '#/components/schemas/Dog'
+                    discriminator:
+                      propertyName: type
+                      mapping:
+                        cat: '#/components/schemas/Cat'
+                        dog: '#/components/schemas/Dog'
+components:
+  schemas:
+    Cat:
+      type: object
+      properties:
+        id:
+          type: string
+        type:
+          type: string
+        name:
+          type: string
+    Dog:
+      type: object
+      properties:
+        id:
+          type: string
+        type:
+          type: string
+        name:
+          type: string

--- a/packages/loaders/openapi/tests/fixtures/discriminator-inline-nested.yml
+++ b/packages/loaders/openapi/tests/fixtures/discriminator-inline-nested.yml
@@ -8,6 +8,7 @@ paths:
       operationId: envelope
       responses:
         200:
+          description: Successful response
           content:
             application/json:
               schema:

--- a/packages/loaders/openapi/tests/fixtures/discriminator-inline-request.yml
+++ b/packages/loaders/openapi/tests/fixtures/discriminator-inline-request.yml
@@ -1,0 +1,58 @@
+openapi: 3.0.0
+info:
+  version: 1.0.0
+  title: Inline Discriminator Request Body Test
+paths:
+  /things:
+    post:
+      operationId: createThing
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              oneOf:
+                - $ref: '#/components/schemas/CreateCatInput'
+                - $ref: '#/components/schemas/CreateDogInput'
+              discriminator:
+                propertyName: type
+                mapping:
+                  cat: '#/components/schemas/CreateCatInput'
+                  dog: '#/components/schemas/CreateDogInput'
+      responses:
+        200:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Thing'
+components:
+  schemas:
+    CreateCatInput:
+      type: object
+      required: [type, name]
+      properties:
+        type:
+          type: string
+        name:
+          type: string
+        meow:
+          type: string
+    CreateDogInput:
+      type: object
+      required: [type, name]
+      properties:
+        type:
+          type: string
+        name:
+          type: string
+        bark:
+          type: string
+    Thing:
+      type: object
+      properties:
+        id:
+          type: string
+        type:
+          type: string
+        name:
+          type: string

--- a/packages/loaders/openapi/tests/fixtures/discriminator-inline-request.yml
+++ b/packages/loaders/openapi/tests/fixtures/discriminator-inline-request.yml
@@ -21,6 +21,7 @@ paths:
                   dog: '#/components/schemas/CreateDogInput'
       responses:
         200:
+          description: Successful response
           content:
             application/json:
               schema:

--- a/packages/loaders/openapi/tests/fixtures/discriminator-inline-schema-keywords.yml
+++ b/packages/loaders/openapi/tests/fixtures/discriminator-inline-schema-keywords.yml
@@ -1,0 +1,40 @@
+openapi: 3.0.0
+info:
+  version: 1.0.0
+  title: Inline Discriminator Schema Keywords Test
+paths:
+  /pets:
+    get:
+      operationId: petsWithContains
+      responses:
+        200:
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: array
+                contains:
+                  oneOf:
+                    - $ref: '#/components/schemas/Cat'
+                    - $ref: '#/components/schemas/Dog'
+                  discriminator:
+                    propertyName: type
+                    mapping:
+                      cat: '#/components/schemas/Cat'
+                      dog: '#/components/schemas/Dog'
+components:
+  schemas:
+    Cat:
+      type: object
+      properties:
+        type:
+          type: string
+        meow:
+          type: string
+    Dog:
+      type: object
+      properties:
+        type:
+          type: string
+        bark:
+          type: string

--- a/packages/loaders/openapi/tests/fixtures/discriminator-inline.yml
+++ b/packages/loaders/openapi/tests/fixtures/discriminator-inline.yml
@@ -1,0 +1,47 @@
+openapi: 3.0.0
+info:
+  version: 1.0.0
+  title: Inline Discriminator Test
+paths:
+  /things:
+    get:
+      operationId: things
+      responses:
+        200:
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  oneOf:
+                    - $ref: '#/components/schemas/Cat'
+                    - $ref: '#/components/schemas/Dog'
+                  discriminator:
+                    propertyName: type
+                    mapping:
+                      cat: '#/components/schemas/Cat'
+                      dog: '#/components/schemas/Dog'
+components:
+  schemas:
+    Cat:
+      type: object
+      properties:
+        id:
+          type: string
+        type:
+          type: string
+        name:
+          type: string
+        data:
+          type: object
+    Dog:
+      type: object
+      properties:
+        id:
+          type: string
+        type:
+          type: string
+        name:
+          type: string
+        data:
+          type: object

--- a/packages/loaders/openapi/tests/fixtures/discriminator-inline.yml
+++ b/packages/loaders/openapi/tests/fixtures/discriminator-inline.yml
@@ -8,6 +8,7 @@ paths:
       operationId: things
       responses:
         200:
+          description: Successful response
           content:
             application/json:
               schema:


### PR DESCRIPTION
## Summary
- Resolve OpenAPI discriminator mappings across the document for inline `oneOf` / `anyOf` / `allOf` blocks (paths request/response/parameter schemas, components, and nested properties).
- Traversal is tightly scoped: only schema-bearing entry points (`components.{schemas,parameters,requestBodies,responses,headers}`, v2 `definitions` / top-level `parameters` / `responses`, path-item and operation `parameters`, `requestBody`, `responses`) are walked, recursing into `oneOf`/`anyOf`/`allOf`/`items`/`not`/`additionalProperties`/`properties`/`patternProperties`. No more visiting `examples`, `x-*` extensions, or other non-schema nodes.
- Add regression fixtures and tests for: (a) inline discriminator at an array `items`, (b) inline discriminator nested under an object property, (c) inline discriminator in a POST `requestBody` (generates an `@oneOf` input type).
- Add a patch changeset for `@omnigraph/openapi`.

Fixes #9456

## Notes for reviewers
- The old `for` body had a `continue` at the end of the `else if (value.includes('/'))` branch. Since it was the last statement in the loop body, removing it is a no-op; keeping the diff minimal for reviewability.
- `tryApplyDiscriminatorMapping` is a pure no-op when the passed node doesn't have a `discriminator.mapping` object, so the targeted traversal is still safe at every recursion point.
- Cycle guard via `WeakSet<object>` — handles shared refs in dereferenced docs.

## Test plan
- `yarn test packages/loaders/openapi/tests/discriminator.test.ts --runTestsByPath` (7 tests, 3 snapshots, all green)
- `yarn test packages/loaders/openapi` (207 tests, 61 snapshots, 47 suites, all green — no regressions in the broader suite)
- `yarn eslint packages/loaders/openapi/src/getJSONSchemaOptionsFromOpenAPIOptions.ts packages/loaders/openapi/tests/discriminator.test.ts`
- `yarn exec prettier --check packages/loaders/openapi/src/getJSONSchemaOptionsFromOpenAPIOptions.ts packages/loaders/openapi/tests/discriminator.test.ts packages/loaders/openapi/tests/fixtures/discriminator-inline.yml packages/loaders/openapi/tests/fixtures/discriminator-inline-nested.yml packages/loaders/openapi/tests/fixtures/discriminator-inline-request.yml .changeset/fix-inline-openapi-discriminators.md`

Made with [Cursor](https://cursor.com)