### PR TITLE
fix(soap-loader): resolve nested WSDL/XSD imports against importing document

### DIFF
--- a/.changeset/fix-soap-loader-imports.md
+++ b/.changeset/fix-soap-loader-imports.md
@@ -1,0 +1,11 @@
+---
+"@omnigraph/soap": patch
+---
+
+Resolve nested `<wsdl:import>` and `<xsd:import>` against the importing document's location, not against a fixed `cwd`. Lets the loader follow multi-file WSDLs whose schemas span more than one directory (e.g. TMForum MTOP, OASIS) without flattening them first.
+
+Also handles the common `<xsd:schema>` wrapper pattern — a schema element with no `targetNamespace` whose only purpose is to bring an external schema into `<wsdl:types>` via `<xsd:import>`. This is widely used and valid per the XML Schema spec; the previous code crashed dereferencing `targetNamespace`.
+
+`fetchWSDL` now uses `readFileOrUrl`, matching `fetchXSD`, so WSDL imports work uniformly with both `http(s):` URLs and filesystem paths.
+
+The new optional `baseUrl` parameter on `loadWSDL` lets callers tell the loader where the document came from. When omitted, the legacy `cwd`-based behaviour is preserved unchanged.

--- a/packages/legacy/handlers/soap/src/index.ts
+++ b/packages/legacy/handlers/soap/src/index.ts
@@ -76,8 +76,9 @@ export default class SoapHandler implements MeshHandler {
           logger: this.logger,
           headers: schemaHeadersFactory({ env: process.env }),
         });
-        const object = await soapLoader.loadWSDL(wsdl);
-        soapLoader.loadedLocations.set(wsdlLocation, object);
+        // Pass wsdlLocation as the base URL so nested <wsdl:import> /
+        // <xsd:import> locations resolve relative to the importing document.
+        await soapLoader.loadWSDL(wsdl, wsdlLocation);
         return soapLoader.buildSchema();
       });
     }

--- a/packages/legacy/handlers/soap/src/index.ts
+++ b/packages/legacy/handlers/soap/src/index.ts
@@ -62,6 +62,7 @@ export default class SoapHandler implements MeshHandler {
           subgraphName: this.name,
           fetch: fetchFn,
           logger: this.logger,
+          cwd: this.baseDir,
           schemaHeaders: this.config.schemaHeaders,
           operationHeaders: this.config.operationHeaders,
           soapHeaders: this.config.soapHeaders,

--- a/packages/loaders/soap/src/SOAPLoader.ts
+++ b/packages/loaders/soap/src/SOAPLoader.ts
@@ -751,11 +751,7 @@ export class SOAPLoader {
 
   private xmlParser = new XMLParser(PARSE_XML_OPTIONS);
 
-  async fetchXSD(
-    location: string,
-    parentAliasMap = new Map<string, string>(),
-    baseUrl?: string,
-  ) {
+  async fetchXSD(location: string, parentAliasMap = new Map<string, string>(), baseUrl?: string) {
     const resolved = resolveLocation(baseUrl ?? this.cwd, location);
     if (this.loadedLocations.has(resolved)) return;
     let xsdText = await readFileOrUrl<string>(resolved, {

--- a/packages/loaders/soap/src/SOAPLoader.ts
+++ b/packages/loaders/soap/src/SOAPLoader.ts
@@ -168,20 +168,26 @@ function isQueryOperationName(operationName: string) {
   return QUERY_PREFIXES.some(prefix => operationName.toLowerCase().startsWith(prefix));
 }
 
+// Matches any RFC-3986 scheme (2+ chars to avoid mistaking Windows drive
+// letters like "C:" for URI schemes). The scheme isn't required to be
+// followed by "//" — `file:/tmp/x`, `urn:isbn:1234`, etc. are valid
+// absolute URIs.
+const URI_SCHEME_RE = /^[a-zA-Z][a-zA-Z0-9+.-]+:/;
+
 /**
  * Resolve a (possibly relative) WSDL/XSD location against the location of the
  * document doing the import. Mirrors XML Schema's xml:base resolution rules:
  * relative `schemaLocation` / `wsdl:import location` is resolved against the
  * importing document's own URI, not against a fixed root.
  *
- * Handles both URLs (http/https/file) and filesystem paths uniformly.
+ * Handles both URIs (http, https, file, urn, …) and filesystem paths uniformly.
  */
 function resolveLocation(base: string | undefined, location: string): string {
-  // Already-absolute URLs pass through.
-  if (/^[a-z][a-z0-9+.-]*:\/\//i.test(location)) return location;
+  // Already-absolute URIs (any scheme) pass through.
+  if (URI_SCHEME_RE.test(location)) return location;
   if (!base) return location;
-  if (/^[a-z][a-z0-9+.-]*:\/\//i.test(base)) {
-    // base is a URL — let URL handle "../" and root-relative ("/foo") paths.
+  if (URI_SCHEME_RE.test(base)) {
+    // base is a URI — let URL handle "../" and root-relative ("/foo") paths.
     return new URL(location, base).href;
   }
   // base is a filesystem path. A filesystem-absolute location passes through;
@@ -803,7 +809,7 @@ export class SOAPLoader {
     let resolvedBase = baseUrl;
     if (
       resolvedBase &&
-      !/^[a-z][a-z0-9+.-]*:\/\//i.test(resolvedBase) &&
+      !URI_SCHEME_RE.test(resolvedBase) &&
       !isAbsolute(resolvedBase) &&
       this.cwd
     ) {

--- a/packages/loaders/soap/src/SOAPLoader.ts
+++ b/packages/loaders/soap/src/SOAPLoader.ts
@@ -1,4 +1,5 @@
-import { dirname, isAbsolute, resolve as resolvePath } from 'path';
+// eslint-disable-next-line import/no-nodejs-modules
+import { dirname, isAbsolute, resolve as resolvePath } from 'node:path';
 import { XMLParser } from 'fast-xml-parser';
 import type { GraphQLScalarType } from 'graphql';
 import {

--- a/packages/loaders/soap/src/SOAPLoader.ts
+++ b/packages/loaders/soap/src/SOAPLoader.ts
@@ -794,12 +794,26 @@ export class SOAPLoader {
         `WSDL definitions not found! Please make sure if your WSDL source is correct, and it contains <definitions> tag.\nReturned response;\n${wsdlText}`,
       );
     }
+    // Anchor a relative filesystem baseUrl against this.cwd. Without this, a
+    // caller passing a relative source (e.g. "./wsdl/foo.wsdl") would have
+    // path.resolve fall back to process.cwd() — which can differ from the
+    // loader's working directory in monorepos / containers, sending nested
+    // imports to the wrong absolute paths.
+    let resolvedBase = baseUrl;
+    if (
+      resolvedBase &&
+      !/^[a-z][a-z0-9+.-]*:\/\//i.test(resolvedBase) &&
+      !isAbsolute(resolvedBase) &&
+      this.cwd
+    ) {
+      resolvedBase = resolvePath(this.cwd, resolvedBase);
+    }
     // Pre-register before recursing so circular imports terminate.
-    if (baseUrl) {
-      this.loadedLocations.set(baseUrl, wsdlObject);
+    if (resolvedBase) {
+      this.loadedLocations.set(resolvedBase, wsdlObject);
     }
     for (const definition of wsdlObject.definitions) {
-      await this.loadDefinition(definition, baseUrl);
+      await this.loadDefinition(definition, resolvedBase);
     }
     return wsdlObject;
   }

--- a/packages/loaders/soap/src/SOAPLoader.ts
+++ b/packages/loaders/soap/src/SOAPLoader.ts
@@ -416,7 +416,9 @@ export class SOAPLoader {
     // A bare <xsd:schema> wrapper that only contains imports (no targetNamespace,
     // no type definitions) is a valid pattern — it lets a WSDL pull external
     // schemas into its <wsdl:types> without redefining anything itself. Process
-    // its imports and return; there's nothing else to register.
+    // its imports here. A "chameleon" schema (no targetNamespace + own type
+    // definitions) is a different, larger case the loader doesn't yet support;
+    // surface it loudly rather than silently dropping the definitions.
     if (!schemaObj.attributes || !schemaObj.attributes.targetNamespace) {
       if (schemaObj.import) {
         for (const importObj of schemaObj.import) {
@@ -425,6 +427,12 @@ export class SOAPLoader {
             await this.fetchXSD(importLocation, parentAliasMap, baseUrl);
           }
         }
+      }
+      if (schemaObj.complexType || schemaObj.simpleType || schemaObj.element) {
+        throw new Error(
+          '<xsd:schema> without targetNamespace but with type definitions ' +
+            '(chameleon schemas) is not yet supported by the SOAP loader.',
+        );
       }
       return;
     }

--- a/packages/loaders/soap/src/SOAPLoader.ts
+++ b/packages/loaders/soap/src/SOAPLoader.ts
@@ -177,15 +177,16 @@ function isQueryOperationName(operationName: string) {
  * Handles both URLs (http/https/file) and filesystem paths uniformly.
  */
 function resolveLocation(base: string | undefined, location: string): string {
-  // Already-absolute URLs and absolute filesystem paths pass through.
+  // Already-absolute URLs pass through.
   if (/^[a-z][a-z0-9+.-]*:\/\//i.test(location)) return location;
-  if (isAbsolute(location)) return location;
   if (!base) return location;
   if (/^[a-z][a-z0-9+.-]*:\/\//i.test(base)) {
-    // base is a URL — let URL handle "../" and similar.
+    // base is a URL — let URL handle "../" and root-relative ("/foo") paths.
     return new URL(location, base).href;
   }
-  // base is a filesystem path — resolve relative to its containing directory.
+  // base is a filesystem path. A filesystem-absolute location passes through;
+  // anything else is resolved relative to base's containing directory.
+  if (isAbsolute(location)) return location;
   return resolvePath(dirname(base), location);
 }
 

--- a/packages/loaders/soap/src/SOAPLoader.ts
+++ b/packages/loaders/soap/src/SOAPLoader.ts
@@ -1,3 +1,4 @@
+import { dirname, isAbsolute, resolve as resolvePath } from 'path';
 import { XMLParser } from 'fast-xml-parser';
 import type { GraphQLScalarType } from 'graphql';
 import {
@@ -164,6 +165,27 @@ const QUERY_PREFIXES = [
 
 function isQueryOperationName(operationName: string) {
   return QUERY_PREFIXES.some(prefix => operationName.toLowerCase().startsWith(prefix));
+}
+
+/**
+ * Resolve a (possibly relative) WSDL/XSD location against the location of the
+ * document doing the import. Mirrors XML Schema's xml:base resolution rules:
+ * relative `schemaLocation` / `wsdl:import location` is resolved against the
+ * importing document's own URI, not against a fixed root.
+ *
+ * Handles both URLs (http/https/file) and filesystem paths uniformly.
+ */
+function resolveLocation(base: string | undefined, location: string): string {
+  // Already-absolute URLs and absolute filesystem paths pass through.
+  if (/^[a-z][a-z0-9+.-]*:\/\//i.test(location)) return location;
+  if (isAbsolute(location)) return location;
+  if (!base) return location;
+  if (/^[a-z][a-z0-9+.-]*:\/\//i.test(base)) {
+    // base is a URL — let URL handle "../" and similar.
+    return new URL(location, base).href;
+  }
+  // base is a filesystem path — resolve relative to its containing directory.
+  return resolvePath(dirname(base), location);
 }
 
 /**
@@ -385,7 +407,26 @@ export class SOAPLoader {
     return namespaceMessageMap;
   }
 
-  async loadSchema(schemaObj: XSSchema, parentAliasMap: Map<string, string> = new Map()) {
+  async loadSchema(
+    schemaObj: XSSchema,
+    parentAliasMap: Map<string, string> = new Map(),
+    baseUrl?: string,
+  ) {
+    // A bare <xsd:schema> wrapper that only contains imports (no targetNamespace,
+    // no type definitions) is a valid pattern — it lets a WSDL pull external
+    // schemas into its <wsdl:types> without redefining anything itself. Process
+    // its imports and return; there's nothing else to register.
+    if (!schemaObj.attributes || !schemaObj.attributes.targetNamespace) {
+      if (schemaObj.import) {
+        for (const importObj of schemaObj.import) {
+          const importLocation = importObj.attributes.schemaLocation;
+          if (importLocation) {
+            await this.fetchXSD(importLocation, parentAliasMap, baseUrl);
+          }
+        }
+      }
+      return;
+    }
     const schemaNamespace = schemaObj.attributes.targetNamespace;
     const aliasMap = this.getAliasMapFromAttributes(schemaObj.attributes);
     let typePrefix = this.namespaceTypePrefixMap.get(schemaNamespace);
@@ -403,8 +444,8 @@ export class SOAPLoader {
     if (schemaObj.import) {
       for (const importObj of schemaObj.import) {
         const importLocation = importObj.attributes.schemaLocation;
-        if (importLocation && !this.loadedLocations.has(importLocation)) {
-          await this.fetchXSD(importLocation);
+        if (importLocation) {
+          await this.fetchXSD(importLocation, parentAliasMap, baseUrl);
         }
       }
     }
@@ -481,7 +522,7 @@ export class SOAPLoader {
     }
   }
 
-  async loadDefinition(definition: WSDLDefinition) {
+  async loadDefinition(definition: WSDLDefinition, baseUrl?: string) {
     this.getNamespaceDefinitions(definition.attributes.targetNamespace).push(definition);
     if (definition.attributes.soap12) {
       this.soapNamespace = 'http://www.w3.org/2003/05/soap-envelope';
@@ -498,15 +539,15 @@ export class SOAPLoader {
     if (definition.import) {
       for (const importObj of definition.import) {
         const importLocation = importObj.attributes.location;
-        if (importLocation && !this.loadedLocations.has(importLocation)) {
-          await this.fetchWSDL(importLocation);
+        if (importLocation) {
+          await this.fetchWSDL(importLocation, baseUrl);
         }
       }
     }
     if (definition.types) {
       for (const typesObj of definition.types) {
         for (const schemaObj of typesObj.schema) {
-          await this.loadSchema(schemaObj, definitionAliasMap);
+          await this.loadSchema(schemaObj, definitionAliasMap, baseUrl);
         }
       }
     }
@@ -710,8 +751,14 @@ export class SOAPLoader {
 
   private xmlParser = new XMLParser(PARSE_XML_OPTIONS);
 
-  async fetchXSD(location: string, parentAliasMap = new Map<string, string>()) {
-    let xsdText = await readFileOrUrl<string>(location, {
+  async fetchXSD(
+    location: string,
+    parentAliasMap = new Map<string, string>(),
+    baseUrl?: string,
+  ) {
+    const resolved = resolveLocation(baseUrl ?? this.cwd, location);
+    if (this.loadedLocations.has(resolved)) return;
+    let xsdText = await readFileOrUrl<string>(resolved, {
       allowUnknownExtensions: true,
       cwd: this.cwd,
       fetch: this.fetchFn,
@@ -722,13 +769,14 @@ export class SOAPLoader {
     xsdText = xsdText.split('xmlns:').join('namespace:');
     // WSDL Import is different than XS Import
     const xsdObj: XSDObject = this.xmlParser.parse(xsdText, PARSE_XML_OPTIONS);
+    // Pre-register before recursing so circular imports terminate.
+    this.loadedLocations.set(resolved, xsdObj);
     for (const schemaObj of xsdObj.schema) {
-      await this.loadSchema(schemaObj, parentAliasMap);
+      await this.loadSchema(schemaObj, parentAliasMap, resolved);
     }
-    this.loadedLocations.set(location, xsdObj);
   }
 
-  async loadWSDL(wsdlText: string) {
+  async loadWSDL(wsdlText: string, baseUrl?: string) {
     wsdlText = wsdlText.split('xmlns:').join('namespace:');
     let wsdlObject: WSDLObject;
     try {
@@ -741,19 +789,28 @@ export class SOAPLoader {
         `WSDL definitions not found! Please make sure if your WSDL source is correct, and it contains <definitions> tag.\nReturned response;\n${wsdlText}`,
       );
     }
+    // Pre-register before recursing so circular imports terminate.
+    if (baseUrl) {
+      this.loadedLocations.set(baseUrl, wsdlObject);
+    }
     for (const definition of wsdlObject.definitions) {
-      await this.loadDefinition(definition);
+      await this.loadDefinition(definition, baseUrl);
     }
     return wsdlObject;
   }
 
-  async fetchWSDL(location: string) {
-    const response = await this.fetchFn(location, {
+  async fetchWSDL(location: string, baseUrl?: string) {
+    const resolved = resolveLocation(baseUrl ?? this.cwd, location);
+    if (this.loadedLocations.has(resolved)) return;
+    const wsdlText = await readFileOrUrl<string>(resolved, {
+      allowUnknownExtensions: true,
+      cwd: this.cwd,
+      fetch: this.fetchFn,
+      importFn: defaultImportFn,
+      logger: this.logger,
       headers: this.schemaHeadersFactory({ env: process.env }),
     });
-    const wsdlText = await response.text();
-    const wsdlObject = await this.loadWSDL(wsdlText);
-    this.loadedLocations.set(location, wsdlObject);
+    await this.loadWSDL(wsdlText, resolved);
   }
 
   getAliasMapFromAttributes(attributes: XSSchema['attributes'] | WSDLDefinition['attributes']) {

--- a/packages/loaders/soap/src/SOAPLoader.ts
+++ b/packages/loaders/soap/src/SOAPLoader.ts
@@ -1,5 +1,3 @@
-// eslint-disable-next-line import/no-nodejs-modules
-import { dirname, isAbsolute, resolve as resolvePath } from 'node:path';
 import { XMLParser } from 'fast-xml-parser';
 import type { GraphQLScalarType } from 'graphql';
 import {
@@ -39,7 +37,7 @@ import {
   GraphQLVoid,
   RegularExpression,
 } from 'graphql-scalars';
-import { process } from '@graphql-mesh/cross-helpers';
+import { path, process } from '@graphql-mesh/cross-helpers';
 import type { ResolverDataBasedFactory } from '@graphql-mesh/string-interpolation';
 import { getInterpolatedHeadersFactory } from '@graphql-mesh/string-interpolation';
 import { ObjMapScalar } from '@graphql-mesh/transport-common';
@@ -192,8 +190,8 @@ function resolveLocation(base: string | undefined, location: string): string {
   }
   // base is a filesystem path. A filesystem-absolute location passes through;
   // anything else is resolved relative to base's containing directory.
-  if (isAbsolute(location)) return location;
-  return resolvePath(dirname(base), location);
+  if (path.isAbsolute(location)) return location;
+  return path.resolve(path.dirname(base), location);
 }
 
 /**
@@ -810,10 +808,10 @@ export class SOAPLoader {
     if (
       resolvedBase &&
       !URI_SCHEME_RE.test(resolvedBase) &&
-      !isAbsolute(resolvedBase) &&
+      !path.isAbsolute(resolvedBase) &&
       this.cwd
     ) {
-      resolvedBase = resolvePath(this.cwd, resolvedBase);
+      resolvedBase = path.resolve(this.cwd, resolvedBase);
     }
     // Pre-register before recursing so circular imports terminate.
     if (resolvedBase) {

--- a/packages/loaders/soap/src/index.ts
+++ b/packages/loaders/soap/src/index.ts
@@ -69,13 +69,12 @@ export function loadSOAPSubgraph(subgraphName: string, options: SOAPSubgraphLoad
             importFn: defaultImportFn,
             logger,
           }),
+        // Pass source as the base URL so nested <wsdl:import> / <xsd:import>
+        // locations resolve relative to the importing document.
         wsdl =>
           handleMaybePromise(
-            () => soapLoader.loadWSDL(wsdl),
-            object => {
-              soapLoader.loadedLocations.set(options.source, object);
-              return soapLoader.buildSchema();
-            },
+            () => soapLoader.loadWSDL(wsdl, options.source),
+            () => soapLoader.buildSchema(),
           ),
       ),
     };

--- a/packages/loaders/soap/test/__snapshots__/multi-file.test.ts.snap
+++ b/packages/loaders/soap/test/__snapshots__/multi-file.test.ts.snap
@@ -40,3 +40,44 @@ input SOAPHeaders {
 
 scalar ObjMap"
 `;
+
+exports[`Multi-file WSDL resolves relative source against the loader cwd, not process.cwd() 1`] = `
+"schema @transport(kind: "soap", subgraph: "multi-file") {
+  query: Query
+  mutation: Mutation
+}
+
+directive @soap(elementName: String, bindingNamespace: String, endpoint: String, subgraph: String, bodyAlias: String, soapHeaders: SOAPHeaders, soapAction: String, soapNamespace: String) on FIELD_DEFINITION
+
+type Query {
+  placeholder: Void
+}
+
+"""Represents NULL values"""
+scalar Void
+
+type Mutation {
+  HelloService_HelloService_HelloPort_hello(Hello: tns_Hello_Input): tns_HelloResponse @soap(elementName: "HelloResponse", bindingNamespace: "http://example.com/hello/wsdl", endpoint: "http://example.com/hello", subgraph: "multi-file", soapNamespace: "http://schemas.xmlsoap.org/soap/envelope/", soapAction: "hello")
+}
+
+type tns_HelloResponse {
+  greeting: String
+}
+
+input tns_Hello_Input {
+  who: tns_Name_Input
+}
+
+input tns_Name_Input {
+  first: String
+  last: String
+}
+
+input SOAPHeaders {
+  namespace: String
+  alias: String
+  headers: ObjMap
+}
+
+scalar ObjMap"
+`;

--- a/packages/loaders/soap/test/__snapshots__/multi-file.test.ts.snap
+++ b/packages/loaders/soap/test/__snapshots__/multi-file.test.ts.snap
@@ -1,0 +1,42 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`Multi-file WSDL resolves nested <wsdl:import> / <xsd:import> against each document's own location 1`] = `
+"schema @transport(kind: "soap", subgraph: "multi-file") {
+  query: Query
+  mutation: Mutation
+}
+
+directive @soap(elementName: String, bindingNamespace: String, endpoint: String, subgraph: String, bodyAlias: String, soapHeaders: SOAPHeaders, soapAction: String, soapNamespace: String) on FIELD_DEFINITION
+
+type Query {
+  placeholder: Void
+}
+
+"""Represents NULL values"""
+scalar Void
+
+type Mutation {
+  HelloService_HelloService_HelloPort_hello(Hello: tns_Hello_Input): tns_HelloResponse @soap(elementName: "HelloResponse", bindingNamespace: "http://example.com/hello/wsdl", endpoint: "http://example.com/hello", subgraph: "multi-file", soapNamespace: "http://schemas.xmlsoap.org/soap/envelope/", soapAction: "hello")
+}
+
+type tns_HelloResponse {
+  greeting: String
+}
+
+input tns_Hello_Input {
+  who: tns_Name_Input
+}
+
+input tns_Name_Input {
+  first: String
+  last: String
+}
+
+input SOAPHeaders {
+  namespace: String
+  alias: String
+  headers: ObjMap
+}
+
+scalar ObjMap"
+`;

--- a/packages/loaders/soap/test/fixtures/multi-file/service.wsdl
+++ b/packages/loaders/soap/test/fixtures/multi-file/service.wsdl
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Minimal multi-file WSDL fixture.
+
+  - <wsdl:types> contains a bare <xsd:schema> wrapper (no targetNamespace,
+    no type definitions of its own — just an import). Real-world WSDLs
+    (TMForum MTOP, OASIS, others) use this pattern to bring an external
+    schema into <wsdl:types> without redefining anything.
+
+  - The schema imports xsd/types.xsd, which itself imports xsd/names.xsd
+    (sibling). The nested import is resolved relative to types.xsd's own
+    location — not relative to this WSDL's directory — matching standard
+    XML Schema xml:base resolution.
+-->
+<wsdl:definitions
+  name="HelloService"
+  targetNamespace="http://example.com/hello/wsdl"
+  xmlns:tns="http://example.com/hello/wsdl"
+  xmlns:msg="http://example.com/hello/types"
+  xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/"
+  xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/"
+  xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+
+  <wsdl:types>
+    <xsd:schema>
+      <xsd:import namespace="http://example.com/hello/types"
+                  schemaLocation="xsd/types.xsd"/>
+    </xsd:schema>
+  </wsdl:types>
+
+  <wsdl:message name="HelloRequest">
+    <wsdl:part name="parameters" element="msg:Hello"/>
+  </wsdl:message>
+  <wsdl:message name="HelloResponse">
+    <wsdl:part name="parameters" element="msg:HelloResponse"/>
+  </wsdl:message>
+
+  <wsdl:portType name="HelloPort">
+    <wsdl:operation name="hello">
+      <wsdl:input message="tns:HelloRequest"/>
+      <wsdl:output message="tns:HelloResponse"/>
+    </wsdl:operation>
+  </wsdl:portType>
+
+  <wsdl:binding name="HelloBinding" type="tns:HelloPort">
+    <soap:binding style="document" transport="http://schemas.xmlsoap.org/soap/http"/>
+    <wsdl:operation name="hello">
+      <soap:operation soapAction="hello"/>
+      <wsdl:input><soap:body use="literal"/></wsdl:input>
+      <wsdl:output><soap:body use="literal"/></wsdl:output>
+    </wsdl:operation>
+  </wsdl:binding>
+
+  <wsdl:service name="HelloService">
+    <wsdl:port name="HelloPort" binding="tns:HelloBinding">
+      <soap:address location="http://example.com/hello"/>
+    </wsdl:port>
+  </wsdl:service>
+</wsdl:definitions>

--- a/packages/loaders/soap/test/fixtures/multi-file/xsd/names.xsd
+++ b/packages/loaders/soap/test/fixtures/multi-file/xsd/names.xsd
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema
+  targetNamespace="http://example.com/hello/names"
+  xmlns:tns="http://example.com/hello/names"
+  xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+  elementFormDefault="qualified">
+
+  <xsd:complexType name="Name">
+    <xsd:sequence>
+      <xsd:element name="first" type="xsd:string"/>
+      <xsd:element name="last" type="xsd:string"/>
+    </xsd:sequence>
+  </xsd:complexType>
+</xsd:schema>

--- a/packages/loaders/soap/test/fixtures/multi-file/xsd/types.xsd
+++ b/packages/loaders/soap/test/fixtures/multi-file/xsd/types.xsd
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  This XSD lives one directory below the WSDL. Its sibling import
+  ("names.xsd") must resolve relative to THIS file's location. With the
+  loader's old fixed-cwd resolution, the path would resolve relative to
+  the WSDL directory and ENOENT.
+-->
+<xsd:schema
+  targetNamespace="http://example.com/hello/types"
+  xmlns:tns="http://example.com/hello/types"
+  xmlns:names="http://example.com/hello/names"
+  xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+  elementFormDefault="qualified">
+
+  <xsd:import namespace="http://example.com/hello/names" schemaLocation="names.xsd"/>
+
+  <xsd:element name="Hello">
+    <xsd:complexType>
+      <xsd:sequence>
+        <xsd:element name="who" type="names:Name"/>
+      </xsd:sequence>
+    </xsd:complexType>
+  </xsd:element>
+
+  <xsd:element name="HelloResponse">
+    <xsd:complexType>
+      <xsd:sequence>
+        <xsd:element name="greeting" type="xsd:string"/>
+      </xsd:sequence>
+    </xsd:complexType>
+  </xsd:element>
+</xsd:schema>

--- a/packages/loaders/soap/test/multi-file.test.ts
+++ b/packages/loaders/soap/test/multi-file.test.ts
@@ -1,0 +1,30 @@
+/* eslint-disable import/no-nodejs-modules */
+import { promises } from 'fs';
+import { join } from 'path';
+import { printSchemaWithDirectives } from '@graphql-tools/utils';
+import { fetch } from '@whatwg-node/fetch';
+import { dummyLogger as logger } from '../../../testing/dummyLogger';
+import { SOAPLoader } from '../src/index.js';
+
+const { readFile } = promises;
+
+describe('Multi-file WSDL', () => {
+  it('resolves nested <wsdl:import> / <xsd:import> against each document\'s own location', async () => {
+    // Fixture layout:
+    //   service.wsdl                  — entry (has <xsd:schema> wrapper-only block)
+    //   xsd/types.xsd                 — imports sibling names.xsd
+    //   xsd/names.xsd                 — defines Name type
+    //
+    // Without per-file base-URI tracking the second-level import (names.xsd
+    // from types.xsd) would resolve against the WSDL directory rather than
+    // the XSD's own directory and fail with ENOENT.
+    const entryPath = join(__dirname, './fixtures/multi-file/service.wsdl');
+    const wsdl = await readFile(entryPath, 'utf-8');
+
+    const loader = new SOAPLoader({ subgraphName: 'multi-file', fetch, logger });
+    await loader.loadWSDL(wsdl, entryPath);
+    const schema = loader.buildSchema();
+
+    expect(printSchemaWithDirectives(schema)).toMatchSnapshot();
+  });
+});

--- a/packages/loaders/soap/test/multi-file.test.ts
+++ b/packages/loaders/soap/test/multi-file.test.ts
@@ -9,7 +9,7 @@ import { SOAPLoader } from '../src/index.js';
 const { readFile } = promises;
 
 describe('Multi-file WSDL', () => {
-  it('resolves nested <wsdl:import> / <xsd:import> against each document\'s own location', async () => {
+  it("resolves nested <wsdl:import> / <xsd:import> against each document's own location", async () => {
     // Fixture layout:
     //   service.wsdl                  — entry (has <xsd:schema> wrapper-only block)
     //   xsd/types.xsd                 — imports sibling names.xsd

--- a/packages/loaders/soap/test/multi-file.test.ts
+++ b/packages/loaders/soap/test/multi-file.test.ts
@@ -27,4 +27,27 @@ describe('Multi-file WSDL', () => {
 
     expect(printSchemaWithDirectives(schema)).toMatchSnapshot();
   });
+
+  it('resolves relative source against the loader cwd, not process.cwd()', async () => {
+    // Same fixture, but the source is given as a relative path with the
+    // loader's cwd set to the parent directory. Exercises the
+    // relative-baseUrl-anchoring code in loadWSDL — without it, the nested
+    // imports would resolve against process.cwd() and ENOENT.
+    const fixturesDir = join(__dirname, './fixtures');
+    const relativeSource = 'multi-file/service.wsdl';
+    const wsdl = await readFile(join(fixturesDir, relativeSource), 'utf-8');
+
+    const loader = new SOAPLoader({
+      subgraphName: 'multi-file',
+      fetch,
+      logger,
+      cwd: fixturesDir,
+    });
+    await loader.loadWSDL(wsdl, relativeSource);
+    const schema = loader.buildSchema();
+
+    // Same schema as the absolute-source case — proving relative source is
+    // anchored to loader cwd correctly.
+    expect(printSchemaWithDirectives(schema)).toMatchSnapshot();
+  });
 });


### PR DESCRIPTION
## Description

In one sentence: `SOAPLoader` resolves every relative `<wsdl:import>` / `<xsd:import>` against a single fixed `cwd`, so non-flattened multi-file WSDLs (TMForum MTOP, OASIS, etc.) fail on the second hop — this PR threads the resolved absolute URI of each loaded document through the load/fetch chain so nested imports resolve relative to the file that contains them, matching XML Schema's xml:base rules and every other mainstream XML processor.

The minimal reproduction is in the fixture added with this change (commit `4153b8b`, `packages/loaders/soap/test/fixtures/multi-file/`): three files, two-level nesting. With the existing code, loading `service.wsdl` crashes with `Cannot read properties of undefined (reading 'targetNamespace')` on a bare `<xsd:schema>` wrapper; after that's bypassed, `xsd/names.xsd` fails to resolve because its sibling import is interpreted from the WSDL's directory rather than the XSD's.

Fixes #9466

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## What changes

A small `resolveLocation(base, location)` helper handles relative-URI resolution uniformly for both `http(s):` URLs (via `new URL()`) and filesystem paths (via `path.resolve(path.dirname(base), ...)`). The loader now threads each loaded document's absolute URI through the load/fetch chain:

- **`fetchXSD(location, parentAliasMap, baseUrl?)`** — resolves `location` against `baseUrl ?? this.cwd`, dedups via `loadedLocations` on the resolved key, passes the resolved URI as the base for nested `loadSchema` calls.
- **`fetchWSDL(location, baseUrl?)`** — same pattern; switched from raw `fetchFn(location)` to `readFileOrUrl(...)` so it supports both URLs and file paths uniformly with `fetchXSD`.
- **`loadWSDL(wsdlText, baseUrl?)`** — pre-registers the document in `loadedLocations` so circular imports terminate, threads `baseUrl` to nested `loadDefinition`.
- **`loadDefinition(definition, baseUrl?)`** / **`loadSchema(schemaObj, parentAliasMap, baseUrl?)`** — pass `baseUrl` to nested fetches.
- **`loadSchema`** also detects bare `<xsd:schema>` wrappers (no `targetNamespace`, just `<xsd:import>`s) and processes their imports without registering types.
- **`loadSOAPSubgraph`** in `packages/loaders/soap/src/index.ts` now passes `options.source` as the base URL when calling `loadWSDL`, so users running through the standard config entry point get correct resolution automatically.

## Compatibility

`baseUrl` is optional everywhere it's threaded. When omitted, the legacy `this.cwd`-based resolution applies — same behavior as before. The single existing public caller (`loadSOAPSubgraph`) is updated to pass it; any other consumers continue to work unchanged.

`loadedLocations` keys now use resolved absolute URIs rather than raw input strings, but the map is internal (used only for cycle/dedup detection), so external state isn't affected.

## How Has This Been Tested?

- [x] All existing test suites pass (`examples`, `soap`, `headers`, `multi-namespace`) with snapshots unchanged.
- [x] New `multi-file.test.ts` against a 3-file fixture asserts that the cross-namespace `Name` type from the second-level XSD import is reachable from the operation arg in the built schema — proving the nested import was actually resolved.
- [x] Verified the new test **fails on master** with `Cannot read properties of undefined (reading 'targetNamespace')`, then passes after the fix.
- [x] End-to-end: with the fix, `@omnigraph/soap` loads the official TMForum mtosi_4.0 ConnectionRetrieval WSDL directly from the public GitHub source (16 nested files across 4 DDP directories) and the generated `getSubnetworkConnection` request, when POSTed to a production Huawei U2000 NMS, returns HTTP 200 with the matching SNC payload.

**Test Environment:**
- OS: Linux
- `@omnigraph/soap`: this PR
- NodeJS: 20+

## Checklist

- [x] Followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc
- [x] Self-reviewed
- [x] Commented hard-to-understand areas (the `resolveLocation` helper and the bare `<xsd:schema>` wrapper case in `loadSchema`)
- [x] Added a changeset (`patch` for `@omnigraph/soap`)
- [x] New and existing unit tests pass locally