### PR TITLE
fix(utils): return null for a null key in key-based additional resolvers

### DIFF
--- a/.changeset/fix-null-key-additional-resolver-delegation.md
+++ b/.changeset/fix-null-key-additional-resolver-delegation.md
@@ -1,0 +1,21 @@
+---
+"@graphql-mesh/utils": patch
+---
+
+Fix key-based (batch) additional resolvers delegating with a `null` key
+
+A key-based additional resolver (what `mesh-compose` emits for `@resolveTo` /
+`BatchResolveTo` with `keyField` + `keysArg`) resolves a relationship field by
+looking up the parent's key field in another subgraph. When the parent's key
+field value was `null`/`undefined` — a legitimately nullable foreign key — the
+in-context SDK's `if (key && argsFromKeys)` gate treated the nullish key as "no
+batch" and fell through to the keyless regular delegation path. That emitted an
+arg-less query to the source subgraph (no `keysArg` built); if the source
+field's argument is optional the subgraph accepted the call and returned its
+list (often `[]`), which was then projected onto a singular target field,
+surfacing as `Cannot return null for non-nullable field <Type>.<field>.`.
+
+`batchDelegateToSchema` already short-circuits `if (key == null) return null;`,
+but the gate diverted nullish keys away before that guard could apply. The
+in-context SDK now resolves a nullish key (`key == null`) to `null` before
+delegating.

--- a/packages/legacy/utils/src/in-context-sdk.ts
+++ b/packages/legacy/utils/src/in-context-sdk.ts
@@ -202,6 +202,11 @@ export function getInContextSDK(
                 };
               }
             }
+            // A null/undefined key has no entity to look up: resolve to null
+            // instead of falling through to the keyless arg-less delegation below.
+            if (key == null && argsFromKeys) {
+              return null;
+            }
             if (key && argsFromKeys) {
               const batchDelegationOptions = {
                 ...commonDelegateOptions,

--- a/packages/legacy/utils/test/in-context-sdk.spec.ts
+++ b/packages/legacy/utils/test/in-context-sdk.spec.ts
@@ -1,0 +1,106 @@
+import {
+  GraphQLID,
+  GraphQLList,
+  GraphQLNonNull,
+  GraphQLObjectType,
+  GraphQLSchema,
+  GraphQLString,
+} from 'graphql';
+import type { RawSourceOutput } from '@graphql-mesh/types';
+import { DefaultLogger, getInContextSDK } from '@graphql-mesh/utils';
+
+describe('getInContextSDK key-based delegation', () => {
+  const UserType = new GraphQLObjectType({
+    name: 'User',
+    fields: {
+      id: { type: new GraphQLNonNull(GraphQLID) },
+      name: { type: new GraphQLNonNull(GraphQLString) },
+    },
+  });
+
+  function buildSource() {
+    // `ids` is optional, so an arg-less call would be accepted and return a list.
+    const usersByIds = jest.fn((_root: unknown, { ids }: { ids?: string[] }) =>
+      (ids || []).map(id => ({ id, name: `User ${id}` })),
+    );
+    const schema = new GraphQLSchema({
+      query: new GraphQLObjectType({
+        name: 'Query',
+        fields: {
+          usersByIds: {
+            type: new GraphQLNonNull(new GraphQLList(UserType)),
+            args: { ids: { type: new GraphQLList(new GraphQLNonNull(GraphQLID)) } },
+            resolve: usersByIds,
+          },
+        },
+      }),
+    });
+    const rawSource: RawSourceOutput = {
+      name: 'users',
+      schema,
+      transforms: [],
+      contextVariables: {},
+      handler: {} as RawSourceOutput['handler'],
+      batch: true,
+      createProxyingResolver: () => undefined as any,
+    };
+    const inContextSDK = getInContextSDK(schema, [rawSource], new DefaultLogger('test'), []);
+    return { inContextSDK, usersByIds };
+  }
+
+  // `resolve-additional-resolvers` passes `key = lodashGet(root, keyField)` and an
+  // `argsFromKeys` that packs the keys under `keysArg`.
+  const argsFromKeys = (keys: readonly string[]) => ({ ids: keys });
+  const selectionSet = /* GraphQL */ `
+    {
+      id
+      name
+    }
+  `;
+
+  it('resolves to null when the key is null, without delegating', async () => {
+    const { inContextSDK, usersByIds } = buildSource();
+
+    const result = await inContextSDK.users.Query.usersByIds({
+      root: { authorId: null },
+      context: {},
+      key: null,
+      argsFromKeys,
+      selectionSet,
+    });
+
+    expect(result).toBeNull();
+    expect(usersByIds).not.toHaveBeenCalled();
+  });
+
+  it('resolves to null when the key is undefined, without delegating', async () => {
+    const { inContextSDK, usersByIds } = buildSource();
+
+    const result = await inContextSDK.users.Query.usersByIds({
+      root: {},
+      context: {},
+      key: undefined,
+      argsFromKeys,
+      selectionSet,
+    });
+
+    expect(result).toBeNull();
+    expect(usersByIds).not.toHaveBeenCalled();
+  });
+
+  it('still delegates with a non-null key (batch path)', async () => {
+    const { inContextSDK, usersByIds } = buildSource();
+
+    const result = await inContextSDK.users.Query.usersByIds({
+      root: { authorId: '1' },
+      context: {},
+      key: '1',
+      argsFromKeys,
+      selectionSet,
+    });
+
+    expect(result).toEqual({ id: '1', name: 'User 1' });
+    expect(usersByIds).toHaveBeenCalledTimes(1);
+    expect(usersByIds.mock.calls[0][1]).toEqual({ ids: ['1'] });
+  });
+});

--- a/packages/legacy/utils/test/resolve-additional-resolvers.spec.ts
+++ b/packages/legacy/utils/test/resolve-additional-resolvers.spec.ts
@@ -1,4 +1,5 @@
-import { parse } from 'graphql';
+/* eslint-disable import/no-extraneous-dependencies */
+import { parse, type ExecutionResult } from 'graphql';
 import { MemPubSub } from '@graphql-hive/pubsub';
 import type { RawSourceOutput } from '@graphql-mesh/types';
 import {
@@ -569,7 +570,7 @@ describe('key-based (batch) additional resolver with a null parent key', () => {
   it('resolves the relation to null without delegating or a non-null error', async () => {
     const { stitched, contextValue, users } = buildScenario(null);
 
-    const result = await execute({
+    const result = (await execute({
       schema: stitched,
       document: parse(/* GraphQL */ `
         {
@@ -582,7 +583,7 @@ describe('key-based (batch) additional resolver with a null parent key', () => {
         }
       `),
       contextValue,
-    });
+    })) as ExecutionResult;
 
     expect(result.errors).toBeUndefined();
     expect(result.data).toEqual({ posts: [{ id: 'post-1', author: null }] });
@@ -593,7 +594,7 @@ describe('key-based (batch) additional resolver with a null parent key', () => {
   it('still resolves the relation via batch delegation when the key is present', async () => {
     const { stitched, contextValue, users } = buildScenario('user-1');
 
-    const result = await execute({
+    const result = (await execute({
       schema: stitched,
       document: parse(/* GraphQL */ `
         {
@@ -607,7 +608,7 @@ describe('key-based (batch) additional resolver with a null parent key', () => {
         }
       `),
       contextValue,
-    });
+    })) as ExecutionResult;
 
     expect(result.errors).toBeUndefined();
     expect(result.data).toEqual({

--- a/packages/legacy/utils/test/resolve-additional-resolvers.spec.ts
+++ b/packages/legacy/utils/test/resolve-additional-resolvers.spec.ts
@@ -1,6 +1,11 @@
 import { parse } from 'graphql';
 import { MemPubSub } from '@graphql-hive/pubsub';
-import { resolveAdditionalResolversWithoutImport } from '@graphql-mesh/utils';
+import type { RawSourceOutput } from '@graphql-mesh/types';
+import {
+  DefaultLogger,
+  getInContextSDK,
+  resolveAdditionalResolversWithoutImport,
+} from '@graphql-mesh/utils';
 import type { SubschemaConfig } from '@graphql-tools/delegate';
 import { execute, subscribe } from '@graphql-tools/executor';
 import { makeExecutableSchema } from '@graphql-tools/schema';
@@ -471,4 +476,144 @@ it('should resolve from subgraph when fragments are present even if all fields a
 `);
 
   expect(products.productPriceResolver).toHaveBeenCalled();
+});
+
+// End-to-end regression for a key-based (batch) additional resolver whose parent
+// key is null. Before the fix, a null key fell through to a keyless delegation:
+// an arg-less query to the source whose list result was projected onto the
+// singular target field, surfacing as a non-null-field error.
+describe('key-based (batch) additional resolver with a null parent key', () => {
+  // Source subgraph: `ids` is optional, so an arg-less call would be accepted and
+  // return a list; `name` is a non-null leaf.
+  function makeUsers() {
+    const usersByIds = jest.fn((_root: unknown, { ids }: { ids?: string[] }) =>
+      (ids || []).map(id => ({ id, name: `User ${id}` })),
+    );
+    const schema = makeExecutableSchema({
+      typeDefs: parse(/* GraphQL */ `
+        type Query {
+          usersByIds(ids: [ID!]): [User]!
+        }
+        type User {
+          id: ID!
+          name: String!
+        }
+      `),
+      resolvers: { Query: { usersByIds } },
+    });
+    return { schema, usersByIds };
+  }
+
+  // Parent subgraph: a post with a nullable `authorId` foreign key.
+  function makePosts(authorId: string | null) {
+    return makeExecutableSchema({
+      typeDefs: parse(/* GraphQL */ `
+        type Query {
+          posts: [Post!]!
+        }
+        type Post {
+          id: ID!
+          authorId: ID
+        }
+      `),
+      resolvers: {
+        Query: { posts: () => [{ id: 'post-1', authorId }] },
+      },
+    });
+  }
+
+  function buildScenario(authorId: string | null) {
+    const users = makeUsers();
+    const postsSchema = makePosts(authorId);
+
+    const usersRawSource: RawSourceOutput = {
+      name: 'users',
+      schema: users.schema,
+      transforms: [],
+      contextVariables: {},
+      handler: {} as RawSourceOutput['handler'],
+      batch: true,
+      createProxyingResolver: () => undefined as any,
+    };
+    const inContextSDK = getInContextSDK(
+      users.schema,
+      [usersRawSource],
+      new DefaultLogger('test'),
+      [],
+    );
+
+    const additionalResolvers = resolveAdditionalResolversWithoutImport({
+      targetTypeName: 'Post',
+      targetFieldName: 'author',
+      requiredSelectionSet: '{ authorId }',
+      keyField: 'authorId',
+      keysArg: 'ids',
+      sourceName: 'users',
+      sourceTypeName: 'Query',
+      sourceFieldName: 'usersByIds',
+    } as any);
+
+    const stitched = stitchSchemas({
+      subschemas: [{ schema: postsSchema }, { schema: users.schema }] as SubschemaConfig[],
+      typeDefs: parse(/* GraphQL */ `
+        extend type Post {
+          author: User
+        }
+      `),
+      resolvers: additionalResolvers,
+    });
+
+    return { stitched, contextValue: { ...inContextSDK }, users };
+  }
+
+  it('resolves the relation to null without delegating or a non-null error', async () => {
+    const { stitched, contextValue, users } = buildScenario(null);
+
+    const result = await execute({
+      schema: stitched,
+      document: parse(/* GraphQL */ `
+        {
+          posts {
+            id
+            author {
+              name
+            }
+          }
+        }
+      `),
+      contextValue,
+    });
+
+    expect(result.errors).toBeUndefined();
+    expect(result.data).toEqual({ posts: [{ id: 'post-1', author: null }] });
+    // A null key must not trigger an (arg-less) delegation to the source.
+    expect(users.usersByIds).not.toHaveBeenCalled();
+  });
+
+  it('still resolves the relation via batch delegation when the key is present', async () => {
+    const { stitched, contextValue, users } = buildScenario('user-1');
+
+    const result = await execute({
+      schema: stitched,
+      document: parse(/* GraphQL */ `
+        {
+          posts {
+            id
+            author {
+              id
+              name
+            }
+          }
+        }
+      `),
+      contextValue,
+    });
+
+    expect(result.errors).toBeUndefined();
+    expect(result.data).toEqual({
+      posts: [{ id: 'post-1', author: { id: 'user-1', name: 'User user-1' } }],
+    });
+    expect(users.usersByIds).toHaveBeenCalledTimes(1);
+    expect(users.usersByIds.mock.calls[0][1]).toEqual({ ids: ['user-1'] });
+  });
 });


### PR DESCRIPTION
## Description

A key-based (batch) additional resolver resolves a relationship by looking up the parent's key in another subgraph. (It's what `mesh-compose` emits for `@resolveTo` with `keyField` + `keysArg`.) When the parent's key is `null` (a nullable foreign key), `getInContextSDK`'s `if (key && argsFromKeys)` gate treats the falsy key as "no batch" and falls through to the keyless regular-delegation path. That emits an arg-less query to the source subgraph; for an optional source argument the subgraph returns its list (often `[]`), which is projected onto the singular target field and surfaces as:

> Cannot return null for non-nullable field `<Type>.<field>`.

`batchDelegateToSchema` already short-circuits `if (key == null) return null;`, but the gate diverts null keys away before that guard applies. This resolves a `null` key to `null` before delegating.

The relation exercised by the tests:

```graphql
# Source subgraph "Users": ids is optional, so an arg-less call is accepted
type Query { usersByIds(ids: [ID!]): [User]! }
type User { id: ID!  name: String! }   # name is a non-null leaf

# Parent subgraph "Posts": authorId is a nullable foreign key
type Query { posts: [Post!]! }
type Post { id: ID!  authorId: ID }

# Gateway relation (the test uses the additionalResolvers object form;
# the @resolveTo equivalent is shown here)
extend type Post {
  author: User
    @resolveTo(
      sourceName: "Users"
      sourceTypeName: "Query"
      sourceFieldName: "usersByIds"
      requiredSelectionSet: "{ authorId }"
      keyField: "authorId"
      keysArg: "ids"
    )
}
```

With `authorId: null`, `{ posts { author { name } } }` throws `Cannot return null for non-nullable field User.name.` before the fix and resolves `author` to `null` after.

Fixes #9510

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- `packages/legacy/utils/test/in-context-sdk.spec.ts` — a null key and an undefined key each resolve to `null` without delegating; a non-null key still delegates via the batch path with the key projected into `ids`.
- `packages/legacy/utils/test/resolve-additional-resolvers.spec.ts` — end-to-end through `resolveAdditionalResolversWithoutImport` + `getInContextSDK` + `stitchSchemas` + `execute`: a `Post.author` → `usersByIds(ids: [ID!]): [User]!` relation where `User.name: String!`. A post with `authorId: null` resolves `author` to `null` with no error; a present key still resolves via batch delegation. Fails before the change with `Cannot return null for non-nullable field User.name.`, passes after.
- Full unit suite green (`yarn test`): 806 passed, 3 skipped. `yarn typecheck`, Prettier, and ESLint clean.

**Test Environment**:

- OS: macOS
- `@graphql-mesh/utils`: 0.104.x (`master`)
- NodeJS: 22.x

## Checklist:

- [x] I have followed the CONTRIBUTING doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (n/a — internal behavior fix)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective, and a changeset using `yarn changeset` that bumps the version
- [x] New and existing unit tests and linter rules pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules (n/a)

## Further comments

Scoped intentionally to the `null`/`undefined` case to keep the change minimal. One thing worth a maintainer call: the same `if (key && argsFromKeys)` gate also routes legitimately-falsy keys (`0`, `""`) into the keyless path, even though `batchDelegateToSchema` treats them as real lookups (`loader.load(key)` — only `key == null` short-circuits to `null`). Fully fixing that would mean gating purely on `argsFromKeys` (present ⟺ batch resolver) and short-circuiting only `key == null` inside:

```ts
if (argsFromKeys) {
  if (key == null) return null;
  // batch lookup — 0, "", "abc" all delegated
}
```

Happy to fold that in here or leave it as a follow-up — whichever you'd prefer.
